### PR TITLE
[amdgcn] Allow `sregs` to be values

### DIFF
--- a/include/aster/Dialect/AMDGCN/IR/AMDGCNTypes.td
+++ b/include/aster/Dialect/AMDGCN/IR/AMDGCNTypes.td
@@ -157,30 +157,39 @@ def VGPRType : AMDGCN_RegisterDef<"VGPR", "vgpr", [MemRefElementTypeInterface]> 
 class SREGBase<string name, string mnemonic, string kind>
     : AMDGCN_RegisterDef<name, mnemonic, [MemRefElementTypeInterface]> {
   let summary = kind # " special register type";
-  let assemblyFormat = "";
+  let parameters = (ins
+    DefaultValuedParameter<"Register", "Register()">:$reg
+  );
+  let assemblyFormat = "(`<` $reg^ `>`)?";
+  let builders = [
+    TypeBuilder<(ins "Register":$reg), [{
+      return $_get($_ctxt, normalizeRegister(reg));
+    }]>
+  ];
+  let skipDefaultBuilders = 1;
   string declarations = StrSubst<[{
     /// The register kind for this SREG type.
     static constexpr RegisterKind kRegisterKind = RegisterKind::$kind;
     }], [VarRepl<"kind", kind>]>.result;
   let extraClassDeclaration = declarations # [{
-    /// Returns true if the register is relocatable.
-    bool isRelocatable() const { return false; }
+    static Register normalizeRegister(Register reg) {
+      if (reg.getSemantics() == RegisterSemantics::Allocated)
+        return Register(0);
+      return reg;
+    }
 
     //===------------------------------------------------------------------===//
     // RegisterTypeInterface
     //===------------------------------------------------------------------===//
-    bool isRegisterRange() const { return false; }
     RegisterRange getAsRange() const {
-      return RegisterRange(Register(0), 1);
+      return RegisterRange(getReg(), 1);
     }
     RegisterKind getRegisterKind() const {
       return kRegisterKind;
     }
     RegisterTypeInterface cloneRegisterType(RegisterRange range) const {
-      return get(getContext());
-    }
-    RegisterTypeInterface cloneRegisterType(Register reg) const {
-      return get(getContext());
+      assert(range.size() == 1 && "SREG type can only clone single register");
+      return get(getContext(), range.begin());
     }
 
     //===------------------------------------------------------------------===//

--- a/lib/Dialect/AMDGCN/Transforms/LegalizeCF.cpp
+++ b/lib/Dialect/AMDGCN/Transforms/LegalizeCF.cpp
@@ -196,7 +196,7 @@ Value LegalizeCF::getOrCreateLoweredCmp(lsir::CmpIOp cmpOp,
       std::swap(lhs, rhs);
       pred = swapPredicate(pred);
     }
-    Type vccType = VCCType::get(rewriter.getContext());
+    Type vccType = VCCType::get(rewriter.getContext(), Register(0));
     Value vcc = AllocaOp::create(rewriter, loc, vccType);
     OpCode cmpOpCode = getVectorCompareOpCode(pred);
     amdgcn::CmpIOp::create(rewriter, loc, cmpOpCode, vcc, lhs, rhs);
@@ -205,7 +205,7 @@ Value LegalizeCF::getOrCreateLoweredCmp(lsir::CmpIOp cmpOp,
   }
 
   // Scalar compare: s_cmp_* writes to SCC.
-  Type sccType = SCCType::get(rewriter.getContext());
+  Type sccType = SCCType::get(rewriter.getContext(), Register(0));
   Value scc = AllocaOp::create(rewriter, loc, sccType);
   OpCode cmpOpCode = getScalarCompareOpCode(cmpOp.getPredicate());
   amdgcn::CmpIOp::create(rewriter, loc, cmpOpCode, scc, cmpOp.getLhs(),

--- a/test/Dialect/AMDGCN/Analysis/cdna3-hazards.mlir
+++ b/test/Dialect/AMDGCN/Analysis/cdna3-hazards.mlir
@@ -36,25 +36,25 @@ func.func @cdna3_store_hazard_detected(%arg0: !amdgcn.vgpr<0>, %arg1: !amdgcn.vg
 //===----------------------------------------------------------------------===//
 
 // CHECK-LABEL: Symbol: cdna3_vcc_vccz_hazard_detected
-// CHECK: Op: func.func @cdna3_vcc_vccz_hazard_detected(%{{.*}}: !amdgcn.vcc, %{{.*}}: !amdgcn.vccz, %{{.*}}: !amdgcn.vgpr<0>, %{{.*}}: !amdgcn.vgpr<1>, %{{.*}}: !amdgcn.vgpr<2>) {...}
+// CHECK: Op: func.func @cdna3_vcc_vccz_hazard_detected(%{{.*}}: !amdgcn.vcc<0>, %{{.*}}: !amdgcn.vccz<0>, %{{.*}}: !amdgcn.vgpr<0>, %{{.*}}: !amdgcn.vgpr<1>, %{{.*}}: !amdgcn.vgpr<2>) {...}
 // CHECK:   HAZARD STATE AFTER: <Empty>
-// CHECK: Op: amdgcn.cmpi v_cmp_eq_i32 outs %{{.*}} ins %{{.*}}, %{{.*}} : outs(!amdgcn.vcc) ins(!amdgcn.vgpr<0>, !amdgcn.vgpr<1>)
+// CHECK: Op: amdgcn.cmpi v_cmp_eq_i32 outs %{{.*}} ins %{{.*}}, %{{.*}} : outs(!amdgcn.vcc<0>) ins(!amdgcn.vgpr<0>, !amdgcn.vgpr<1>)
 // CHECK:   HAZARD STATE AFTER: {
 // CHECK:     active = [
-// CHECK:       {#amdgcn.cdna3_vcc_exec_vccz_execz_hazard, amdgcn.cmpi v_cmp_eq_i32 outs %{{.*}} ins %{{.*}}, %{{.*}} : outs(!amdgcn.vcc) ins(!amdgcn.vgpr<0>, !amdgcn.vgpr<1>), none, {v:5, s:0, ds:0}}
+// CHECK:       {#amdgcn.cdna3_vcc_exec_vccz_execz_hazard, amdgcn.cmpi v_cmp_eq_i32 outs %{{.*}} ins %{{.*}}, %{{.*}} : outs(!amdgcn.vcc<0>) ins(!amdgcn.vgpr<0>, !amdgcn.vgpr<1>), none, {v:5, s:0, ds:0}}
 // CHECK:     ]
 // CHECK:     nop counts = {v:0, s:0, ds:0}
 // CHECK:   }
-// CHECK: Op: amdgcn.cmpi v_cmp_eq_i32 outs %{{.*}} ins %{{.*}}, %{{.*}} : outs(!amdgcn.vcc) ins(!amdgcn.vccz, !amdgcn.vgpr<2>)
+// CHECK: Op: amdgcn.cmpi v_cmp_eq_i32 outs %{{.*}} ins %{{.*}}, %{{.*}} : outs(!amdgcn.vcc<0>) ins(!amdgcn.vccz<0>, !amdgcn.vgpr<2>)
 // CHECK:   HAZARD STATE AFTER: {
 // CHECK:     active = [
-// CHECK:       {#amdgcn.cdna3_vcc_exec_vccz_execz_hazard, amdgcn.cmpi v_cmp_eq_i32 outs %{{.*}} ins %{{.*}}, %{{.*}} : outs(!amdgcn.vcc) ins(!amdgcn.vccz, !amdgcn.vgpr<2>), none, {v:5, s:0, ds:0}}
+// CHECK:       {#amdgcn.cdna3_vcc_exec_vccz_execz_hazard, amdgcn.cmpi v_cmp_eq_i32 outs %{{.*}} ins %{{.*}}, %{{.*}} : outs(!amdgcn.vcc<0>) ins(!amdgcn.vccz<0>, !amdgcn.vgpr<2>), none, {v:5, s:0, ds:0}}
 // CHECK:     ]
 // CHECK:     nop counts = {v:5, s:0, ds:0}
 // CHECK:   }
-func.func @cdna3_vcc_vccz_hazard_detected(%arg0: !amdgcn.vcc, %arg1: !amdgcn.vccz, %arg2: !amdgcn.vgpr<0>, %arg3: !amdgcn.vgpr<1>, %arg4: !amdgcn.vgpr<2>) {
-  amdgcn.cmpi v_cmp_eq_i32 outs %arg0 ins %arg2, %arg3 : outs(!amdgcn.vcc) ins(!amdgcn.vgpr<0>, !amdgcn.vgpr<1>)
-  amdgcn.cmpi v_cmp_eq_i32 outs %arg0 ins %arg1, %arg4 : outs(!amdgcn.vcc) ins(!amdgcn.vccz, !amdgcn.vgpr<2>)
+func.func @cdna3_vcc_vccz_hazard_detected(%arg0: !amdgcn.vcc<0>, %arg1: !amdgcn.vccz<0>, %arg2: !amdgcn.vgpr<0>, %arg3: !amdgcn.vgpr<1>, %arg4: !amdgcn.vgpr<2>) {
+  amdgcn.cmpi v_cmp_eq_i32 outs %arg0 ins %arg2, %arg3 : outs(!amdgcn.vcc<0>) ins(!amdgcn.vgpr<0>, !amdgcn.vgpr<1>)
+  amdgcn.cmpi v_cmp_eq_i32 outs %arg0 ins %arg1, %arg4 : outs(!amdgcn.vcc<0>) ins(!amdgcn.vccz<0>, !amdgcn.vgpr<2>)
   return
 }
 

--- a/test/Dialect/AMDGCN/Analysis/memory-dependence-analysis.mlir
+++ b/test/Dialect/AMDGCN/Analysis/memory-dependence-analysis.mlir
@@ -149,7 +149,7 @@ amdgcn.module @test_memory_dependence target = #amdgcn.target<gfx942> isa = #amd
 //   CHECK-LABEL: Kernel: test_g2s_lds_dep
 amdgcn.module @test_g2s_lds_dep target = #amdgcn.target<gfx950> isa = #amdgcn.isa<cdna4> {
   amdgcn.kernel @test_g2s_lds_dep {
-    %m0 = amdgcn.alloca : !amdgcn.m0
+    %m0 = amdgcn.alloca : !amdgcn.m0<0>
     %s0 = amdgcn.alloca : !amdgcn.sgpr
     %s1 = amdgcn.alloca : !amdgcn.sgpr
     %s2 = amdgcn.alloca : !amdgcn.sgpr
@@ -163,7 +163,7 @@ amdgcn.module @test_g2s_lds_dep target = #amdgcn.target<gfx950> isa = #amdgcn.is
     %c0 = arith.constant 0 : i32
 
     // Set M0 for LDS base offset
-    amdgcn.sop1 s_mov_b32 outs %m0 ins %c0 : !amdgcn.m0, i32
+    amdgcn.sop1 s_mov_b32 outs %m0 ins %c0 : !amdgcn.m0<0>, i32
 
     // G2S: buffer_load_dword with LDS flag - writes to LDS
     // CHECK: Operation: {{.*}}load_lds{{.*}}test.g2s_tag
@@ -171,7 +171,7 @@ amdgcn.module @test_g2s_lds_dep target = #amdgcn.target<gfx950> isa = #amdgcn.is
     // CHECK-NEXT: MUST FLUSH NOW: 0:
     %tok_g2s = amdgcn.load_lds buffer_load_dword_lds m0 %m0 addr %rsrc
         offset u(%soff) + d(%voff) + c(%c0) { test.g2s_tag }
-        : ins(!amdgcn.m0, !amdgcn.sgpr<[? + 4]>, !amdgcn.sgpr, !amdgcn.vgpr, i32)
+        : ins(!amdgcn.m0<0>, !amdgcn.sgpr<[? + 4]>, !amdgcn.sgpr, !amdgcn.vgpr, i32)
         -> !amdgcn.write_token<flat>
 
     // ds_read from LDS - the G2S must be flushed first because LoadToLDSOp

--- a/test/Dialect/AMDGCN/Transforms/legalize-cf.mlir
+++ b/test/Dialect/AMDGCN/Transforms/legalize-cf.mlir
@@ -3,10 +3,10 @@
 // CHECK-LABEL: kernel @test_cond_branch_slt
 // CHECK:         sop1 s_mov_b32 outs %[[A:.*]] ins
 // CHECK:         sop1 s_mov_b32 outs %[[B:.*]] ins
-// CHECK:         %[[SCC:.*]] = alloca : !amdgcn.scc
-// CHECK:         cmpi s_cmp_lt_i32 outs %[[SCC]] ins %[[A]], %[[B]] : outs(!amdgcn.scc) ins(!amdgcn.sgpr<0>, !amdgcn.sgpr<1>)
+// CHECK:         %[[SCC:.*]] = alloca : !amdgcn.scc<0>
+// CHECK:         cmpi s_cmp_lt_i32 outs %[[SCC]] ins %[[A]], %[[B]] : outs(!amdgcn.scc<0>) ins(!amdgcn.sgpr<0>, !amdgcn.sgpr<1>)
 // Use SCC0 because ^bb1 (trueDest) is the next physical block - branch to ^bb2 if false
-// CHECK:         cbranch s_cbranch_scc0 %[[SCC]] ^bb2 fallthrough(^bb1) : !amdgcn.scc
+// CHECK:         cbranch s_cbranch_scc0 %[[SCC]] ^bb2 fallthrough(^bb1) : !amdgcn.scc<0>
 // CHECK:       ^bb1:
 // CHECK:         end_kernel
 // CHECK:       ^bb2:
@@ -54,11 +54,11 @@ amdgcn.module @test_br target = <gfx942> isa = <cdna3> {
 // Branch to ^bb1 if SCC=1 (continue loop), fallthrough to ^bb2 if SCC=0 (exit)
 
 // CHECK-LABEL: kernel @test_cf_cond_br_lsir_cmpi
-//       CHECK:   cmpi s_cmp_gt_i32 outs %{{.*}} ins %{{.*}}, %{{.*}} : outs(!amdgcn.scc) ins(!amdgcn.sgpr<6>, i32)
+//       CHECK:   cmpi s_cmp_gt_i32 outs %{{.*}} ins %{{.*}}, %{{.*}} : outs(!amdgcn.scc<0>) ins(!amdgcn.sgpr<6>, i32)
 //       CHECK:   cbranch s_cbranch_scc0 %{{.*}} ^bb2 fallthrough(^bb1)
 //       CHECK:   ^bb1:
 //       CHECK:     sop2 s_add_u32 outs %[[LOOP_ALLOC:.*]] ins %[[LOOP_ALLOC]]
-//       CHECK:     cmpi s_cmp_lt_i32 outs %{{.*}} ins %{{.*}}, %{{.*}} : outs(!amdgcn.scc) ins(!amdgcn.sgpr<7>, !amdgcn.sgpr<6>)
+//       CHECK:     cmpi s_cmp_lt_i32 outs %{{.*}} ins %{{.*}}, %{{.*}} : outs(!amdgcn.scc<0>) ins(!amdgcn.sgpr<7>, !amdgcn.sgpr<6>)
 //       CHECK:     cbranch s_cbranch_scc1 %{{.*}} ^bb1 fallthrough(^bb2)
 //       CHECK:   ^bb2:
 //       CHECK:     end_kernel
@@ -278,7 +278,7 @@ amdgcn.module @test_loop target = <gfx942> isa = <cdna3> {
 // CHECK-LABEL: kernel @test_select_i1
 // CHECK:         sop1 s_mov_b32 outs %[[A:.*]] ins
 // CHECK:         sop1 s_mov_b32 outs %[[B:.*]] ins
-// CHECK:         %[[SCC:.*]] = alloca : !amdgcn.scc
+// CHECK:         %[[SCC:.*]] = alloca : !amdgcn.scc<0>
 // CHECK:         cmpi s_cmp_eq_i32 outs %[[SCC]] ins %[[A]], %[[B]]
 // CHECK:         sop2 s_cselect_b32 outs %{{.*}} ins
 // CHECK:         end_kernel
@@ -307,9 +307,9 @@ amdgcn.module @test_select_i1_mod target = <gfx942> isa = <cdna3> {
 // CHECK-LABEL: kernel @test_select_fanout
 // CHECK:         sop1 s_mov_b32 outs %[[A:.*]] ins
 // CHECK:         sop1 s_mov_b32 outs %[[B:.*]] ins
-// CHECK:         %[[SCC:.*]] = alloca : !amdgcn.scc
+// CHECK:         %[[SCC:.*]] = alloca : !amdgcn.scc<0>
 // CHECK:         cmpi s_cmp_eq_i32 outs %[[SCC]] ins %[[A]], %[[B]]
-// CHECK-NOT:     alloca : !amdgcn.scc
+// CHECK-NOT:     alloca : !amdgcn.scc<0>
 // CHECK-NOT:     cmpi
 // CHECK:         sop2 s_cselect_b32
 // CHECK:         sop2 s_cselect_b32
@@ -342,9 +342,9 @@ amdgcn.module @test_select_fanout_mod target = <gfx942> isa = <cdna3> {
 // CHECK-LABEL: kernel @test_mixed_consumers
 // CHECK:         sop1 s_mov_b32 outs %[[A:.*]] ins
 // CHECK:         sop1 s_mov_b32 outs %[[B:.*]] ins
-// CHECK:         %[[SCC:.*]] = alloca : !amdgcn.scc
+// CHECK:         %[[SCC:.*]] = alloca : !amdgcn.scc<0>
 // CHECK:         cmpi s_cmp_eq_i32 outs %[[SCC]] ins %[[A]], %[[B]]
-// CHECK-NOT:     alloca : !amdgcn.scc
+// CHECK-NOT:     alloca : !amdgcn.scc<0>
 // CHECK-NOT:     cmpi
 // CHECK:         sop2 s_cselect_b32
 // CHECK:         cbranch s_cbranch_scc0 %[[SCC]]
@@ -493,9 +493,9 @@ amdgcn.module @test_crossblock_mod target = <gfx942> isa = <cdna3> {
 // Branch uses s_cbranch_vccz since ^bb1 (trueDest) is the next physical block.
 
 // CHECK-LABEL: kernel @test_vopc_cond_branch
-// CHECK:         %[[VCC:.*]] = alloca : !amdgcn.vcc
-// CHECK:         cmpi v_cmp_lt_i32 outs %[[VCC]] ins %{{.*}}, %{{.*}} : outs(!amdgcn.vcc) ins(i32, !amdgcn.vgpr<0>)
-// CHECK:         cbranch s_cbranch_vccz %[[VCC]] ^bb2 fallthrough(^bb1) : !amdgcn.vcc
+// CHECK:         %[[VCC:.*]] = alloca : !amdgcn.vcc<0>
+// CHECK:         cmpi v_cmp_lt_i32 outs %[[VCC]] ins %{{.*}}, %{{.*}} : outs(!amdgcn.vcc<0>) ins(i32, !amdgcn.vgpr<0>)
+// CHECK:         cbranch s_cbranch_vccz %[[VCC]] ^bb2 fallthrough(^bb1) : !amdgcn.vcc<0>
 // CHECK:       ^bb1:
 // CHECK:         end_kernel
 // CHECK:       ^bb2:
@@ -521,8 +521,8 @@ amdgcn.module @test_vopc_mod target = <gfx942> isa = <cdna3> {
 // and predicate is flipped: slt(v0, 32) -> gt(32, v0).
 
 // CHECK-LABEL: kernel @test_vopc_operand_swap
-// CHECK:         cmpi v_cmp_gt_i32 outs %{{.*}} ins %{{.*}}, %{{.*}} : outs(!amdgcn.vcc) ins(i32, !amdgcn.vgpr<0>)
-// CHECK:         cbranch s_cbranch_vccz %{{.*}} ^bb2 fallthrough(^bb1) : !amdgcn.vcc
+// CHECK:         cmpi v_cmp_gt_i32 outs %{{.*}} ins %{{.*}}, %{{.*}} : outs(!amdgcn.vcc<0>) ins(i32, !amdgcn.vgpr<0>)
+// CHECK:         cbranch s_cbranch_vccz %{{.*}} ^bb2 fallthrough(^bb1) : !amdgcn.vcc<0>
 amdgcn.module @test_vopc_swap_mod target = <gfx942> isa = <cdna3> {
   amdgcn.kernel @test_vopc_operand_swap {
     %c32_i32 = arith.constant 32 : i32
@@ -542,8 +542,8 @@ amdgcn.module @test_vopc_swap_mod target = <gfx942> isa = <cdna3> {
 // VOPC with two VGPR operands: no swap needed, rhs already a VGPR.
 
 // CHECK-LABEL: kernel @test_vopc_two_vgprs
-// CHECK:         cmpi v_cmp_eq_i32 outs %{{.*}} ins %{{.*}}, %{{.*}} : outs(!amdgcn.vcc) ins(!amdgcn.vgpr<0>, !amdgcn.vgpr<1>)
-// CHECK:         cbranch s_cbranch_vccz %{{.*}} ^bb2 fallthrough(^bb1) : !amdgcn.vcc
+// CHECK:         cmpi v_cmp_eq_i32 outs %{{.*}} ins %{{.*}}, %{{.*}} : outs(!amdgcn.vcc<0>) ins(!amdgcn.vgpr<0>, !amdgcn.vgpr<1>)
+// CHECK:         cbranch s_cbranch_vccz %{{.*}} ^bb2 fallthrough(^bb1) : !amdgcn.vcc<0>
 amdgcn.module @test_vopc_vv_mod target = <gfx942> isa = <cdna3> {
   amdgcn.kernel @test_vopc_two_vgprs {
     %v0 = alloca : !amdgcn.vgpr<0>
@@ -564,8 +564,8 @@ amdgcn.module @test_vopc_vv_mod target = <gfx942> isa = <cdna3> {
 // src0/src1 must be register-typed (VOP2 constraint), so we use VGPRs.
 
 // CHECK-LABEL: kernel @test_vopc_select
-// CHECK:         %[[VCC:.*]] = alloca : !amdgcn.vcc
-// CHECK:         cmpi v_cmp_eq_i32 outs %[[VCC]] ins %{{.*}}, %{{.*}} : outs(!amdgcn.vcc) ins(!amdgcn.vgpr<0>, !amdgcn.vgpr<1>)
+// CHECK:         %[[VCC:.*]] = alloca : !amdgcn.vcc<0>
+// CHECK:         cmpi v_cmp_eq_i32 outs %[[VCC]] ins %{{.*}}, %{{.*}} : outs(!amdgcn.vcc<0>) ins(!amdgcn.vgpr<0>, !amdgcn.vgpr<1>)
 // CHECK:         vop2 v_cndmask_b32 outs %{{.*}} ins %{{.*}}, %{{.*}} src2 = %[[VCC]]
 // CHECK:         end_kernel
 amdgcn.module @test_vopc_select_mod target = <gfx942> isa = <cdna3> {
@@ -587,8 +587,8 @@ amdgcn.module @test_vopc_select_mod target = <gfx942> isa = <cdna3> {
 // Materialize the true value into dst via v_mov_b32_e32 first.
 
 // CHECK-LABEL: kernel @test_vopc_select_nonvgpr_true
-// CHECK:         %[[VCC:.*]] = alloca : !amdgcn.vcc
-// CHECK:         cmpi v_cmp_eq_i32 outs %[[VCC]] ins %{{.*}}, %{{.*}} : outs(!amdgcn.vcc) ins(!amdgcn.vgpr<0>, !amdgcn.vgpr<1>)
+// CHECK:         %[[VCC:.*]] = alloca : !amdgcn.vcc<0>
+// CHECK:         cmpi v_cmp_eq_i32 outs %[[VCC]] ins %{{.*}}, %{{.*}} : outs(!amdgcn.vcc<0>) ins(!amdgcn.vgpr<0>, !amdgcn.vgpr<1>)
 // CHECK:         vop1.vop1 <v_mov_b32_e32> %{{.*}}, %{{.*}} : (!amdgcn.vgpr<2>, i32) -> ()
 // CHECK:         vop2 v_cndmask_b32 outs %{{.*}} ins %{{.*}}, %{{.*}} src2 = %[[VCC]]
 // CHECK:         end_kernel
@@ -609,8 +609,8 @@ amdgcn.module @test_vopc_select_imm_true_mod target = <gfx942> isa = <cdna3> {
 // Same as above: true value in SGPR still needs v_mov_b32_e32 into dst for src1.
 
 // CHECK-LABEL: kernel @test_vopc_select_sgpr_true
-// CHECK:         %[[VCC:.*]] = alloca : !amdgcn.vcc
-// CHECK:         cmpi v_cmp_eq_i32 outs %[[VCC]] ins %{{.*}}, %{{.*}} : outs(!amdgcn.vcc) ins(!amdgcn.vgpr<0>, !amdgcn.vgpr<1>)
+// CHECK:         %[[VCC:.*]] = alloca : !amdgcn.vcc<0>
+// CHECK:         cmpi v_cmp_eq_i32 outs %[[VCC]] ins %{{.*}}, %{{.*}} : outs(!amdgcn.vcc<0>) ins(!amdgcn.vgpr<0>, !amdgcn.vgpr<1>)
 // CHECK:         vop1.vop1 <v_mov_b32_e32> %{{.*}}, %{{.*}} : (!amdgcn.vgpr<2>, !amdgcn.sgpr<0>) -> ()
 // CHECK:         vop2 v_cndmask_b32 outs %{{.*}} ins %{{.*}}, %{{.*}} src2 = %[[VCC]]
 // CHECK:         end_kernel

--- a/test/Dialect/AMDGCN/cmp-ops.mlir
+++ b/test/Dialect/AMDGCN/cmp-ops.mlir
@@ -1,66 +1,66 @@
 // RUN: aster-opt %s --verify-roundtrip
 
-func.func @cmpi(%scc: !amdgcn.scc, %vcc: !amdgcn.vcc, %a: i32, %b: i32,
+func.func @cmpi(%scc: !amdgcn.scc<0>, %vcc: !amdgcn.vcc<0>, %a: i32, %b: i32,
     %v1: !amdgcn.vgpr, %dst: !amdgcn.sgpr<[? + 2]>, %dstAlloc: !amdgcn.sgpr<[0 : 2]>) {
-  amdgcn.cmpi s_cmp_eq_i32 outs %scc ins %a, %b : outs(!amdgcn.scc) ins(i32, i32)
-  amdgcn.cmpi v_cmp_eq_i32 outs %vcc ins %a, %v1 : outs(!amdgcn.vcc) ins(i32, !amdgcn.vgpr)
+  amdgcn.cmpi s_cmp_eq_i32 outs %scc ins %a, %b : outs(!amdgcn.scc<0>) ins(i32, i32)
+  amdgcn.cmpi v_cmp_eq_i32 outs %vcc ins %a, %v1 : outs(!amdgcn.vcc<0>) ins(i32, !amdgcn.vgpr)
   %0 = amdgcn.cmpi v_cmp_eq_i32_e64 outs %dst ins %a, %v1 : dps(!amdgcn.sgpr<[? + 2]>) ins(i32, !amdgcn.vgpr)
   amdgcn.cmpi v_cmp_eq_i32_e64 outs %dstAlloc ins %a, %v1 : outs(!amdgcn.sgpr<[0 : 2]>) ins(i32, !amdgcn.vgpr)
   return
 }
 
-func.func @sopc_signed_comparisons(%src0: !amdgcn.sgpr, %src1: !amdgcn.sgpr, %scc: !amdgcn.scc) {
+func.func @sopc_signed_comparisons(%src0: !amdgcn.sgpr, %src1: !amdgcn.sgpr, %scc: !amdgcn.scc<0>) {
   // s_cmp_eq_i32 - SOPC compare equal (signed 32-bit)
   amdgcn.cmpi s_cmp_eq_i32 outs %scc ins %src0, %src1
-    : outs(!amdgcn.scc) ins(!amdgcn.sgpr, !amdgcn.sgpr)
+    : outs(!amdgcn.scc<0>) ins(!amdgcn.sgpr, !amdgcn.sgpr)
 
   // s_cmp_lg_i32 - SOPC compare not equal (signed 32-bit)
   amdgcn.cmpi s_cmp_lg_i32 outs %scc ins %src0, %src1
-    : outs(!amdgcn.scc) ins(!amdgcn.sgpr, !amdgcn.sgpr)
+    : outs(!amdgcn.scc<0>) ins(!amdgcn.sgpr, !amdgcn.sgpr)
 
   // s_cmp_gt_i32 - SOPC compare greater than (signed 32-bit)
   amdgcn.cmpi s_cmp_gt_i32 outs %scc ins %src0, %src1
-    : outs(!amdgcn.scc) ins(!amdgcn.sgpr, !amdgcn.sgpr)
+    : outs(!amdgcn.scc<0>) ins(!amdgcn.sgpr, !amdgcn.sgpr)
 
   // s_cmp_ge_i32 - SOPC compare greater than or equal (signed 32-bit)
   amdgcn.cmpi s_cmp_ge_i32 outs %scc ins %src0, %src1
-    : outs(!amdgcn.scc) ins(!amdgcn.sgpr, !amdgcn.sgpr)
+    : outs(!amdgcn.scc<0>) ins(!amdgcn.sgpr, !amdgcn.sgpr)
 
   // s_cmp_lt_i32 - SOPC compare less than (signed 32-bit)
   amdgcn.cmpi s_cmp_lt_i32 outs %scc ins %src0, %src1
-    : outs(!amdgcn.scc) ins(!amdgcn.sgpr, !amdgcn.sgpr)
+    : outs(!amdgcn.scc<0>) ins(!amdgcn.sgpr, !amdgcn.sgpr)
 
   // s_cmp_le_i32 - SOPC compare less than or equal (signed 32-bit)
   amdgcn.cmpi s_cmp_le_i32 outs %scc ins %src0, %src1
-    : outs(!amdgcn.scc) ins(!amdgcn.sgpr, !amdgcn.sgpr)
+    : outs(!amdgcn.scc<0>) ins(!amdgcn.sgpr, !amdgcn.sgpr)
 
   return
 }
 
-func.func @sopc_unsigned_comparisons(%src0: !amdgcn.sgpr, %src1: !amdgcn.sgpr, %scc: !amdgcn.scc) {
+func.func @sopc_unsigned_comparisons(%src0: !amdgcn.sgpr, %src1: !amdgcn.sgpr, %scc: !amdgcn.scc<0>) {
   // s_cmp_eq_u32 - SOPC compare equal (unsigned 32-bit)
   amdgcn.cmpi s_cmp_eq_u32 outs %scc ins %src0, %src1
-    : outs(!amdgcn.scc) ins(!amdgcn.sgpr, !amdgcn.sgpr)
+    : outs(!amdgcn.scc<0>) ins(!amdgcn.sgpr, !amdgcn.sgpr)
 
   // s_cmp_lg_u32 - SOPC compare not equal (unsigned 32-bit)
   amdgcn.cmpi s_cmp_lg_u32 outs %scc ins %src0, %src1
-    : outs(!amdgcn.scc) ins(!amdgcn.sgpr, !amdgcn.sgpr)
+    : outs(!amdgcn.scc<0>) ins(!amdgcn.sgpr, !amdgcn.sgpr)
 
   // s_cmp_gt_u32 - SOPC compare greater than (unsigned 32-bit)
   amdgcn.cmpi s_cmp_gt_u32 outs %scc ins %src0, %src1
-    : outs(!amdgcn.scc) ins(!amdgcn.sgpr, !amdgcn.sgpr)
+    : outs(!amdgcn.scc<0>) ins(!amdgcn.sgpr, !amdgcn.sgpr)
 
   // s_cmp_ge_u32 - SOPC compare greater than or equal (unsigned 32-bit)
   amdgcn.cmpi s_cmp_ge_u32 outs %scc ins %src0, %src1
-    : outs(!amdgcn.scc) ins(!amdgcn.sgpr, !amdgcn.sgpr)
+    : outs(!amdgcn.scc<0>) ins(!amdgcn.sgpr, !amdgcn.sgpr)
 
   // s_cmp_lt_u32 - SOPC compare less than (unsigned 32-bit)
   amdgcn.cmpi s_cmp_lt_u32 outs %scc ins %src0, %src1
-    : outs(!amdgcn.scc) ins(!amdgcn.sgpr, !amdgcn.sgpr)
+    : outs(!amdgcn.scc<0>) ins(!amdgcn.sgpr, !amdgcn.sgpr)
 
   // s_cmp_le_u32 - SOPC compare less than or equal (unsigned 32-bit)
   amdgcn.cmpi s_cmp_le_u32 outs %scc ins %src0, %src1
-    : outs(!amdgcn.scc) ins(!amdgcn.sgpr, !amdgcn.sgpr)
+    : outs(!amdgcn.scc<0>) ins(!amdgcn.sgpr, !amdgcn.sgpr)
 
   return
 }

--- a/test/Dialect/AMDGCN/load-to-lds.mlir
+++ b/test/Dialect/AMDGCN/load-to-lds.mlir
@@ -6,54 +6,54 @@
 
 // buffer_load_dword with LDS flag (32-bit G2S)
 func.func @test_buffer_load_dword_lds(
-    %m0: !amdgcn.m0,
+    %m0: !amdgcn.m0<0>,
     %buf_desc: !amdgcn.sgpr<[? + 4]>,
     %soffset: !amdgcn.sgpr,
     %voffset: !amdgcn.vgpr) {
   %c0 = arith.constant 0 : i32
   %tok = amdgcn.load_lds buffer_load_dword_lds m0 %m0 addr %buf_desc
       offset u(%soffset) + d(%voffset) + c(%c0)
-      : ins(!amdgcn.m0, !amdgcn.sgpr<[? + 4]>, !amdgcn.sgpr, !amdgcn.vgpr, i32)
+      : ins(!amdgcn.m0<0>, !amdgcn.sgpr<[? + 4]>, !amdgcn.sgpr, !amdgcn.vgpr, i32)
       -> !amdgcn.write_token<flat>
   return
 }
 
 // buffer_load_dwordx4 with LDS flag (128-bit G2S)
 func.func @test_buffer_load_dwordx4_lds(
-    %m0: !amdgcn.m0,
+    %m0: !amdgcn.m0<0>,
     %buf_desc: !amdgcn.sgpr<[? + 4]>,
     %soffset: !amdgcn.sgpr,
     %voffset: !amdgcn.vgpr) {
   %c64 = arith.constant 64 : i32
   %tok = amdgcn.load_lds buffer_load_dwordx4_lds m0 %m0 addr %buf_desc
       offset u(%soffset) + d(%voffset) + c(%c64)
-      : ins(!amdgcn.m0, !amdgcn.sgpr<[? + 4]>, !amdgcn.sgpr, !amdgcn.vgpr, i32)
+      : ins(!amdgcn.m0<0>, !amdgcn.sgpr<[? + 4]>, !amdgcn.sgpr, !amdgcn.vgpr, i32)
       -> !amdgcn.write_token<flat>
   return
 }
 
 // G2S without optional uniform offset
 func.func @test_buffer_load_dword_lds_no_soffset(
-    %m0: !amdgcn.m0,
+    %m0: !amdgcn.m0<0>,
     %buf_desc: !amdgcn.sgpr<[? + 4]>,
     %voffset: !amdgcn.vgpr) {
   %c0 = arith.constant 0 : i32
   %tok = amdgcn.load_lds buffer_load_dword_lds m0 %m0 addr %buf_desc
       offset d(%voffset) + c(%c0)
-      : ins(!amdgcn.m0, !amdgcn.sgpr<[? + 4]>, !amdgcn.vgpr, i32)
+      : ins(!amdgcn.m0<0>, !amdgcn.sgpr<[? + 4]>, !amdgcn.vgpr, i32)
       -> !amdgcn.write_token<flat>
   return
 }
 
 // G2S without optional dynamic offset
 func.func @test_buffer_load_dword_lds_no_voffset(
-    %m0: !amdgcn.m0,
+    %m0: !amdgcn.m0<0>,
     %buf_desc: !amdgcn.sgpr<[? + 4]>,
     %soffset: !amdgcn.sgpr) {
   %c0 = arith.constant 0 : i32
   %tok = amdgcn.load_lds buffer_load_dword_lds m0 %m0 addr %buf_desc
       offset u(%soffset) + c(%c0)
-      : ins(!amdgcn.m0, !amdgcn.sgpr<[? + 4]>, !amdgcn.sgpr, i32)
+      : ins(!amdgcn.m0<0>, !amdgcn.sgpr<[? + 4]>, !amdgcn.sgpr, i32)
       -> !amdgcn.write_token<flat>
   return
 }

--- a/test/Dialect/AMDGCN/sop1.mlir
+++ b/test/Dialect/AMDGCN/sop1.mlir
@@ -18,25 +18,25 @@ func.func @sop1_mov_immediate(%sdst: !amdgcn.sgpr) -> !amdgcn.sgpr {
   return %result : !amdgcn.sgpr
 }
 
-func.func @sop1_mov_to_m0(%m0: !amdgcn.m0, %src: !amdgcn.sgpr) {
+func.func @sop1_mov_to_m0(%m0: !amdgcn.m0<0>, %src: !amdgcn.sgpr) {
   // s_mov_b32 - SOP1 move SGPR value to M0 register.
   // M0 has Allocated semantics (fixed physical register), so no SSA result.
   amdgcn.sop1 s_mov_b32 outs %m0 ins %src
-    : !amdgcn.m0, !amdgcn.sgpr
+    : !amdgcn.m0<0>, !amdgcn.sgpr
   return
 }
 
-func.func @sop1_mov_imm_to_m0(%m0: !amdgcn.m0) {
+func.func @sop1_mov_imm_to_m0(%m0: !amdgcn.m0<0>) {
   // s_mov_b32 - SOP1 move immediate to M0 register
   %imm = arith.constant 1024 : i32
   amdgcn.sop1 s_mov_b32 outs %m0 ins %imm
-    : !amdgcn.m0, i32
+    : !amdgcn.m0<0>, i32
   return
 }
 
-func.func @sop1_mov_m0_to_sgpr(%sdst: !amdgcn.sgpr, %m0: !amdgcn.m0) -> !amdgcn.sgpr {
+func.func @sop1_mov_m0_to_sgpr(%sdst: !amdgcn.sgpr, %m0: !amdgcn.m0<0>) -> !amdgcn.sgpr {
   // s_mov_b32 - SOP1 read M0 back into an SGPR
   %result = amdgcn.sop1 s_mov_b32 outs %sdst ins %m0
-    : !amdgcn.sgpr, !amdgcn.m0
+    : !amdgcn.sgpr, !amdgcn.m0<0>
   return %result : !amdgcn.sgpr
 }

--- a/test/Dialect/AMDGCN/type.mlir
+++ b/test/Dialect/AMDGCN/type.mlir
@@ -5,10 +5,10 @@
 !sgpr3 = !amdgcn.sgpr<[0 : 3]>
 !sgpr4 = !amdgcn.sgpr<[0 : 4 align 8]>
 
-!vcc = !amdgcn.vcc
-!scc = !amdgcn.scc
-!exec = !amdgcn.exec
-!execz = !amdgcn.execz
+!vcc = !amdgcn.vcc<0>
+!scc = !amdgcn.scc<0>
+!exec = !amdgcn.exec<0>
+!execz = !amdgcn.execz<0>
 
 func.func private @test(
   !amdgcn.vgpr<*>, !amdgcn.vgpr<?>, !amdgcn.vgpr<5>,

--- a/test/Target/ASM/cbranch.mlir
+++ b/test/Target/ASM/cbranch.mlir
@@ -31,11 +31,11 @@ amdgcn.module @mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
   ^entry:
     %s2 = amdgcn.alloca : !amdgcn.sgpr<2>
     %s3 = amdgcn.alloca : !amdgcn.sgpr<3>
-    %scc = amdgcn.alloca : !amdgcn.scc
+    %scc = amdgcn.alloca : !amdgcn.scc<0>
     amdgcn.cmpi s_cmp_gt_u32 outs %scc ins %s2, %s3
-      : outs(!amdgcn.scc) ins(!amdgcn.sgpr<2>, !amdgcn.sgpr<3>)
+      : outs(!amdgcn.scc<0>) ins(!amdgcn.sgpr<2>, !amdgcn.sgpr<3>)
     amdgcn.cbranch s_cbranch_scc1 %scc ^loop fallthrough (^exit)
-      : !amdgcn.scc
+      : !amdgcn.scc<0>
   ^exit:
     amdgcn.end_kernel
   ^loop:
@@ -46,11 +46,11 @@ amdgcn.module @mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
   ^entry:
     %s0 = amdgcn.alloca : !amdgcn.sgpr<0>
     %s1 = amdgcn.alloca : !amdgcn.sgpr<1>
-    %scc = amdgcn.alloca : !amdgcn.scc
+    %scc = amdgcn.alloca : !amdgcn.scc<0>
     amdgcn.cmpi s_cmp_eq_i32 outs %scc ins %s0, %s1
-      : outs(!amdgcn.scc) ins(!amdgcn.sgpr<0>, !amdgcn.sgpr<1>)
+      : outs(!amdgcn.scc<0>) ins(!amdgcn.sgpr<0>, !amdgcn.sgpr<1>)
     amdgcn.cbranch s_cbranch_scc0 %scc ^true_path fallthrough (^false_path)
-      : !amdgcn.scc
+      : !amdgcn.scc<0>
   ^false_path:
     amdgcn.end_kernel
   ^true_path:

--- a/test/Target/ASM/g2s-load-lds.mlir
+++ b/test/Target/ASM/g2s-load-lds.mlir
@@ -19,9 +19,9 @@ amdgcn.module @g2s_mod target = #amdgcn.target<gfx950> isa = #amdgcn.isa<cdna4> 
 
   amdgcn.kernel @test_g2s_dword {
   ^entry:
-    %m0 = amdgcn.alloca : !amdgcn.m0
+    %m0 = amdgcn.alloca : !amdgcn.m0<0>
     %c0 = arith.constant 0 : i32
-    amdgcn.sop1 s_mov_b32 outs %m0 ins %c0 : !amdgcn.m0, i32
+    amdgcn.sop1 s_mov_b32 outs %m0 ins %c0 : !amdgcn.m0<0>, i32
 
     // Buffer descriptor (s[0:3]) and scalar offset (s4)
     %s0 = amdgcn.alloca : !amdgcn.sgpr<0>
@@ -35,7 +35,7 @@ amdgcn.module @g2s_mod target = #amdgcn.target<gfx950> isa = #amdgcn.isa<cdna4> 
 
     %tok = amdgcn.load_lds buffer_load_dword_lds m0 %m0 addr %rsrc
         offset u(%soff) + d(%voff) + c(%c0)
-        : ins(!amdgcn.m0, !amdgcn.sgpr<[0 : 4]>, !amdgcn.sgpr<4>, !amdgcn.vgpr<0>, i32)
+        : ins(!amdgcn.m0<0>, !amdgcn.sgpr<[0 : 4]>, !amdgcn.sgpr<4>, !amdgcn.vgpr<0>, i32)
         -> !amdgcn.write_token<flat>
     amdgcn.sopp.s_waitcnt #amdgcn.inst<s_waitcnt> vmcnt = 0
     amdgcn.end_kernel
@@ -43,10 +43,10 @@ amdgcn.module @g2s_mod target = #amdgcn.target<gfx950> isa = #amdgcn.isa<cdna4> 
 
   amdgcn.kernel @test_g2s_dwordx4 {
   ^entry:
-    %m0 = amdgcn.alloca : !amdgcn.m0
+    %m0 = amdgcn.alloca : !amdgcn.m0<0>
     %c0 = arith.constant 0 : i32
     %c64 = arith.constant 64 : i32
-    amdgcn.sop1 s_mov_b32 outs %m0 ins %c0 : !amdgcn.m0, i32
+    amdgcn.sop1 s_mov_b32 outs %m0 ins %c0 : !amdgcn.m0<0>, i32
 
     %s0 = amdgcn.alloca : !amdgcn.sgpr<0>
     %s1 = amdgcn.alloca : !amdgcn.sgpr<1>
@@ -59,7 +59,7 @@ amdgcn.module @g2s_mod target = #amdgcn.target<gfx950> isa = #amdgcn.isa<cdna4> 
 
     %tok = amdgcn.load_lds buffer_load_dwordx4_lds m0 %m0 addr %rsrc
         offset u(%soff) + d(%voff) + c(%c64)
-        : ins(!amdgcn.m0, !amdgcn.sgpr<[0 : 4]>, !amdgcn.sgpr<4>, !amdgcn.vgpr<0>, i32)
+        : ins(!amdgcn.m0<0>, !amdgcn.sgpr<[0 : 4]>, !amdgcn.sgpr<4>, !amdgcn.vgpr<0>, i32)
         -> !amdgcn.write_token<flat>
     amdgcn.sopp.s_waitcnt #amdgcn.inst<s_waitcnt> vmcnt = 0
     amdgcn.end_kernel

--- a/test/Target/ASM/loops.mlir
+++ b/test/Target/ASM/loops.mlir
@@ -44,17 +44,17 @@ amdgcn.module @mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
   ^entry:
     %c5 = arith.constant 5 : i32
     %c4 = arith.constant 4 : i32
-    %scc = amdgcn.alloca : !amdgcn.scc
+    %scc = amdgcn.alloca : !amdgcn.scc<0>
     %s0 = amdgcn.alloca : !amdgcn.sgpr<0>
     %s1 = amdgcn.alloca : !amdgcn.sgpr<1>
 
     amdgcn.sop1 s_mov_b32 outs %s0 ins %c5 : !amdgcn.sgpr<0>, i32
     amdgcn.sop1 s_mov_b32 outs %s1 ins %c4 : !amdgcn.sgpr<1>, i32
     amdgcn.cmpi s_cmp_le_i32 outs %scc ins %s0, %s1
-      : outs(!amdgcn.scc) ins(!amdgcn.sgpr<0>, !amdgcn.sgpr<1>)
+      : outs(!amdgcn.scc<0>) ins(!amdgcn.sgpr<0>, !amdgcn.sgpr<1>)
 
     amdgcn.cbranch s_cbranch_scc1 %scc ^then fallthrough (^else)
-      : !amdgcn.scc
+      : !amdgcn.scc<0>
   ^else:
     amdgcn.end_kernel
   ^then:
@@ -68,7 +68,7 @@ amdgcn.module @mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
   ^entry:
     %c10 = arith.constant 10 : i32
     %c9 = arith.constant 9 : i32
-    %scc = amdgcn.alloca : !amdgcn.scc
+    %scc = amdgcn.alloca : !amdgcn.scc<0>
     %s2 = amdgcn.alloca : !amdgcn.sgpr<2>
     %s3 = amdgcn.alloca : !amdgcn.sgpr<3>
 
@@ -78,9 +78,9 @@ amdgcn.module @mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
 
   ^loop_header:
     amdgcn.cmpi s_cmp_lt_i32 outs %scc ins %s3, %s2
-      : outs(!amdgcn.scc) ins(!amdgcn.sgpr<3>, !amdgcn.sgpr<2>)
+      : outs(!amdgcn.scc<0>) ins(!amdgcn.sgpr<3>, !amdgcn.sgpr<2>)
     amdgcn.cbranch s_cbranch_scc0 %scc ^exit fallthrough (^loop_body)
-      : !amdgcn.scc
+      : !amdgcn.scc<0>
   ^loop_body:
     amdgcn.branch s_branch ^loop_header
   ^exit:

--- a/test/Target/ASM/s-mov-m0.mlir
+++ b/test/Target/ASM/s-mov-m0.mlir
@@ -16,17 +16,17 @@
 amdgcn.module @m0_mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
   amdgcn.kernel @test_s_mov_m0_imm {
   ^entry:
-    %m0 = amdgcn.alloca : !amdgcn.m0
+    %m0 = amdgcn.alloca : !amdgcn.m0<0>
     %c1024 = arith.constant 1024 : i32
-    amdgcn.sop1 s_mov_b32 outs %m0 ins %c1024 : !amdgcn.m0, i32
+    amdgcn.sop1 s_mov_b32 outs %m0 ins %c1024 : !amdgcn.m0<0>, i32
     amdgcn.end_kernel
   }
 
   amdgcn.kernel @test_s_mov_m0_sgpr {
   ^entry:
-    %m0 = amdgcn.alloca : !amdgcn.m0
+    %m0 = amdgcn.alloca : !amdgcn.m0<0>
     %s0 = amdgcn.alloca : !amdgcn.sgpr<0>
-    amdgcn.sop1 s_mov_b32 outs %m0 ins %s0 : !amdgcn.m0, !amdgcn.sgpr<0>
+    amdgcn.sop1 s_mov_b32 outs %m0 ins %s0 : !amdgcn.m0<0>, !amdgcn.sgpr<0>
     amdgcn.end_kernel
   }
 }

--- a/test/Target/ASM/vopc-branch.mlir
+++ b/test/Target/ASM/vopc-branch.mlir
@@ -33,12 +33,12 @@ amdgcn.module @vopc_branch_mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa
   amdgcn.kernel @test_vcmp_lt_i32_vccnz {
   ^entry:
     %v0 = amdgcn.alloca : !amdgcn.vgpr<0>
-    %vcc = amdgcn.alloca : !amdgcn.vcc
+    %vcc = amdgcn.alloca : !amdgcn.vcc<0>
     %c0 = arith.constant 0 : i32
     amdgcn.cmpi v_cmp_lt_i32 outs %vcc ins %c0, %v0
-      : outs(!amdgcn.vcc) ins(i32, !amdgcn.vgpr<0>)
+      : outs(!amdgcn.vcc<0>) ins(i32, !amdgcn.vgpr<0>)
     amdgcn.cbranch s_cbranch_vccz %vcc ^taken fallthrough(^fallthru)
-      : !amdgcn.vcc
+      : !amdgcn.vcc<0>
   ^fallthru:
     amdgcn.end_kernel
   ^taken:
@@ -50,11 +50,11 @@ amdgcn.module @vopc_branch_mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa
   ^entry:
     %v0 = amdgcn.alloca : !amdgcn.vgpr<0>
     %v1 = amdgcn.alloca : !amdgcn.vgpr<1>
-    %vcc = amdgcn.alloca : !amdgcn.vcc
+    %vcc = amdgcn.alloca : !amdgcn.vcc<0>
     amdgcn.cmpi v_cmp_eq_i32 outs %vcc ins %v0, %v1
-      : outs(!amdgcn.vcc) ins(!amdgcn.vgpr<0>, !amdgcn.vgpr<1>)
+      : outs(!amdgcn.vcc<0>) ins(!amdgcn.vgpr<0>, !amdgcn.vgpr<1>)
     amdgcn.cbranch s_cbranch_vccz %vcc ^taken fallthrough(^fallthru)
-      : !amdgcn.vcc
+      : !amdgcn.vcc<0>
   ^fallthru:
     amdgcn.end_kernel
   ^taken:
@@ -65,12 +65,12 @@ amdgcn.module @vopc_branch_mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa
   amdgcn.kernel @test_vcmp_gt_swap {
   ^entry:
     %v0 = amdgcn.alloca : !amdgcn.vgpr<0>
-    %vcc = amdgcn.alloca : !amdgcn.vcc
+    %vcc = amdgcn.alloca : !amdgcn.vcc<0>
     %c32 = arith.constant 32 : i32
     amdgcn.cmpi v_cmp_gt_i32 outs %vcc ins %c32, %v0
-      : outs(!amdgcn.vcc) ins(i32, !amdgcn.vgpr<0>)
+      : outs(!amdgcn.vcc<0>) ins(i32, !amdgcn.vgpr<0>)
     amdgcn.cbranch s_cbranch_vccz %vcc ^taken fallthrough(^fallthru)
-      : !amdgcn.vcc
+      : !amdgcn.vcc<0>
   ^fallthru:
     amdgcn.end_kernel
   ^taken:

--- a/test/Target/ASM/vopc-cndmask.mlir
+++ b/test/Target/ASM/vopc-cndmask.mlir
@@ -21,9 +21,9 @@ amdgcn.module @vopc_cndmask_mod target = #amdgcn.target<gfx942> isa = #amdgcn.is
     %v0 = amdgcn.alloca : !amdgcn.vgpr<0>
     %v1 = amdgcn.alloca : !amdgcn.vgpr<1>
     %v2 = amdgcn.alloca : !amdgcn.vgpr<2>
-    %vcc = amdgcn.alloca : !amdgcn.vcc
+    %vcc = amdgcn.alloca : !amdgcn.vcc<0>
     vop2 v_cndmask_b32 outs %v2 ins %v0, %v1 src2 = %vcc
-      : !amdgcn.vgpr<2>, !amdgcn.vgpr<0>, !amdgcn.vgpr<1>, !amdgcn.vcc
+      : !amdgcn.vgpr<2>, !amdgcn.vgpr<0>, !amdgcn.vgpr<1>, !amdgcn.vcc<0>
     amdgcn.end_kernel
   }
 
@@ -32,12 +32,12 @@ amdgcn.module @vopc_cndmask_mod target = #amdgcn.target<gfx942> isa = #amdgcn.is
   ^entry:
     %v0 = amdgcn.alloca : !amdgcn.vgpr<0>
     %v2 = amdgcn.alloca : !amdgcn.vgpr<2>
-    %vcc = amdgcn.alloca : !amdgcn.vcc
+    %vcc = amdgcn.alloca : !amdgcn.vcc<0>
     %c42 = arith.constant 42 : i32
     amdgcn.vop1.vop1 #amdgcn.inst<v_mov_b32_e32> %v2, %c42
       : (!amdgcn.vgpr<2>, i32) -> ()
     vop2 v_cndmask_b32 outs %v2 ins %v0, %v2 src2 = %vcc
-      : !amdgcn.vgpr<2>, !amdgcn.vgpr<0>, !amdgcn.vgpr<2>, !amdgcn.vcc
+      : !amdgcn.vgpr<2>, !amdgcn.vgpr<0>, !amdgcn.vgpr<2>, !amdgcn.vcc<0>
     amdgcn.end_kernel
   }
 
@@ -46,11 +46,11 @@ amdgcn.module @vopc_cndmask_mod target = #amdgcn.target<gfx942> isa = #amdgcn.is
     %v0 = amdgcn.alloca : !amdgcn.vgpr<0>
     %v2 = amdgcn.alloca : !amdgcn.vgpr<2>
     %s0 = amdgcn.alloca : !amdgcn.sgpr<0>
-    %vcc = amdgcn.alloca : !amdgcn.vcc
+    %vcc = amdgcn.alloca : !amdgcn.vcc<0>
     amdgcn.vop1.vop1 #amdgcn.inst<v_mov_b32_e32> %v2, %s0
       : (!amdgcn.vgpr<2>, !amdgcn.sgpr<0>) -> ()
     vop2 v_cndmask_b32 outs %v2 ins %v0, %v2 src2 = %vcc
-      : !amdgcn.vgpr<2>, !amdgcn.vgpr<0>, !amdgcn.vgpr<2>, !amdgcn.vcc
+      : !amdgcn.vgpr<2>, !amdgcn.vgpr<0>, !amdgcn.vgpr<2>, !amdgcn.vcc<0>
     amdgcn.end_kernel
   }
 }

--- a/test/integration/g2s-load-lds-e2e.mlir
+++ b/test/integration/g2s-load-lds-e2e.mlir
@@ -103,9 +103,9 @@ amdgcn.module @g2s_e2e_mod target = #amdgcn.target<gfx950> isa = #amdgcn.isa<cdn
     // Set M0 = 44 (non-trivial dword-aligned LDS base offset for coverage).
     // Hardware writes to LDS at M0[17:2]*4 + tid*4 = 44 + tid*4.
     // M0 must be dword-aligned (low 2 bits are masked by hardware).
-    %m0 = amdgcn.alloca : !amdgcn.m0
+    %m0 = amdgcn.alloca : !amdgcn.m0<0>
     %c44 = arith.constant 44 : i32
-    amdgcn.sop1 s_mov_b32 outs %m0 ins %c44 : !amdgcn.m0, i32
+    amdgcn.sop1 s_mov_b32 outs %m0 ins %c44 : !amdgcn.m0<0>, i32
 
     // 1 NOP required after SALU writes M0 before G2S (CDNA4 hazard)
     amdgcn.sopp.sopp #amdgcn.inst<s_nop> , imm = 10
@@ -116,7 +116,7 @@ amdgcn.module @g2s_e2e_mod target = #amdgcn.target<gfx950> isa = #amdgcn.isa<cdn
     // Each lane loads src[tid] -> LDS[44 + tid*4]
     %tok_g2s = amdgcn.load_lds buffer_load_dword_lds m0 %m0 addr %src_rsrc
         offset u(%soffset) + d(%voffset) + c(%c0)
-        : ins(!amdgcn.m0, !amdgcn.sgpr<[? + 4]>, !amdgcn.sgpr, !amdgcn.vgpr, i32)
+        : ins(!amdgcn.m0<0>, !amdgcn.sgpr<[? + 4]>, !amdgcn.sgpr, !amdgcn.vgpr, i32)
         -> !amdgcn.write_token<flat>
 
     // Wait for G2S to complete (vmcnt tracks buffer loads).

--- a/test/integration/sreg-roundtrip-e2e.mlir
+++ b/test/integration/sreg-roundtrip-e2e.mlir
@@ -31,15 +31,15 @@ amdgcn.module @m0_roundtrip_mod target = #amdgcn.target<gfx942> isa = #amdgcn.is
 
     // Write constant 42 to M0 via s_mov_b32
     // M0 is pre-allocated (fixed physical register), so write has no SSA result.
-    %m0 = amdgcn.alloca : !amdgcn.m0
+    %m0 = amdgcn.alloca : !amdgcn.m0<0>
     %c42 = arith.constant 42 : i32
     amdgcn.sop1 s_mov_b32 outs %m0 ins %c42
-      : !amdgcn.m0, i32
+      : !amdgcn.m0<0>, i32
 
     // Read M0 back into an SGPR via s_mov_b32
     %s_dest = amdgcn.alloca : !amdgcn.sgpr
     %s_val = amdgcn.sop1 s_mov_b32 outs %s_dest ins %m0
-      : !amdgcn.sgpr, !amdgcn.m0
+      : !amdgcn.sgpr, !amdgcn.m0<0>
 
     // Broadcast scalar to all VGPR lanes via v_mov_b32_e32
     %v_dest = amdgcn.alloca : !amdgcn.vgpr


### PR DESCRIPTION
This patch allows treating special registers like `!amdgcn.scc` as values. Note that to keep consistency, the old behavior of `!amdgcn.scc` now corresponds to `!amdgcn.scc<0>`.

Note, that this patch only allows them as types, there's no true support for them at the moment.