### PR TITLE
[AMDGCN] Remove unused instruction definitions

### DIFF
--- a/include/aster/Dialect/AMDGCN/IR/Instructions/Comparison.td
+++ b/include/aster/Dialect/AMDGCN/IR/Instructions/Comparison.td
@@ -283,40 +283,5 @@ def VCmpEqI32E64 : VOPCE64CmpIInst<"v_cmp_eq_i32_e64", [CDNA3, CDNA4, RDNA4]> {
   let summary = "VOPC compare equal (signed 32-bit) E64";
 }
 
-def VCmpNeI32E64 : VOPCE64CmpIInst<"v_cmp_ne_i32_e64", [CDNA3, CDNA4, RDNA4]> {
-  let summary = "VOPC compare not equal (signed 32-bit) E64";
-}
-
-def VCmpLtI32E64 : VOPCE64CmpIInst<"v_cmp_lt_i32_e64", [CDNA3, CDNA4, RDNA4]> {
-  let summary = "VOPC compare less than (signed 32-bit) E64";
-}
-
-def VCmpLeI32E64 : VOPCE64CmpIInst<"v_cmp_le_i32_e64", [CDNA3, CDNA4, RDNA4]> {
-  let summary = "VOPC compare less than or equal (signed 32-bit) E64";
-}
-
-def VCmpGtI32E64 : VOPCE64CmpIInst<"v_cmp_gt_i32_e64", [CDNA3, CDNA4, RDNA4]> {
-  let summary = "VOPC compare greater than (signed 32-bit) E64";
-}
-
-def VCmpGeI32E64 : VOPCE64CmpIInst<"v_cmp_ge_i32_e64", [CDNA3, CDNA4, RDNA4]> {
-  let summary = "VOPC compare greater than or equal (signed 32-bit) E64";
-}
-
-def VCmpLtU32E64 : VOPCE64CmpIInst<"v_cmp_lt_u32_e64", [CDNA3, CDNA4, RDNA4]> {
-  let summary = "VOPC compare less than (unsigned 32-bit) E64";
-}
-
-def VCmpLeU32E64 : VOPCE64CmpIInst<"v_cmp_le_u32_e64", [CDNA3, CDNA4, RDNA4]> {
-  let summary = "VOPC compare less than or equal (unsigned 32-bit) E64";
-}
-
-def VCmpGtU32E64 : VOPCE64CmpIInst<"v_cmp_gt_u32_e64", [CDNA3, CDNA4, RDNA4]> {
-  let summary = "VOPC compare greater than (unsigned 32-bit) E64";
-}
-
-def VCmpGeU32E64 : VOPCE64CmpIInst<"v_cmp_ge_u32_e64", [CDNA3, CDNA4, RDNA4]> {
-  let summary = "VOPC compare greater than or equal (unsigned 32-bit) E64";
-}
 
 #endif // AMDGCN_INST_COMPARISON_TD

--- a/include/aster/Dialect/AMDGCN/IR/Instructions/SOP2.td
+++ b/include/aster/Dialect/AMDGCN/IR/Instructions/SOP2.td
@@ -166,45 +166,20 @@ def SAndn2B32 : SOP2Inst<"s_andn2_b32", [CDNA3, CDNA4]> {
   let summary = "SOP2 bitwise AND with negated second operand (32-bit)";
 }
 
-def SAndn2B64 : SOP2Inst<"s_andn2_b64", [CDNA3, CDNA4]> {
-  let summary = "SOP2 bitwise AND with negated second operand (64-bit)";
-  let constraints = SOP2Constraints<2, 1>.constraints;
-}
-
 def SOrn2B32 : SOP2Inst<"s_orn2_b32", [CDNA3, CDNA4]> {
   let summary = "SOP2 bitwise OR with negated second operand (32-bit)";
-}
-
-def SOrn2B64 : SOP2Inst<"s_orn2_b64", [CDNA3, CDNA4]> {
-  let summary = "SOP2 bitwise OR with negated second operand (64-bit)";
-  let constraints = SOP2Constraints<2, 1>.constraints;
 }
 
 def SNandB32 : SOP2Inst<"s_nand_b32", [CDNA3, CDNA4]> {
   let summary = "SOP2 bitwise NAND of two 32-bit values";
 }
 
-def SNandB64 : SOP2Inst<"s_nand_b64", [CDNA3, CDNA4]> {
-  let summary = "SOP2 bitwise NAND of two 64-bit values";
-  let constraints = SOP2Constraints<2, 1>.constraints;
-}
-
 def SNorB32 : SOP2Inst<"s_nor_b32", [CDNA3, CDNA4]> {
   let summary = "SOP2 bitwise NOR of two 32-bit values";
 }
 
-def SNorB64 : SOP2Inst<"s_nor_b64", [CDNA3, CDNA4]> {
-  let summary = "SOP2 bitwise NOR of two 64-bit values";
-  let constraints = SOP2Constraints<2, 1>.constraints;
-}
-
 def SXnorB32 : SOP2Inst<"s_xnor_b32", [CDNA3, CDNA4]> {
   let summary = "SOP2 bitwise XNOR of two 32-bit values";
-}
-
-def SXnorB64 : SOP2Inst<"s_xnor_b64", [CDNA3, CDNA4]> {
-  let summary = "SOP2 bitwise XNOR of two 64-bit values";
-  let constraints = SOP2Constraints<2, 1>.constraints;
 }
 
 //===----------------------------------------------------------------------===//
@@ -246,27 +221,12 @@ def SBfmB32 : SOP2Inst<"s_bfm_b32", [CDNA3, CDNA4]> {
   let summary = "SOP2 create 32-bit bitfield mask";
 }
 
-def SBfmB64 : SOP2Inst<"s_bfm_b64", [CDNA3, CDNA4]> {
-  let summary = "SOP2 create 64-bit bitfield mask";
-  let constraints = SOP2Constraints<2, 1>.constraints;
-}
-
 def SBfeU32 : SOP2Inst<"s_bfe_u32", [CDNA3, CDNA4]> {
   let summary = "SOP2 extract unsigned bitfield from 32-bit value";
 }
 
 def SBfeI32 : SOP2Inst<"s_bfe_i32", [CDNA3, CDNA4]> {
   let summary = "SOP2 extract signed bitfield from 32-bit value";
-}
-
-def SBfeU64 : SOP2Inst<"s_bfe_u64", [CDNA3, CDNA4]> {
-  let summary = "SOP2 extract unsigned bitfield from 64-bit value";
-  let constraints = SOP2Constraints<2, 1>.constraints;
-}
-
-def SBfeI64 : SOP2Inst<"s_bfe_i64", [CDNA3, CDNA4]> {
-  let summary = "SOP2 extract signed bitfield from 64-bit value";
-  let constraints = SOP2Constraints<2, 1>.constraints;
 }
 
 //===----------------------------------------------------------------------===//
@@ -325,20 +285,5 @@ def SLshl4AddU32 : SOP2Inst<"s_lshl4_add_u32", [CDNA3, CDNA4]> {
   let summary = "SOP2 shift left by 4 and add unsigned 32-bit";
 }
 
-//===----------------------------------------------------------------------===//
-// Scalar pack operations
-//===----------------------------------------------------------------------===//
-
-def SPackLlB32B16 : SOP2Inst<"s_pack_ll_b32_b16", [CDNA3, CDNA4]> {
-  let summary = "SOP2 pack two low 16-bit values into 32-bit";
-}
-
-def SPackLhB32B16 : SOP2Inst<"s_pack_lh_b32_b16", [CDNA3, CDNA4]> {
-  let summary = "SOP2 pack low and high 16-bit values into 32-bit";
-}
-
-def SPackHhB32B16 : SOP2Inst<"s_pack_hh_b32_b16", [CDNA3, CDNA4]> {
-  let summary = "SOP2 pack two high 16-bit values into 32-bit";
-}
 
 #endif // AMDGCN_INST_SOP2_TD

--- a/include/aster/Dialect/AMDGCN/IR/Instructions/VOP2.td
+++ b/include/aster/Dialect/AMDGCN/IR/Instructions/VOP2.td
@@ -128,15 +128,6 @@ def VSubF32 : VOP2Inst<"v_sub_f32", [CDNA3, CDNA4]> {
   let summary = "VOP2 subtract 32-bit floating point values";
 }
 
-def VSubrevF32 : VOP2Inst<"v_subrev_f32", [CDNA3, CDNA4]> {
-  let summary = "VOP2 reverse subtract 32-bit floating point values";
-}
-
-def VFmacF64 : VOP2Inst<"v_fmac_f64", [CDNA3, CDNA4]> {
-  let summary = "VOP2 fused multiply-add 64-bit floating point";
-  let constraints = VOP2Constraints<2, /*dst1=*/0, /*src2=*/1>.constraints;
-}
-
 def VMulF32 : VOP2Inst<"v_mul_f32", [CDNA3, CDNA4]> {
   let summary = "VOP2 multiply 32-bit floating point values";
 }
@@ -161,36 +152,8 @@ def VSubF16 : VOP2Inst<"v_sub_f16", [CDNA3, CDNA4]> {
   let summary = "VOP2 subtract 16-bit floating point values";
 }
 
-def VSubrevF16 : VOP2Inst<"v_subrev_f16", [CDNA3, CDNA4]> {
-  let summary = "VOP2 reverse subtract 16-bit floating point values";
-}
-
 def VMulF16 : VOP2Inst<"v_mul_f16", [CDNA3, CDNA4]> {
   let summary = "VOP2 multiply 16-bit floating point values";
-}
-
-def VMacF16 : VOP2Inst<"v_mac_f16", [CDNA3, CDNA4]> {
-  let summary = "VOP2 multiply-accumulate 16-bit floating point";
-}
-
-def VMadmkF16 : VOP2Inst<"v_madmk_f16", [CDNA3, CDNA4]> {
-  let summary = "VOP2 MAD with literal constant multiplier (16-bit)";
-}
-
-def VMadakF16 : VOP2Inst<"v_madak_f16", [CDNA3, CDNA4]> {
-  let summary = "VOP2 MAD with literal constant addend (16-bit)";
-}
-
-def VMaxF16 : VOP2Inst<"v_max_f16", [CDNA3, CDNA4]> {
-  let summary = "VOP2 maximum of two 16-bit floating point values";
-}
-
-def VMinF16 : VOP2Inst<"v_min_f16", [CDNA3, CDNA4]> {
-  let summary = "VOP2 minimum of two 16-bit floating point values";
-}
-
-def VLdexpF16 : VOP2Inst<"v_ldexp_f16", [CDNA3, CDNA4]> {
-  let summary = "VOP2 ldexp 16-bit floating point";
 }
 
 //===----------------------------------------------------------------------===//
@@ -203,10 +166,6 @@ def VAddU16 : VOP2Inst<"v_add_u16", [CDNA3, CDNA4]> {
 
 def VSubU16 : VOP2Inst<"v_sub_u16", [CDNA3, CDNA4]> {
   let summary = "VOP2 subtract unsigned 16-bit integers";
-}
-
-def VSubrevU16 : VOP2Inst<"v_subrev_u16", [CDNA3, CDNA4]> {
-  let summary = "VOP2 reverse subtract unsigned 16-bit integers";
 }
 
 def VMulLoU16 : VOP2Inst<"v_mul_lo_u16", [CDNA3, CDNA4]> {
@@ -227,46 +186,6 @@ def VLshrrevB16 : VOP2Inst<"v_lshrrev_b16", [CDNA3, CDNA4]> {
 
 def VAshrrevI16 : VOP2Inst<"v_ashrrev_i16", [CDNA3, CDNA4]> {
   let summary = "VOP2 arithmetic shift right reverse 16-bit";
-}
-
-//===----------------------------------------------------------------------===//
-// 16-bit integer min/max operations
-//===----------------------------------------------------------------------===//
-
-def VMaxU16 : VOP2Inst<"v_max_u16", [CDNA3, CDNA4]> {
-  let summary = "VOP2 maximum of two unsigned 16-bit integers";
-}
-
-def VMaxI16 : VOP2Inst<"v_max_i16", [CDNA3, CDNA4]> {
-  let summary = "VOP2 maximum of two signed 16-bit integers";
-}
-
-def VMinU16 : VOP2Inst<"v_min_u16", [CDNA3, CDNA4]> {
-  let summary = "VOP2 minimum of two unsigned 16-bit integers";
-}
-
-def VMinI16 : VOP2Inst<"v_min_i16", [CDNA3, CDNA4]> {
-  let summary = "VOP2 minimum of two signed 16-bit integers";
-}
-
-//===----------------------------------------------------------------------===//
-// Integer min/max operations
-//===----------------------------------------------------------------------===//
-
-def VMinI32 : VOP2Inst<"v_min_i32", [CDNA3, CDNA4]> {
-  let summary = "VOP2 minimum of two signed 32-bit integers";
-}
-
-def VMaxI32 : VOP2Inst<"v_max_i32", [CDNA3, CDNA4]> {
-  let summary = "VOP2 maximum of two signed 32-bit integers";
-}
-
-def VMinU32 : VOP2Inst<"v_min_u32", [CDNA3, CDNA4]> {
-  let summary = "VOP2 minimum of two unsigned 32-bit integers";
-}
-
-def VMaxU32 : VOP2Inst<"v_max_u32", [CDNA3, CDNA4]> {
-  let summary = "VOP2 maximum of two unsigned 32-bit integers";
 }
 
 //===----------------------------------------------------------------------===//
@@ -291,38 +210,6 @@ def VOrB32 : VOP2Inst<"v_or_b32", [CDNA3, CDNA4]> {
 
 def VXorB32 : VOP2Inst<"v_xor_b32", [CDNA3, CDNA4]> {
   let summary = "VOP2 bitwise XOR";
-}
-
-//===----------------------------------------------------------------------===//
-// Floating-point FMA with constant operations
-//===----------------------------------------------------------------------===//
-
-def VFmamkF32 : VOP2Inst<"v_fmamk_f32", [CDNA3, CDNA4]> {
-  let summary = "VOP2 FMA with literal constant multiplier";
-}
-
-def VFmaakF32 : VOP2Inst<"v_fmaak_f32", [CDNA3, CDNA4]> {
-  let summary = "VOP2 FMA with literal constant addend";
-}
-
-//===----------------------------------------------------------------------===//
-// Integer multiply operations
-//===----------------------------------------------------------------------===//
-
-def VMulI32I24 : VOP2Inst<"v_mul_i32_i24", [CDNA3, CDNA4]> {
-  let summary = "VOP2 multiply signed 24-bit integers";
-}
-
-def VMulHiI32I24 : VOP2Inst<"v_mul_hi_i32_i24", [CDNA3, CDNA4]> {
-  let summary = "VOP2 multiply signed 24-bit integers (high 32 bits)";
-}
-
-def VMulU32U24 : VOP2Inst<"v_mul_u32_u24", [CDNA3, CDNA4]> {
-  let summary = "VOP2 multiply unsigned 24-bit integers";
-}
-
-def VMulHiU32U24 : VOP2Inst<"v_mul_hi_u32_u24", [CDNA3, CDNA4]> {
-  let summary = "VOP2 multiply unsigned 24-bit integers (high 32 bits)";
 }
 
 //===----------------------------------------------------------------------===//
@@ -351,22 +238,6 @@ def VAddCoU32 : VOP2Inst<"v_add_co_u32", [CDNA3, CDNA4]> {
 
 def VSubCoU32 : VOP2Inst<"v_sub_co_u32", [CDNA3, CDNA4]> {
   let summary = "VOP2 subtract with carry out";
-  let asmFormat = [SingleAsmVariant<"$vdst0, $dst1, $src0, $src1">];
-  let constraints = VOP2Constraints<1, /*dst1=*/1, /*src2=*/0>.constraints;
-  let cppBuilder = OpBuilder<(ins
-    CppValue:$vdst, CppValue:$dst1, CppValue:$src0, CppValue:$src1), [{
-      return $_create($_builder, $_loc, $_opcode, vdst, dst1, src0, src1, nullptr);
-    }]
-  >;
-  let pythonBuilder = OpBuilder<(ins
-    PyValue:$vdst, PyValue:$dst1, PyValue:$src0, PyValue:$src1), [{
-      return $_create(opcode=$_opcode, vdst0=vdst, dst1=dst1, src0=src0, src1=src1, src2=None, $_lastArgs)
-    }]
-  >;
-}
-
-def VSubrevCoU32 : VOP2Inst<"v_subrev_co_u32", [CDNA3, CDNA4]> {
-  let summary = "VOP2 reverse subtract with carry out";
   let asmFormat = [SingleAsmVariant<"$vdst0, $dst1, $src0, $src1">];
   let constraints = VOP2Constraints<1, /*dst1=*/1, /*src2=*/0>.constraints;
   let cppBuilder = OpBuilder<(ins
@@ -413,64 +284,12 @@ def VSubbCoU32 : VOP2Inst<"v_subb_co_u32", [CDNA3, CDNA4]> {
   >;
 }
 
-def VSubbrevCoU32 : VOP2Inst<"v_subbrev_co_u32", [CDNA3, CDNA4]> {
-  let summary = "VOP2 reverse subtract with borrow (carry in and out)";
-  let asmFormat = [SingleAsmVariant<"$vdst0, $dst1, $src0, $src1, $src2">];
-  let constraints = VOP2Constraints<1, /*dst1=*/1, /*src2=*/1>.constraints;
-  let cppBuilder = OpBuilder<(ins
-    CppValue:$vdst, CppValue:$dst1, CppValue:$src0, CppValue:$src1, CppValue:$src2), [{
-      return $_create($_builder, $_loc, $_opcode, vdst, dst1, src0, src1, src2);
-    }]
-  >;
-  let pythonBuilder = OpBuilder<(ins
-    PyValue:$vdst, PyValue:$dst1, PyValue:$src0, PyValue:$src1, PyValue:$src2), [{
-      return $_create(opcode=$_opcode, vdst0=vdst, dst1=dst1, src0=src0, src1=src1, src2=src2, $_lastArgs)
-    }]
-  >;
-}
-
 def VAddU32 : VOP2Inst<"v_add_u32", [CDNA3, CDNA4]> {
   let summary = "VOP2 add two unsigned 32-bit integers";
 }
 
 def VSubU32 : VOP2Inst<"v_sub_u32", [CDNA3, CDNA4]> {
   let summary = "VOP2 subtract unsigned 32-bit integers";
-}
-
-def VSubrevU32 : VOP2Inst<"v_subrev_u32", [CDNA3, CDNA4]> {
-  let summary = "VOP2 reverse subtract unsigned 32-bit integers";
-}
-
-//===----------------------------------------------------------------------===//
-// Dot product operations
-//===----------------------------------------------------------------------===//
-
-def VDot2cF32F16 : VOP2Inst<"v_dot2c_f32_f16", [CDNA3, CDNA4]> {
-  let summary = "VOP2 2-element f16 dot product with f32 accumulation";
-}
-
-def VDot2cI32I16 : VOP2Inst<"v_dot2c_i32_i16", [CDNA3, CDNA4]> {
-  let summary = "VOP2 2-element i16 dot product with i32 accumulation";
-}
-
-def VDot4cI32I8 : VOP2Inst<"v_dot4c_i32_i8", [CDNA3, CDNA4]> {
-  let summary = "VOP2 4-element i8 dot product with i32 accumulation";
-}
-
-def VDot8cI32I4 : VOP2Inst<"v_dot8c_i32_i4", [CDNA3, CDNA4]> {
-  let summary = "VOP2 8-element i4 dot product with i32 accumulation";
-}
-
-def VFmacF32 : VOP2Inst<"v_fmac_f32", [CDNA3, CDNA4]> {
-  let summary = "VOP2 fused multiply-accumulate 32-bit floating point";
-}
-
-def VPkFmacF16 : VOP2Inst<"v_pk_fmac_f16", [CDNA3, CDNA4]> {
-  let summary = "VOP2 packed fused multiply-accumulate 16-bit floating point";
-}
-
-def VXnorB32 : VOP2Inst<"v_xnor_b32", [CDNA3, CDNA4]> {
-  let summary = "VOP2 bitwise XNOR";
 }
 
 def VAddI16 : VOP2Inst<"v_add_i16", [CDNA3, CDNA4]> {

--- a/include/aster/Dialect/AMDGCN/IR/Instructions/VOP3.td
+++ b/include/aster/Dialect/AMDGCN/IR/Instructions/VOP3.td
@@ -73,30 +73,6 @@ class VOP3Inst<string _mnemonic, list<ISAVersion> _isa>
 }
 
 //===----------------------------------------------------------------------===//
-// Conditional and mask operations
-//===----------------------------------------------------------------------===//
-
-def VCndmaskB32E64 : VOP3Inst<"v_cndmask_b32_e64", [CDNA3, CDNA4]> {
-  let summary = "VOP3 conditional mask";
-  let asmFormat = [SingleAsmVariant<"$vdst0, $src0, $src1, $src2">];
-  let constraints = (ins
-    /*outs=*/NotPresent:$dst1,
-    /*ins=*/ Present:$src2
-  );
-  // Default builders.
-  let cppBuilder = OpBuilder<(ins
-    CppValue:$vdst, CppValue:$src0, CppValue:$src1, CppValue:$src2), [{
-      return $_create($_builder, $_loc, $_opcode, vdst, nullptr, src0, src1, src2);
-    }]
-  >;
-  let pythonBuilder = OpBuilder<(ins
-    PyValue:$vdst, PyValue:$src0, PyValue:$src1, PyValue:$src2), [{
-      return $_create(opcode=$_opcode, vdst0=vdst, dst1=None, src0=src0, src1=src1, src2=src2, $_lastArgs)
-    }]
-  >;
-}
-
-//===----------------------------------------------------------------------===//
 // Floating-point arithmetic operations
 //===----------------------------------------------------------------------===//
 
@@ -106,15 +82,6 @@ def VAddF32E64 : VOP3Inst<"v_add_f32_e64", [CDNA3, CDNA4]> {
 
 def VSubF32E64 : VOP3Inst<"v_sub_f32_e64", [CDNA3, CDNA4]> {
   let summary = "VOP3 subtract 32-bit floating point values";
-}
-
-def VSubrevF32E64 : VOP3Inst<"v_subrev_f32_e64", [CDNA3, CDNA4]> {
-  let summary = "VOP3 reverse subtract 32-bit floating point values";
-}
-
-def VFmacF64E64 : VOP3Inst<"v_fmac_f64_e64", [CDNA3, CDNA4]> {
-  let summary = "VOP3 fused multiply-add 64-bit floating point";
-  let constraints = VOP3Constraints</*words=*/2, /*dst1_w=*/0, /*src2_w=*/0>.constraints;
 }
 
 def VMulF32E64 : VOP3Inst<"v_mul_f32_e64", [CDNA3, CDNA4]> {
@@ -149,22 +116,6 @@ def VMulF16E64 : VOP3Inst<"v_mul_f16_e64", [CDNA3, CDNA4]> {
   let summary = "VOP3 multiply 16-bit floating point values";
 }
 
-def VMacF16E64 : VOP3Inst<"v_mac_f16_e64", [CDNA3, CDNA4]> {
-  let summary = "VOP3 multiply-accumulate 16-bit floating point";
-}
-
-def VMaxF16E64 : VOP3Inst<"v_max_f16_e64", [CDNA3, CDNA4]> {
-  let summary = "VOP3 maximum of two 16-bit floating point values";
-}
-
-def VMinF16E64 : VOP3Inst<"v_min_f16_e64", [CDNA3, CDNA4]> {
-  let summary = "VOP3 minimum of two 16-bit floating point values";
-}
-
-def VLdexpF16E64 : VOP3Inst<"v_ldexp_f16_e64", [CDNA3, CDNA4]> {
-  let summary = "VOP3 ldexp 16-bit floating point";
-}
-
 //===----------------------------------------------------------------------===//
 // 16-bit integer arithmetic operations
 //===----------------------------------------------------------------------===//
@@ -175,10 +126,6 @@ def VAddU16E64 : VOP3Inst<"v_add_u16_e64", [CDNA3, CDNA4]> {
 
 def VSubU16E64 : VOP3Inst<"v_sub_u16_e64", [CDNA3, CDNA4]> {
   let summary = "VOP3 subtract unsigned 16-bit integers";
-}
-
-def VSubrevU16E64 : VOP3Inst<"v_subrev_u16_e64", [CDNA3, CDNA4]> {
-  let summary = "VOP3 reverse subtract unsigned 16-bit integers";
 }
 
 def VMulLoU16E64 : VOP3Inst<"v_mul_lo_u16_e64", [CDNA3, CDNA4]> {
@@ -199,46 +146,6 @@ def VLshrrevB16E64 : VOP3Inst<"v_lshrrev_b16_e64", [CDNA3, CDNA4]> {
 
 def VAshrrevI16E64 : VOP3Inst<"v_ashrrev_i16_e64", [CDNA3, CDNA4]> {
   let summary = "VOP3 arithmetic shift right reverse 16-bit";
-}
-
-//===----------------------------------------------------------------------===//
-// 16-bit integer min/max operations
-//===----------------------------------------------------------------------===//
-
-def VMaxU16E64 : VOP3Inst<"v_max_u16_e64", [CDNA3, CDNA4]> {
-  let summary = "VOP3 maximum of two unsigned 16-bit integers";
-}
-
-def VMaxI16E64 : VOP3Inst<"v_max_i16_e64", [CDNA3, CDNA4]> {
-  let summary = "VOP3 maximum of two signed 16-bit integers";
-}
-
-def VMinU16E64 : VOP3Inst<"v_min_u16_e64", [CDNA3, CDNA4]> {
-  let summary = "VOP3 minimum of two unsigned 16-bit integers";
-}
-
-def VMinI16E64 : VOP3Inst<"v_min_i16_e64", [CDNA3, CDNA4]> {
-  let summary = "VOP3 minimum of two signed 16-bit integers";
-}
-
-//===----------------------------------------------------------------------===//
-// Integer min/max operations
-//===----------------------------------------------------------------------===//
-
-def VMinI32E64 : VOP3Inst<"v_min_i32_e64", [CDNA3, CDNA4]> {
-  let summary = "VOP3 minimum of two signed 32-bit integers";
-}
-
-def VMaxI32E64 : VOP3Inst<"v_max_i32_e64", [CDNA3, CDNA4]> {
-  let summary = "VOP3 maximum of two signed 32-bit integers";
-}
-
-def VMinU32E64 : VOP3Inst<"v_min_u32_e64", [CDNA3, CDNA4]> {
-  let summary = "VOP3 minimum of two unsigned 32-bit integers";
-}
-
-def VMaxU32E64 : VOP3Inst<"v_max_u32_e64", [CDNA3, CDNA4]> {
-  let summary = "VOP3 maximum of two unsigned 32-bit integers";
 }
 
 //===----------------------------------------------------------------------===//
@@ -312,74 +219,6 @@ def VMadU64U32 : VOP3Inst<"v_mad_u64_u32", [CDNA3, CDNA4]> {
       return $_create(opcode=$_opcode, vdst0=vdst, dst1=dst1, src0=src0, src1=src1, src2=src2, $_lastArgs)
     }]
   >;
-}
-
-def VMadI64I32 : VOP3Inst<"v_mad_i64_i32", [CDNA3, CDNA4]> {
-  let summary = "VOP3 multiply-add signed 32-bit to 64-bit with carry";
-  let asmFormat = [SingleAsmVariant<"$vdst0, $dst1, $src0, $src1, $src2">];
-  let constraints = VMad64Constraint;
-  let cppBuilder = OpBuilder<(ins
-    CppValue:$vdst, CppValue:$dst1, CppValue:$src0, CppValue:$src1, CppValue:$src2), [{
-      return $_create($_builder, $_loc, $_opcode, vdst, dst1, src0, src1, src2);
-    }]
-  >;
-  let pythonBuilder = OpBuilder<(ins
-    PyValue:$vdst, PyValue:$dst1, PyValue:$src0, PyValue:$src1, PyValue:$src2), [{
-      return $_create(opcode=$_opcode, vdst0=vdst, dst1=dst1, src0=src0, src1=src1, src2=src2, $_lastArgs)
-    }]
-  >;
-}
-
-def VMadU32U16 : VOP3Inst<"v_mad_u32_u16", [CDNA3, CDNA4]> {
-  let summary = "VOP3 multiply-add unsigned 16-bit to 32-bit";
-  let asmFormat = [SingleAsmVariant<"$vdst0, $src0, $src1, $src2">];
-  let constraints = (ins
-    /*outs=*/NotPresent:$dst1,
-    /*ins=*/ Present:$src2
-  );
-  let constraints = VOP3Constraints</*words=*/1, /*dst1_w=*/0, /*src2_w=*/1>.constraints;
-  let cppBuilder = OpBuilder<(ins
-    CppValue:$vdst, CppValue:$src0, CppValue:$src1, CppValue:$src2), [{
-      return $_create($_builder, $_loc, $_opcode, vdst, nullptr, src0, src1, src2);
-    }]
-  >;
-  let pythonBuilder = OpBuilder<(ins
-    PyValue:$vdst, PyValue:$src0, PyValue:$src1, PyValue:$src2), [{
-      return $_create(opcode=$_opcode, vdst0=vdst, dst1=None, src0=src0, src1=src1, src2=src2, $_lastArgs)
-    }]
-  >;
-}
-
-def VMadI32I16 : VOP3Inst<"v_mad_i32_i16", [CDNA3, CDNA4]> {
-  let summary = "VOP3 multiply-add signed 16-bit to 32-bit";
-  let asmFormat = [SingleAsmVariant<"$vdst0, $src0, $src1, $src2">];
-  let constraints = VOP3Constraints</*words=*/1, /*dst1_w=*/0, /*src2_w=*/1>.constraints;
-  let cppBuilder = OpBuilder<(ins
-    CppValue:$vdst, CppValue:$src0, CppValue:$src1, CppValue:$src2), [{
-      return $_create($_builder, $_loc, $_opcode, vdst, nullptr, src0, src1, src2);
-    }]
-  >;
-  let pythonBuilder = OpBuilder<(ins
-    PyValue:$vdst, PyValue:$src0, PyValue:$src1, PyValue:$src2), [{
-      return $_create(opcode=$_opcode, vdst0=vdst, dst1=None, src0=src0, src1=src1, src2=src2, $_lastArgs)
-    }]
-  >;
-}
-
-def VMulI32I24E64 : VOP3Inst<"v_mul_i32_i24_e64", [CDNA3, CDNA4]> {
-  let summary = "VOP3 multiply signed 24-bit integers";
-}
-
-def VMulHiI32I24E64 : VOP3Inst<"v_mul_hi_i32_i24_e64", [CDNA3, CDNA4]> {
-  let summary = "VOP3 multiply signed 24-bit integers (high 32 bits)";
-}
-
-def VMulU32U24E64 : VOP3Inst<"v_mul_u32_u24_e64", [CDNA3, CDNA4]> {
-  let summary = "VOP3 multiply unsigned 24-bit integers";
-}
-
-def VMulHiU32U24E64 : VOP3Inst<"v_mul_hi_u32_u24_e64", [CDNA3, CDNA4]> {
-  let summary = "VOP3 multiply unsigned 24-bit integers (high 32 bits)";
 }
 
 def VMulLoU32 : VOP3Inst<"v_mul_lo_u32", [CDNA3, CDNA4]> {


### PR DESCRIPTION
Remove 78 instruction definitions that have no uses in the codebase:
- SOP2: 64-bit bitwise variants (andn2, orn2, nand, nor, xnor, bfm, bfe), and pack operations
- Comparison: 9 of the 10 E64 VOPC variants (keeping VCmpEqI32E64)
- VOP2: reverse-subtract/FMA/MAC/MADMK/MADAK/min-max 16-bit floats, 16-bit and 32-bit integer min/max, FMA-constant ops, 24-bit integer multiply, reverse-subtract carry ops, dot products, XNOR, FmacF32, PkFmacF16
- VOP3: VCndmaskB32E64, reverse-subtract/FmacF64/MAC 16-bit float variants, 16-bit and 32-bit integer min/max E64, VMadI64I32, VMadU32U16, VMadI32I16, and four 24-bit integer multiply E64 variants