### PR TITLE
[interfaces] Make getSizeInBits return int64_t with per-type implementations

### DIFF
--- a/include/aster/Dialect/AMDGCN/IR/AMDGCNTypes.td
+++ b/include/aster/Dialect/AMDGCN/IR/AMDGCNTypes.td
@@ -62,6 +62,9 @@ def AGPRType : AMDGCN_RegisterDef<"AGPR", "agpr", [MemRefElementTypeInterface]> 
     RegisterTypeInterface cloneRegisterType(RegisterRange range) const {
       return AGPRType::get(getContext(), range);
     }
+    int64_t getSizeInBits() const {
+      return static_cast<int64_t>(getRange().size()) * 32;
+    }
 
     //===------------------------------------------------------------------===//
     // ResourceTypeInterface
@@ -100,6 +103,9 @@ def SGPRType : AMDGCN_RegisterDef<"SGPR", "sgpr", [MemRefElementTypeInterface]> 
     }
     RegisterTypeInterface cloneRegisterType(RegisterRange range) const {
       return SGPRType::get(getContext(), range);
+    }
+    int64_t getSizeInBits() const {
+      return static_cast<int64_t>(getRange().size()) * 32;
     }
 
     //===------------------------------------------------------------------===//
@@ -140,6 +146,9 @@ def VGPRType : AMDGCN_RegisterDef<"VGPR", "vgpr", [MemRefElementTypeInterface]> 
     }
     RegisterTypeInterface cloneRegisterType(RegisterRange range) const {
       return VGPRType::get(getContext(), range);
+    }
+    int64_t getSizeInBits() const {
+      return static_cast<int64_t>(getRange().size()) * 32;
     }
 
     //===------------------------------------------------------------------===//
@@ -190,6 +199,19 @@ class SREGBase<string name, string mnemonic, string kind>
     RegisterTypeInterface cloneRegisterType(RegisterRange range) const {
       assert(range.size() == 1 && "SREG type can only clone single register");
       return get(getContext(), range.begin());
+    }
+    int64_t getSizeInBits() const {
+      switch (kRegisterKind) {
+      case RegisterKind::VCC:
+      case RegisterKind::EXEC:
+        return 64;
+      case RegisterKind::VCCZ:
+      case RegisterKind::EXECZ:
+      case RegisterKind::SCC:
+        return 1;
+      default:
+        return 32;
+      }
     }
 
     //===------------------------------------------------------------------===//

--- a/include/aster/Interfaces/RegisterType.td
+++ b/include/aster/Interfaces/RegisterType.td
@@ -44,12 +44,8 @@ def RegisterTypeInterface : TypeInterface<"RegisterTypeInterface", [
     >,
     InterfaceMethod<[{
         This method returns the size in bits of the register(s).
-        Each register is 32 bits. Returns std::nullopt if the type
-        is not a valid register type.
       }],
-      "std::optional<int64_t>", "getSizeInBits", (ins), [{}], [{
-        return $_type.getAsRange().size() * 32;
-      }]
+      "int64_t", "getSizeInBits"
     >
   ];
   let extraTraitClassDeclaration = [{

--- a/lib/Analysis/MemoryDependenceAnalysis.cpp
+++ b/lib/Analysis/MemoryDependenceAnalysis.cpp
@@ -176,11 +176,8 @@ bool MemoryDependenceAnalysis::isStoreOp(Operation *op) {
 }
 
 static int64_t computeAccessLength(Type type) {
-  if (auto regType = dyn_cast<RegisterTypeInterface>(type)) {
-    std::optional<int64_t> sizeInBits = regType.getSizeInBits();
-    assert(sizeInBits.has_value() && "register type must have valid size");
-    return *sizeInBits / 8;
-  }
+  if (auto regType = dyn_cast<RegisterTypeInterface>(type))
+    return regType.getSizeInBits() / 8;
   // Conservative: assume 4 bytes if we can't determine precisely.
   return 4;
 }


### PR DESCRIPTION
Drop the default implementation and the std::optional return type from RegisterTypeInterface::getSizeInBits. Implement the method in each register type: AGPR/SGPR/VGPR return range.size() * 32, and SREG types return 64 for vcc/exec, 1 for vccz/execz/scc, and 32 for all others.

Made-with: Cursor