### PR TITLE
[amdgcn] Add a pass to lower bb args using special regs

### DIFF
--- a/include/aster/Dialect/AMDGCN/Transforms/AMDGCNPasses.td
+++ b/include/aster/Dialect/AMDGCN/Transforms/AMDGCNPasses.td
@@ -48,6 +48,19 @@ def LegalizeOperands : Pass<"amdgcn-legalize-operands"> {
   ];
 }
 
+def LowerSRegBlockArgs : Pass<"amdgcn-lower-sreg-block-args"> {
+  let summary = "Lower special-register block arguments through SGPRs";
+  let description = [{
+    Transforms block arguments typed as AMDGCN special registers (SCC, VCC, etc.)
+    into SGPRs. Concretely, this pass inserts copies at branch points from the
+    SREG to a freshly allocated SGPR, and in the successor block, it inserts
+    copies back from the SGPR to the actual register type.
+  }];
+  let dependentDialects = [
+    "mlir::aster::lsir::LSIRDialect"
+  ];
+}
+
 def AMDGCNBufferization : Pass<"aster-amdgcn-bufferization"> {
   let summary = "Insert phi-breaking copies to prepare for register allocation";
   let description = [{

--- a/lib/Dialect/AMDGCN/Transforms/CMakeLists.txt
+++ b/lib/Dialect/AMDGCN/Transforms/CMakeLists.txt
@@ -12,6 +12,7 @@ add_mlir_library(AMDGCNTransforms
   LDSAlloc.cpp
   LegalizeCF.cpp
   LegalizeOperands.cpp
+  LowerSRegBlockArgs.cpp
   LowLevelScheduler.cpp
   Mem2Reg.cpp
   OptimizeAMDGCN.cpp

--- a/lib/Dialect/AMDGCN/Transforms/LowerSRegBlockArgs.cpp
+++ b/lib/Dialect/AMDGCN/Transforms/LowerSRegBlockArgs.cpp
@@ -1,0 +1,254 @@
+//===- LowerSRegBlockArgs.cpp - Tunnel SREG block args through SGPR ------===//
+//
+// Copyright 2025 The ASTER Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This pass lowers AMDGCN special-register block arguments to SGPR carriers.
+//
+//===----------------------------------------------------------------------===//
+
+#include "aster/Dialect/AMDGCN/IR/AMDGCNOps.h"
+#include "aster/Dialect/AMDGCN/IR/Utils.h"
+#include "aster/Dialect/AMDGCN/Transforms/Passes.h"
+#include "aster/Dialect/LSIR/IR/LSIRDialect.h"
+#include "aster/Dialect/LSIR/IR/LSIROps.h"
+#include "aster/IR/CFG.h"
+#include "aster/Interfaces/RegisterType.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
+
+namespace mlir::aster {
+namespace amdgcn {
+#define GEN_PASS_DEF_LOWERSREGBLOCKARGS
+#include "aster/Dialect/AMDGCN/Transforms/Passes.h.inc"
+} // namespace amdgcn
+} // namespace mlir::aster
+
+using namespace mlir;
+using namespace mlir::aster;
+using namespace mlir::aster::amdgcn;
+
+/// Returns true if `arg` is a special register with value semantics.
+static bool isSpecialReg(Type type) {
+  auto regTy = dyn_cast<AMDGCNRegisterTypeInterface>(type);
+  if (!regTy || !regTy.hasValueSemantics())
+    return false;
+  RegisterKind k = regTy.getRegisterKind();
+  if (k == RegisterKind::Unknown || k == RegisterKind::AGPR ||
+      k == RegisterKind::SGPR || k == RegisterKind::VGPR)
+    return false;
+  return true;
+}
+
+namespace {
+//===----------------------------------------------------------------------===//
+// LowerSRegBlockArgs
+//===----------------------------------------------------------------------===//
+struct LowerSRegBlockArgs
+    : public amdgcn::impl::LowerSRegBlockArgsBase<LowerSRegBlockArgs> {
+  using Base::Base;
+  void runOnOperation() override;
+};
+
+//===----------------------------------------------------------------------===//
+// TransformImpl
+//===----------------------------------------------------------------------===//
+
+/// An edge in the control flow graph that needs to be lowered.
+struct ForwardingEdge {
+  BranchOpInterface brOp;
+  BlockArgument destArg;
+  int32_t successorIndex;
+};
+
+/// Collects SREG phi edges, rewrites predecessors through SGPR carriers,
+/// then materializes SREG values in successors.
+class TransformImpl {
+public:
+  explicit TransformImpl(FunctionOpInterface funcOp)
+      : funcOp(funcOp), rewriter(funcOp.getContext()) {}
+
+  /// Walks the function body, rewrites all qualifying block arguments, or
+  /// returns failure.
+  LogicalResult run();
+
+  /// Inserts alloca + `lsir.copy` before the branch and patches one successor
+  /// operand.
+  void handleBranchOpEdge(const ForwardingEdge &edge,
+                          RegisterTypeInterface sgprTy);
+
+  /// Handles the given block by changing the block argument types and adding
+  /// copies for the SREGs.
+  void handleBlock(Block *bb, ArrayRef<Type> newArgTys,
+                   ArrayRef<Location> bbArgLocs);
+
+  FunctionOpInterface funcOp;
+  IRRewriter rewriter;
+  SmallVector<ForwardingEdge> forwardingEdges;
+};
+
+/// CFG walker that appends to `forwardingEdges`.
+struct Collector : CFGWalker<Collector> {
+  TransformImpl *impl = nullptr;
+  LogicalResult visitControlFlowEdge(const BranchPoint &branchPoint,
+                                     const Successor &successor);
+};
+} // namespace
+
+LogicalResult Collector::visitControlFlowEdge(const BranchPoint &branchPoint,
+                                              const Successor &successor) {
+  if (branchPoint.isEntryPoint() || !successor.isBlock())
+    return success();
+
+  // Bail out if the branch point has produced operands.
+  if (branchPoint.getProducedOperandCount() > 0)
+    return branchPoint.getPoint()->emitError()
+           << "expected a branch point with no produced operands";
+
+  // Get the branch point operands and successor block arguments.
+  ValueRange cfOperands = branchPoint.getOperands();
+  ValueRange succVars = successor.getInputs();
+
+  // Get the forwarding edges. We only care about block arguments with special
+  // register value semantics. zip_equal is used to assert that operand and
+  // argument counts match.
+  BranchOpInterface brOp = dyn_cast<BranchOpInterface>(branchPoint.getPoint());
+  for (auto [cfOperand, succVar] : llvm::zip_equal(cfOperands, succVars)) {
+    (void)cfOperand;
+    auto ba = dyn_cast<BlockArgument>(succVar);
+    if (!ba || !isSpecialReg(ba.getType()) || !brOp)
+      continue;
+    impl->forwardingEdges.push_back(
+        ForwardingEdge{brOp, ba, branchPoint.getSuccessorIndex()});
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// TransformImpl
+//===----------------------------------------------------------------------===//
+
+void TransformImpl::handleBranchOpEdge(const ForwardingEdge &edge,
+                                       RegisterTypeInterface sgprTy) {
+  BranchOpInterface brOp = edge.brOp;
+  SuccessorOperands succOperands =
+      brOp.getSuccessorOperands(edge.successorIndex);
+
+  OpBuilder::InsertionGuard guard(rewriter);
+  rewriter.setInsertionPoint(brOp);
+
+  // Insert a copy from the SREG to the SGPR, and update the successor operands.
+  Value sgprSlot = createAllocation(rewriter, brOp.getLoc(), sgprTy);
+  auto copyOp = lsir::CopyOp::create(rewriter, brOp.getLoc(), sgprSlot,
+                                     succOperands[edge.destArg.getArgNumber()]);
+  succOperands.getMutableForwardedOperands()[edge.destArg.getArgNumber()].set(
+      copyOp.getTargetRes());
+}
+
+void TransformImpl::handleBlock(Block *bb, ArrayRef<Type> newArgTys,
+                                ArrayRef<Location> bbArgLocs) {
+  // Create the new block.
+  Block *newBb = rewriter.createBlock(bb, newArgTys, bbArgLocs);
+  SmallVector<Value> args;
+  llvm::append_range(args, newBb->getArguments());
+
+  // Insert the copies back from the SGPR to the actual register type.
+  OpBuilder::InsertionGuard guard(rewriter);
+  rewriter.setInsertionPointToStart(newBb);
+  for (auto &&[oldArg, arg] : llvm::zip_equal(bb->getArguments(), args)) {
+    if (oldArg.getType() == arg.getType())
+      continue;
+    Value sreg =
+        createAllocation(rewriter, oldArg.getLoc(),
+                         cast<RegisterTypeInterface>(oldArg.getType()));
+    lsir::CopyOp copyOp =
+        lsir::CopyOp::create(rewriter, oldArg.getLoc(), sreg, arg);
+    arg = copyOp.getTargetRes();
+  }
+
+  // Replace the old block with the new one.
+  rewriter.replaceAllUsesWith(bb, newBb);
+  rewriter.inlineBlockBefore(bb, newBb, newBb->end(), args);
+}
+
+LogicalResult TransformImpl::run() {
+  // Collect the forwarding edges.
+  Collector collector;
+  collector.impl = this;
+  if (failed(collector.walk(funcOp)))
+    return failure();
+
+  // If there are no forwarding edges, we're done.
+  if (forwardingEdges.empty())
+    return success();
+
+  // Sort the edges to get a consistent lowering order within a compilation.
+  llvm::stable_sort(forwardingEdges, [](ForwardingEdge a, ForwardingEdge b) {
+    return std::make_tuple(a.destArg.getOwner(), a.destArg.getArgNumber(),
+                           a.brOp.getOperation(), a.successorIndex) <
+           std::make_tuple(b.destArg.getOwner(), b.destArg.getArgNumber(),
+                           b.brOp.getOperation(), b.successorIndex);
+  });
+
+  // Update all edges.
+  int64_t idx = 0, size = forwardingEdges.size();
+  while (idx < size) {
+    Block *tgtBb = forwardingEdges[idx].destArg.getOwner();
+
+    // Find the last edge for this block.
+    int64_t bbEnd = idx + 1;
+    while (bbEnd < size && forwardingEdges[bbEnd].destArg.getOwner() == tgtBb)
+      bbEnd++;
+
+    // Get the block argument types.
+    SmallVector<Type> bbArgTys;
+    SmallVector<Location> bbArgLocs = llvm::map_to_vector(
+        tgtBb->getArguments(), [](BlockArgument arg) { return arg.getLoc(); });
+    llvm::append_range(bbArgTys, TypeRange(tgtBb->getArguments()));
+
+    // Get the new block argument types.
+    for (Type &argTy : bbArgTys) {
+      if (!isSpecialReg(argTy))
+        continue;
+      int64_t sizeInBits = cast<RegisterTypeInterface>(argTy).getSizeInBits();
+      assert(sizeInBits > 0 &&
+             sizeInBits <= 32 * std::numeric_limits<int16_t>::max() &&
+             "register size out of range");
+      int16_t words = static_cast<int16_t>((sizeInBits + 31) / 32);
+      argTy = getSGPR(argTy.getContext(), words);
+    }
+
+    // Rewrite all the branch ops.
+    for (int64_t i = idx; i < bbEnd; i++) {
+      ForwardingEdge &edge = forwardingEdges[i];
+      handleBranchOpEdge(edge, cast<RegisterTypeInterface>(
+                                   bbArgTys[edge.destArg.getArgNumber()]));
+    }
+
+    // Update the block.
+    handleBlock(tgtBb, bbArgTys, bbArgLocs);
+
+    // Move to the next block.
+    idx = bbEnd;
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// LowerSRegBlockArgs
+//===----------------------------------------------------------------------===//
+
+void LowerSRegBlockArgs::runOnOperation() {
+  getOperation()->walk<WalkOrder::PostOrder>([&](FunctionOpInterface funcOp) {
+    if (failed(TransformImpl(funcOp).run())) {
+      signalPassFailure();
+      return WalkResult::interrupt();
+    }
+    return WalkResult::skip();
+  });
+}

--- a/test/Dialect/AMDGCN/Transforms/lower-sreg-block-args.mlir
+++ b/test/Dialect/AMDGCN/Transforms/lower-sreg-block-args.mlir
@@ -1,0 +1,112 @@
+// RUN: aster-opt %s --split-input-file \
+// RUN:   --amdgcn-lower-sreg-block-args \
+// RUN:   | FileCheck %s
+
+// CHECK-LABEL: kernel @scc_through_sgpr
+// CHECK:         %[[SG:.*]] = alloca : !amdgcn.sgpr
+// CHECK:         %[[CPY0:.*]] = lsir.copy %[[SG]], %{{.*}} : !amdgcn.sgpr, !amdgcn.scc
+// CHECK:         cf.br ^[[BB1:bb[0-9]+]](%[[CPY0]] : !amdgcn.sgpr)
+// CHECK:       ^[[BB1]](%[[A:.*]]: !amdgcn.sgpr):
+// CHECK:         %[[SC:.*]] = alloca : !amdgcn.scc
+// CHECK:         %[[CPY1:.*]] = lsir.copy %[[SC]], %[[A]] : !amdgcn.scc{{.*}}, !amdgcn.sgpr
+// CHECK:         test_inst ins %[[CPY1]] : (!amdgcn.scc) -> ()
+// CHECK:         end_kernel
+amdgcn.kernel @scc_through_sgpr {
+^bb0:
+  %scc = amdgcn.alloca : !amdgcn.scc
+  cf.br ^bb1(%scc : !amdgcn.scc)
+^bb1(%arg : !amdgcn.scc):
+  test_inst ins %arg : (!amdgcn.scc) -> ()
+  amdgcn.end_kernel
+}
+
+// -----
+
+// CHECK-LABEL: kernel @cond_br_scc
+// CHECK:         alloca : !amdgcn.sgpr
+// CHECK:         lsir.copy %{{.*}}, %{{.*}} : !amdgcn.sgpr, !amdgcn.scc
+// CHECK:         alloca : !amdgcn.sgpr
+// CHECK:         lsir.copy %{{.*}}, %{{.*}} : !amdgcn.sgpr, !amdgcn.scc
+// CHECK:         cf.cond_br %{{.*}}, ^{{bb[0-9]+}}(%{{.*}} : !amdgcn.sgpr), ^{{bb[0-9]+}}(%{{.*}} : !amdgcn.sgpr)
+// CHECK:       ^bb{{[0-9]+}}(%{{.*}}: !amdgcn.sgpr):
+// CHECK:         lsir.copy %{{.*}}, %{{.*}} : !amdgcn.scc{{.*}}, !amdgcn.sgpr
+// CHECK:       ^bb{{[0-9]+}}(%{{.*}}: !amdgcn.sgpr):
+// CHECK:         lsir.copy %{{.*}}, %{{.*}} : !amdgcn.scc{{.*}}, !amdgcn.sgpr
+amdgcn.kernel @cond_br_scc {
+^bb0:
+  %c = arith.constant true
+  %scc = amdgcn.alloca : !amdgcn.scc
+  cf.cond_br %c, ^bb1(%scc : !amdgcn.scc), ^bb2(%scc : !amdgcn.scc)
+^bb1(%a1 : !amdgcn.scc):
+  amdgcn.end_kernel
+^bb2(%a2 : !amdgcn.scc):
+  amdgcn.end_kernel
+}
+
+// -----
+
+// Allocated SCC (`<0>`) has non-value semantics; the pass must not rewrite.
+// CHECK-LABEL: kernel @allocated_scc_unchanged
+// CHECK:         cf.br ^{{bb[0-9]+}}(%{{.*}} : !amdgcn.scc<0>)
+// CHECK:       ^{{bb[0-9]+}}(%{{.*}}: !amdgcn.scc<0>):
+amdgcn.kernel @allocated_scc_unchanged {
+^bb0:
+  %scc = amdgcn.alloca : !amdgcn.scc<0>
+  cf.br ^bb1(%scc : !amdgcn.scc<0>)
+^bb1(%arg : !amdgcn.scc<0>):
+  amdgcn.end_kernel
+}
+
+// -----
+
+// Unallocated SCC (`<?>`) has non-value semantics; the pass must not rewrite.
+// CHECK-LABEL: kernel @unallocated_scc_unchanged
+// CHECK:         cf.br ^{{bb[0-9]+}}(%{{.*}} : !amdgcn.scc<?>)
+// CHECK:       ^{{bb[0-9]+}}(%{{.*}}: !amdgcn.scc<?>):
+amdgcn.kernel @unallocated_scc_unchanged {
+^bb0:
+  %scc = amdgcn.alloca : !amdgcn.scc<?>
+  cf.br ^bb1(%scc : !amdgcn.scc<?>)
+^bb1(%arg : !amdgcn.scc<?>):
+  amdgcn.end_kernel
+}
+
+// -----
+
+// VCC is a 64-bit (2-word) special register; the SGPR carrier must have size 2.
+// CHECK-LABEL: kernel @vcc_through_sgpr
+// CHECK:         %[[CPY0:.*]] = lsir.copy %{{.*}}, %{{.*}} : !amdgcn.sgpr{{.*}}, !amdgcn.vcc
+// CHECK:         cf.br ^[[BB1:bb[0-9]+]](%[[CPY0]] : !amdgcn.sgpr<[? + 2]>)
+// CHECK:       ^[[BB1]](%[[A:.*]]: !amdgcn.sgpr<[? + 2]>):
+// CHECK:         %[[VC:.*]] = alloca : !amdgcn.vcc
+// CHECK:         %[[CPY1:.*]] = lsir.copy %[[VC]], %[[A]] : !amdgcn.vcc{{.*}}, !amdgcn.sgpr{{.*}}
+// CHECK:         end_kernel
+amdgcn.kernel @vcc_through_sgpr {
+^bb0:
+  %vcc = amdgcn.alloca : !amdgcn.vcc
+  cf.br ^bb1(%vcc : !amdgcn.vcc)
+^bb1(%arg : !amdgcn.vcc):
+  amdgcn.end_kernel
+}
+
+// -----
+
+// Two distinct predecessors forwarding SCC to the same block argument.
+// CHECK-LABEL: kernel @multi_pred_scc
+// CHECK:         lsir.copy %{{.*}}, %{{.*}} : !amdgcn.sgpr, !amdgcn.scc
+// CHECK:         cf.cond_br %{{.*}}, ^{{bb[0-9]+}}, ^[[DEST:bb[0-9]+]](%{{.*}} : !amdgcn.sgpr)
+// CHECK:         lsir.copy %{{.*}}, %{{.*}} : !amdgcn.sgpr, !amdgcn.scc
+// CHECK:         cf.br ^[[DEST]](%{{.*}} : !amdgcn.sgpr)
+// CHECK:       ^[[DEST]](%{{.*}}: !amdgcn.sgpr):
+// CHECK:         lsir.copy %{{.*}}, %{{.*}} : !amdgcn.scc{{.*}}, !amdgcn.sgpr
+amdgcn.kernel @multi_pred_scc {
+^bb0:
+  %c = arith.constant true
+  %s0 = amdgcn.alloca : !amdgcn.scc
+  cf.cond_br %c, ^bb1, ^bb2(%s0 : !amdgcn.scc)
+^bb1:
+  %s1 = amdgcn.alloca : !amdgcn.scc
+  cf.br ^bb2(%s1 : !amdgcn.scc)
+^bb2(%arg : !amdgcn.scc):
+  amdgcn.end_kernel
+}


### PR DESCRIPTION
Introduce a pass that tunnels special-register block arguments (SCC, VCC, M0, etc.) through SGPR carriers using alloca and `lsir.copy` on predecessor edges, matching the CFG-walk style used elsewhere.

Only register types with value semantics (e.g. plain `!amdgcn.scc`) are rewritten; allocated and unallocated registers such as `!amdgcn.scc<0>` or `!amdgcn.scc<?>` are left unchanged.

Made-with: Cursor