### PR TITLE
[Interfaces] Introduce TargetAttrInterface

### DIFF
--- a/contrib/kittens/test/test_001_gemm_fp16_lds_1buf.mlir
+++ b/contrib/kittens/test/test_001_gemm_fp16_lds_1buf.mlir
@@ -22,7 +22,7 @@
 !future_global_read = !aster_utils.struct<value: !aster_utils.any, token: !amdgcn.read_token<flat>>
 !index_pair = !aster_utils.struct<i: index, j: index>
 
-amdgcn.module @kittens_gemm_16x16xK_lds_1buf target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @kittens_gemm_16x16xK_lds_1buf target = #amdgcn.target<gfx942> {
   // From compute_16x16_f16.mlir (AGPR)
   func.func private @zero_C() -> !rt_C_f32
   func.func private @mfma_f32_16x16x16_f16(!rt_A_f16, !rt_B_f16, !rt_C_f32) -> !rt_C_f32

--- a/contrib/kittens/test/test_002_gemm_fp16_lds_2buf.mlir
+++ b/contrib/kittens/test/test_002_gemm_fp16_lds_2buf.mlir
@@ -22,7 +22,7 @@
 !future_global_read = !aster_utils.struct<value: !aster_utils.any, token: !amdgcn.read_token<flat>>
 !index_pair = !aster_utils.struct<i: index, j: index>
 
-amdgcn.module @kittens_gemm_16x16xK_lds_2buf target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @kittens_gemm_16x16xK_lds_2buf target = #amdgcn.target<gfx942> {
   // From compute_16x16_f16.mlir (AGPR)
   func.func private @zero_C() -> !rt_C_f32
   func.func private @mfma_f32_16x16x16_f16(!rt_A_f16, !rt_B_f16, !rt_C_f32) -> !rt_C_f32

--- a/contrib/kittens/test/test_003_gemm_fp16_lds_3buf.mlir
+++ b/contrib/kittens/test/test_003_gemm_fp16_lds_3buf.mlir
@@ -22,7 +22,7 @@
 !future_global_read = !aster_utils.struct<value: !aster_utils.any, token: !amdgcn.read_token<flat>>
 !index_pair = !aster_utils.struct<i: index, j: index>
 
-amdgcn.module @kittens_gemm_16x16xK_lds_3buf target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @kittens_gemm_16x16xK_lds_3buf target = #amdgcn.target<gfx942> {
   // From compute_16x16_f16.mlir (AGPR)
   func.func private @zero_C() -> !rt_C_f32
   func.func private @mfma_f32_16x16x16_f16(!rt_A_f16, !rt_B_f16, !rt_C_f32) -> !rt_C_f32

--- a/contrib/kittens/test/test_004_gemm_fp16_2wave_lds.mlir
+++ b/contrib/kittens/test/test_004_gemm_fp16_2wave_lds.mlir
@@ -27,7 +27,7 @@
 !future_global_read = !aster_utils.struct<value: !aster_utils.any, token: !amdgcn.read_token<flat>>
 !index_pair = !aster_utils.struct<i: index, j: index>
 
-amdgcn.module @kittens_gemm_2wave_lds target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @kittens_gemm_2wave_lds target = #amdgcn.target<gfx942> {
   // From mlir_kernels/library/common/indexing.mlir
   func.func private @wave_id() -> index
 

--- a/contrib/kittens/test/test_005_gemm_fp16_lds_pipelined.mlir
+++ b/contrib/kittens/test/test_005_gemm_fp16_lds_pipelined.mlir
@@ -31,7 +31,7 @@
 !future_global_read = !aster_utils.struct<value: !aster_utils.any, token: !amdgcn.read_token<flat>>
 !index_pair = !aster_utils.struct<i: index, j: index>
 
-amdgcn.module @kittens_gemm_16x16xK_lds_pipelined target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @kittens_gemm_16x16xK_lds_pipelined target = #amdgcn.target<gfx942> {
   // From compute_16x16_f16.mlir (AGPR)
   func.func private @zero_C() -> !rt_C_f32
   func.func private @mfma_f32_16x16x16_f16(!rt_A_f16, !rt_B_f16, !rt_C_f32) -> !rt_C_f32

--- a/contrib/kittens/test/test_006_gemm_fp16_multitile_lds_pipelined.mlir
+++ b/contrib/kittens/test/test_006_gemm_fp16_multitile_lds_pipelined.mlir
@@ -34,7 +34,7 @@
 !future_global_read = !aster_utils.struct<value: !aster_utils.any, token: !amdgcn.read_token<flat>>
 !index_pair = !aster_utils.struct<i: index, j: index>
 
-amdgcn.module @kittens_gemm_multitile_lds_pipelined target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @kittens_gemm_multitile_lds_pipelined target = #amdgcn.target<gfx942> {
   // From compute_16x16_f16.mlir (AGPR)
   func.func private @zero_C() -> !rt_C_f32
   func.func private @mfma_f32_16x16x16_f16(!rt_A_f16, !rt_B_f16, !rt_C_f32) -> !rt_C_f32

--- a/contrib/kittens/test/test_007_gemm_fp16_4wave_lds_pipelined.mlir
+++ b/contrib/kittens/test/test_007_gemm_fp16_4wave_lds_pipelined.mlir
@@ -28,7 +28,7 @@
 !future_global_read = !aster_utils.struct<value: !aster_utils.any, token: !amdgcn.read_token<flat>>
 !index_pair = !aster_utils.struct<i: index, j: index>
 
-amdgcn.module @kittens_gemm_4wave_lds_pipelined target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @kittens_gemm_4wave_lds_pipelined target = #amdgcn.target<gfx942> {
   func.func private @wave_id() -> index
 
   // From compute_16x16_f16.mlir (AGPR)

--- a/contrib/kittens/test/test_100_gemm_python_1buf.py
+++ b/contrib/kittens/test/test_100_gemm_python_1buf.py
@@ -57,7 +57,7 @@ def _build_gemm_1buf(k, stride_a, stride_b):
     GLOBAL_STORE_TILE_C = Layout((4, 16, 4), (4 * stride_c, 4, stride_c))
     GLOBAL_STORE_SUB_TILE_C = Layout(1, 0)
 
-    b = KernelBuilder("gemm_1buf_mod", "gemm_1buf", target=MCPU, isa="cdna3")
+    b = KernelBuilder("gemm_1buf_mod", "gemm_1buf", target=MCPU)
     b.add_ptr_arg(AccessKind.ReadOnly)  # A
     b.add_ptr_arg(AccessKind.ReadOnly)  # B
     b.add_ptr_arg(AccessKind.WriteOnly)  # C
@@ -77,16 +77,28 @@ def _build_gemm_1buf(k, stride_a, stride_b):
     def _(k_iv, acc):
         tile_off = b.affine_apply(d0 * 64, [k_iv])
 
-        [(a_data, a_tok)] = b.load_multi_tile_from_global(a_ptr, tile_off, GLOBAL_LOAD_TILE_A, GLOBAL_LOAD_SUB_TILE_A, b.global_load_dwordx4)
-        [(b_data, b_tok)] = b.load_multi_tile_from_global(b_ptr, tile_off, GLOBAL_LOAD_TILE_B, GLOBAL_LOAD_SUB_TILE_B, b.global_load_dwordx4)
+        [(a_data, a_tok)] = b.load_multi_tile_from_global(
+            a_ptr, tile_off, GLOBAL_LOAD_TILE_A, GLOBAL_LOAD_SUB_TILE_A, b.global_load_dwordx4
+        )
+        [(b_data, b_tok)] = b.load_multi_tile_from_global(
+            b_ptr, tile_off, GLOBAL_LOAD_TILE_B, GLOBAL_LOAD_SUB_TILE_B, b.global_load_dwordx4
+        )
         b.wait_deps(a_tok, b_tok)
 
-        a_wtoks = b.write_multi_tile_to_lds(a_data, lds_a, LDS_WRITE_TILE_A, LDS_SWIZZLE, LDS_WRITE_SUB_TILE_A, b.ds_write_b64)
-        b_wtoks = b.write_multi_tile_to_lds(b_data, lds_b, LDS_WRITE_TILE_B, LDS_SWIZZLE, LDS_WRITE_SUB_TILE_B, b.ds_write_b64)
+        a_wtoks = b.write_multi_tile_to_lds(
+            a_data, lds_a, LDS_WRITE_TILE_A, LDS_SWIZZLE, LDS_WRITE_SUB_TILE_A, b.ds_write_b64
+        )
+        b_wtoks = b.write_multi_tile_to_lds(
+            b_data, lds_b, LDS_WRITE_TILE_B, LDS_SWIZZLE, LDS_WRITE_SUB_TILE_B, b.ds_write_b64
+        )
         b.wait_deps(*a_wtoks, *b_wtoks)
 
-        a_frags = b.read_multi_fragment_from_lds(lds_a, LDS_READ_TILE_A, LDS_SWIZZLE, LDS_READ_SUB_TILE_A, b.ds_read_b64)
-        b_frags = b.read_multi_fragment_from_lds(lds_b, LDS_READ_TILE_B, LDS_SWIZZLE, LDS_READ_SUB_TILE_B, b.ds_read_b64)
+        a_frags = b.read_multi_fragment_from_lds(
+            lds_a, LDS_READ_TILE_A, LDS_SWIZZLE, LDS_READ_SUB_TILE_A, b.ds_read_b64
+        )
+        b_frags = b.read_multi_fragment_from_lds(
+            lds_b, LDS_READ_TILE_B, LDS_SWIZZLE, LDS_READ_SUB_TILE_B, b.ds_read_b64
+        )
 
         for (a_d, a_t), (b_d, b_t) in zip(a_frags, b_frags):
             b.wait_deps(a_t, b_t)

--- a/contrib/kittens/test/test_101_gemm_python_pipelined.py
+++ b/contrib/kittens/test/test_101_gemm_python_pipelined.py
@@ -60,7 +60,7 @@ def _build_gemm_pipelined(k, stride_ab):
     GLOBAL_STORE_TILE_C = Layout((4, 16, 4), (4 * stride_c, 4, stride_c))
     GLOBAL_STORE_SUB_TILE_C = Layout(1, 0)
 
-    b = KernelBuilder("gemm_pipe_mod", "gemm_pipelined", target=MCPU, isa="cdna3")
+    b = KernelBuilder("gemm_pipe_mod", "gemm_pipelined", target=MCPU)
     b.add_ptr_arg(AccessKind.ReadOnly)
     b.add_ptr_arg(AccessKind.ReadOnly)
     b.add_ptr_arg(AccessKind.WriteOnly)
@@ -88,13 +88,21 @@ def _build_gemm_pipelined(k, stride_ab):
 
         with b.stage(STAGE_WRITE):
             b.wait_deps(a_tok, b_tok)
-            a_wtoks = b.write_multi_tile_to_lds(a_data, lds_a, LDS_WRITE_TILE_A, LDS_SWIZZLE, LDS_WRITE_SUB_TILE_A, b.ds_write_b64)
-            b_wtoks = b.write_multi_tile_to_lds(b_data, lds_b, LDS_WRITE_TILE_B, LDS_SWIZZLE, LDS_WRITE_SUB_TILE_B, b.ds_write_b64)
+            a_wtoks = b.write_multi_tile_to_lds(
+                a_data, lds_a, LDS_WRITE_TILE_A, LDS_SWIZZLE, LDS_WRITE_SUB_TILE_A, b.ds_write_b64
+            )
+            b_wtoks = b.write_multi_tile_to_lds(
+                b_data, lds_b, LDS_WRITE_TILE_B, LDS_SWIZZLE, LDS_WRITE_SUB_TILE_B, b.ds_write_b64
+            )
 
         with b.stage(STAGE_READ):
             b.wait_deps(*a_wtoks, *b_wtoks)
-            a_frags = b.read_multi_fragment_from_lds(lds_a, LDS_READ_TILE_A, LDS_SWIZZLE, LDS_READ_SUB_TILE_A, b.ds_read_b64)
-            b_frags = b.read_multi_fragment_from_lds(lds_b, LDS_READ_TILE_B, LDS_SWIZZLE, LDS_READ_SUB_TILE_B, b.ds_read_b64)
+            a_frags = b.read_multi_fragment_from_lds(
+                lds_a, LDS_READ_TILE_A, LDS_SWIZZLE, LDS_READ_SUB_TILE_A, b.ds_read_b64
+            )
+            b_frags = b.read_multi_fragment_from_lds(
+                lds_b, LDS_READ_TILE_B, LDS_SWIZZLE, LDS_READ_SUB_TILE_B, b.ds_read_b64
+            )
 
         with b.stage(STAGE_COMPUTE):
             for (a_d, a_t), (b_d, b_t) in zip(a_frags, b_frags):

--- a/contrib/kittens/test/test_102_gemm_python_multitile.py
+++ b/contrib/kittens/test/test_102_gemm_python_multitile.py
@@ -210,7 +210,7 @@ def _build_multitile_gemm(
 
     d0, d1 = ir.AffineExpr.get_dim(0), ir.AffineExpr.get_dim(1)
 
-    b = KernelBuilder("gemm_mod", cfg.kernel_name, target=mapping.mcpu, isa=mapping.isa)
+    b = KernelBuilder("gemm_mod", cfg.kernel_name, target=mapping.mcpu)
     b.set_block_dims(mapping.num_threads)
     b.set_grid_dims(mapping.num_workgroups)
     b.add_ptr_arg(AccessKind.ReadOnly)

--- a/contrib/kittens/test/test_102_gemm_python_multitile_cdna4.py
+++ b/contrib/kittens/test/test_102_gemm_python_multitile_cdna4.py
@@ -177,7 +177,7 @@ def _build_cdna4_gemm(cfg: "Cdna4GemmInstance") -> ir.Module:
 
     d0, d1 = ir.AffineExpr.get_dim(0), ir.AffineExpr.get_dim(1)
 
-    b = KernelBuilder("gemm_cdna4_mod", cfg.kernel_name, target=mapping.mcpu, isa=mapping.isa)
+    b = KernelBuilder("gemm_cdna4_mod", cfg.kernel_name, target=mapping.mcpu)
     b.set_block_dims(mapping.num_threads)
     b.set_grid_dims(mapping.num_workgroups)
     b.add_ptr_arg(AccessKind.ReadOnly)

--- a/contrib/kittens/test/test_perf_001_gemm_fp16_direct_ab.mlir
+++ b/contrib/kittens/test/test_perf_001_gemm_fp16_direct_ab.mlir
@@ -30,7 +30,7 @@
 !vals_b_buf = memref<?x!rt_B_f16>
 !c_buf = memref<?x!rt_C_f32>
 
-amdgcn.module @kittens_gemm_f16_direct_ab target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @kittens_gemm_f16_direct_ab target = #amdgcn.target<gfx942> {
   // Library functions
   func.func private @linear_block_id() -> index
   func.func private @wave_id() -> index

--- a/contrib/kittens/test/test_perf_001_gemm_fp16_direct_b.mlir
+++ b/contrib/kittens/test/test_perf_001_gemm_fp16_direct_b.mlir
@@ -29,7 +29,7 @@
 !vals_b_buf = memref<?x!rt_B_f16>
 !c_buf = memref<?x!rt_C_f32>
 
-amdgcn.module @kittens_gemm_f16_direct_b target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @kittens_gemm_f16_direct_b target = #amdgcn.target<gfx942> {
   // Library functions
   func.func private @linear_block_id() -> index
   func.func private @wave_id() -> index

--- a/contrib/kittens/test/test_perf_001_gemm_fp16_weak_scaled.mlir
+++ b/contrib/kittens/test/test_perf_001_gemm_fp16_weak_scaled.mlir
@@ -29,7 +29,7 @@
 !vals_b_buf = memref<?x!rt_B_f16>
 !c_buf = memref<?x!rt_C_f32>
 
-amdgcn.module @kittens_gemm_f16_weak_scaled target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @kittens_gemm_f16_weak_scaled target = #amdgcn.target<gfx942> {
   // Library functions (external, provided by preload library)
   func.func private @wave_id() -> index
   // From compute_16x16_f16.mlir (AGPR MFMA and fire-and-forget C tile store)

--- a/contrib/mlir-air/test/linalg-to-amdgcn.mlir
+++ b/contrib/mlir-air/test/linalg-to-amdgcn.mlir
@@ -106,7 +106,7 @@ module attributes {transform.with_named_sequence} {
     func.func private @fill_f16_16x32(%val: f16, %lds_dst: index) { return }
   }
 
-  amdgcn.module @matmul_mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+  amdgcn.module @matmul_mod target = #amdgcn.target<gfx942> {
     func.func @matmul_f16_32x32(
         %A: memref<32x32xf16, #amdgcn.addr_space<global, read_write>>,
         %B: memref<32x32xf16, #amdgcn.addr_space<global, read_write>>,

--- a/demo/add_10.mlir
+++ b/demo/add_10.mlir
@@ -1,5 +1,5 @@
 module {
-  amdgcn.module @add_10_module target = <gfx942> isa = <cdna3> {
+  amdgcn.module @add_10_module target = <gfx942> {
     kernel @kernel {
       %0 = alloca : !amdgcn.vgpr<10>
       %1 = alloca : !amdgcn.vgpr<11>

--- a/demo/generate_add_10.py
+++ b/demo/generate_add_10.py
@@ -9,7 +9,7 @@ from aster.dialects.kernel_builder import KernelBuilder
 
 def build_add_10_module(ctx: ir.Context, num_add_instructions: int) -> ir.Module:
     """Build the add_10 kernel module programmatically."""
-    b = KernelBuilder("add_10_module", "kernel", target="gfx942", isa="cdna3")
+    b = KernelBuilder("add_10_module", "kernel", target="gfx942")
 
     # Allocate VGPRs
     res = b.alloca_vgpr()

--- a/demo/generate_mfma_10.py
+++ b/demo/generate_mfma_10.py
@@ -9,7 +9,7 @@ from aster.dialects.kernel_builder import KernelBuilder
 
 def build_mfma_10_module(ctx: ir.Context, num_mfma_instructions: int) -> ir.Module:
     """Build the mfma_10 kernel module programmatically."""
-    b = KernelBuilder("mfma_10_module", "kernel", target="gfx942", isa="cdna3")
+    b = KernelBuilder("mfma_10_module", "kernel", target="gfx942")
 
     for _ in range(num_mfma_instructions):
         a = b.alloc_vgprx2()

--- a/examples/01_hello_asm/kernel.mlir
+++ b/examples/01_hello_asm/kernel.mlir
@@ -11,7 +11,7 @@
 //   s_trap 2 - hardware trap (GPU abort)
 
 module {
-  amdgcn.module @hello target = <gfx942> isa = <cdna3> {
+  amdgcn.module @hello target = <gfx942> {
     kernel @kernel {
     ^entry:
       %v0 = alloca : !amdgcn.vgpr<0>

--- a/examples/02_nop_insertion/kernel.mlir
+++ b/examples/02_nop_insertion/kernel.mlir
@@ -5,7 +5,7 @@
 // Each thread stores its thread ID to output[tid], then overwrites v0.
 
 module {
-  amdgcn.module @nop_demo target = <gfx942> isa = <cdna3> {
+  amdgcn.module @nop_demo target = <gfx942> {
     kernel @kernel arguments <[
       #amdgcn.buffer_arg<address_space = generic, access = write_only>
     ]> attributes {normal_forms = [#amdgcn.all_registers_allocated]} {

--- a/examples/03_vector_add/kernel.mlir
+++ b/examples/03_vector_add/kernel.mlir
@@ -14,7 +14,7 @@
 //   v3     = b[tid]
 
 module {
-  amdgcn.module @vadd target = <gfx942> isa = <cdna3> {
+  amdgcn.module @vadd target = <gfx942> {
 
     // Reusable: load three buffer pointers from kernarg segment.
     func.func private @load_3_ptrs(%kernarg: !amdgcn.sgpr<[0 : 2]>)

--- a/examples/04_regalloc/kernel.mlir
+++ b/examples/04_regalloc/kernel.mlir
@@ -15,7 +15,7 @@
 // Pre-allocated registers are treated as constraints: the allocator
 // assigns virtual registers to physical slots that don't conflict.
 
-amdgcn.module @regalloc target = <gfx942> isa = <cdna3> {
+amdgcn.module @regalloc target = <gfx942> {
   amdgcn.kernel @kernel arguments <[
       #amdgcn.buffer_arg<address_space = generic, access = read_only>,
       #amdgcn.buffer_arg<address_space = generic, access = write_only>

--- a/examples/05_python/run.py
+++ b/examples/05_python/run.py
@@ -33,7 +33,7 @@ opts = parse_args()
 
 def build_add42():
     """Out[tid] = in[tid] + 42 -- same as 04_regalloc/kernel.mlir."""
-    b = KernelBuilder("add42", KERNEL, target="gfx942", isa="cdna3")
+    b = KernelBuilder("add42", KERNEL, target="gfx942")
 
     b.add_ptr_arg(AccessKind.ReadOnly)  # in
     b.add_ptr_arg(AccessKind.WriteOnly)  # out

--- a/include/aster/Dialect/AMDGCN/IR/AMDGCN.td
+++ b/include/aster/Dialect/AMDGCN/IR/AMDGCN.td
@@ -20,6 +20,7 @@ include "aster/Dialect/AMDGCN/IR/AMDGCNAttrs.td"
 include "aster/Dialect/AMDGCN/IR/AMDGCNEnumAttrs.td"
 include "aster/Dialect/AMDGCN/IR/AMDGCNModifiers.td"
 include "aster/Dialect/AMDGCN/IR/AMDGCNTypes.td"
+include "aster/Interfaces/TargetAttr.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/IR/Constraints.td"
 
@@ -184,7 +185,8 @@ def AMDGCNTargets
   let cppNamespace = "::mlir::aster::amdgcn";
 }
 
-def AMDGCNTargetAttr : AMDGCN_EnumAttr<"Target", "target", AMDGCNTargets>;
+def AMDGCNTargetAttr : AMDGCN_EnumAttr<"Target", "target", AMDGCNTargets,
+    [DeclareAttrInterfaceMethods<TargetAttrInterface>]>;
 
 //===----------------------------------------------------------------------===//
 // Instruction properties definitions

--- a/include/aster/Dialect/AMDGCN/IR/AMDGCNAttrs.h
+++ b/include/aster/Dialect/AMDGCN/IR/AMDGCNAttrs.h
@@ -24,6 +24,7 @@
 #include "aster/Dialect/NormalForm/IR/NormalFormInterfaces.h"
 #include "aster/Interfaces/MemorySpaceConstraints.h"
 #include "aster/Interfaces/SchedInterfaces.h"
+#include "aster/Interfaces/TargetAttr.h"
 #include "mlir/Dialect/Ptr/IR/MemorySpaceInterfaces.h"
 #include "mlir/IR/Attributes.h"
 

--- a/include/aster/Dialect/AMDGCN/IR/AMDGCNOps.td
+++ b/include/aster/Dialect/AMDGCN/IR/AMDGCNOps.td
@@ -535,12 +535,12 @@ def AMDGCN_ModuleOp : AMDGCN_Op<"module", [
   let description = [{
     An AMDGCN module.
   }];
-  let arguments = (ins AMDGCNTargetAttr:$target, IsaVersionAttr:$isa_version,
+  let arguments = (ins AMDGCNTargetAttr:$target,
       SymbolNameAttr:$sym_name, OptionalAttr<StrAttr>:$sym_visibility,
       OptionalNormalFormAttrArray:$normal_forms);
   let regions = (region SizedRegion<1>:$body_region);
   let assemblyFormat = [{
-    $sym_name `target` `=` $target `isa` `=` $isa_version
+    $sym_name `target` `=` $target
     attr-dict-with-keyword $body_region
   }];
   let hasRegionVerifier = 1;

--- a/include/aster/Interfaces/CMakeLists.txt
+++ b/include/aster/Interfaces/CMakeLists.txt
@@ -66,3 +66,8 @@ set(LLVM_TARGET_DEFINITIONS SchedInterfaces.td)
 mlir_tablegen(SchedInterfaces.h.inc -gen-attr-interface-decls)
 mlir_tablegen(SchedInterfaces.cpp.inc -gen-attr-interface-defs)
 add_public_tablegen_target(SchedInterfacesIncGen)
+
+set(LLVM_TARGET_DEFINITIONS TargetAttr.td)
+mlir_tablegen(TargetAttr.h.inc -gen-attr-interface-decls)
+mlir_tablegen(TargetAttr.cpp.inc -gen-attr-interface-defs)
+add_public_tablegen_target(TargetAttrIncGen)

--- a/include/aster/Interfaces/TargetAttr.h
+++ b/include/aster/Interfaces/TargetAttr.h
@@ -1,0 +1,51 @@
+//===- TargetAttr.h - Target attribute interface ----------------*- C++ -*-===//
+//
+// Copyright 2025 The ASTER Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the TargetAttr attribute interface and the Target and
+// TargetFamily typed enum types.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ASTER_INTERFACES_TARGETATTR_H
+#define ASTER_INTERFACES_TARGETATTR_H
+
+#include "aster/Support/EnumUtils.h"
+#include "mlir/IR/Attributes.h"
+
+namespace mlir::aster {
+/// Identifies a specific compilation target.
+struct TargetArch : TypedEnum {
+  using TypedEnum::TypedEnum;
+  using TypedEnum::operator=;
+};
+
+/// Identifies a family of compilation targets.
+struct TargetFamily : TypedEnum {
+  using TypedEnum::TypedEnum;
+  using TypedEnum::operator=;
+};
+
+/// Identifies a target encoding for an instruction.
+struct Encoding : TypedEnum {
+  using TypedEnum::TypedEnum;
+};
+
+/// Identifies a specific target and encoding for an instruction.
+struct EncodedArch {
+  EncodedArch(TargetFamily targetFamily, Encoding encoding)
+      : targetFamily(targetFamily), encoding(encoding) {}
+  TargetFamily targetFamily;
+  Encoding encoding;
+};
+} // namespace mlir::aster
+
+#include "aster/Interfaces/TargetAttr.h.inc"
+
+#endif // ASTER_INTERFACES_TARGETATTR_H

--- a/include/aster/Interfaces/TargetAttr.td
+++ b/include/aster/Interfaces/TargetAttr.td
@@ -1,0 +1,41 @@
+//===- TargetAttr.td - Target attribute interface ----------*- tablegen -*-===//
+//
+// Copyright 2025 The ASTER Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the TargetAttr attribute interface.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ASTER_INTERFACES_TARGETATTR_TD
+#define ASTER_INTERFACES_TARGETATTR_TD
+
+include "mlir/IR/OpBase.td"
+
+//===----------------------------------------------------------------------===//
+// TargetAttr interface
+//===----------------------------------------------------------------------===//
+
+def TargetAttrInterface : AttrInterface<"TargetAttrInterface"> {
+  let cppNamespace = "::mlir::aster";
+  let description = [{
+    Interface for attributes that identify a compilation target.
+  }];
+  let methods = [
+    InterfaceMethod<
+      "Get the specific target.",
+      "::mlir::aster::TargetArch", "getTarget"
+    >,
+    InterfaceMethod<
+      "Get the target family.",
+      "::mlir::aster::TargetFamily", "getTargetFamily"
+    >
+  ];
+}
+
+#endif // ASTER_INTERFACES_TARGETATTR_TD

--- a/include/aster/Support/EnumUtils.h
+++ b/include/aster/Support/EnumUtils.h
@@ -1,0 +1,113 @@
+//===- EnumUtils.h - Typed enum utilities -----------------------*- C++ -*-===//
+//
+// Copyright 2026 The ASTER Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file provides TypedEnum, a type-safe enum wrapper.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ASTER_SUPPORT_ENUMUTILS_H
+#define ASTER_SUPPORT_ENUMUTILS_H
+
+#include "mlir/Support/TypeID.h"
+#include <cstdint>
+#include <limits>
+#include <optional>
+#include <type_traits>
+
+namespace mlir::aster {
+namespace impl {
+template <typename EnumTy>
+inline constexpr int32_t getEnumNumBits() {
+  if constexpr (std::is_enum_v<EnumTy>) {
+    return std::numeric_limits<
+        std::make_unsigned_t<std::underlying_type_t<EnumTy>>>::digits;
+  }
+  return 0;
+}
+} // namespace impl
+
+/// Type-safe enum wrapper.
+class TypedEnum {
+public:
+  template <typename EnumTy>
+  static constexpr bool is_valid_enum_v = impl::getEnumNumBits<EnumTy>();
+
+  TypedEnum() = default;
+  TypedEnum(TypedEnum &&) = default;
+  TypedEnum(const TypedEnum &) = default;
+  TypedEnum &operator=(TypedEnum &&other) {
+    value = std::move(other.value);
+    typeID = std::move(other.typeID);
+    return *this;
+  }
+  TypedEnum &operator=(const TypedEnum &other) {
+    value = other.value;
+    typeID = other.typeID;
+    return *this;
+  }
+  template <typename EnumTy, std::enable_if_t<is_valid_enum_v<EnumTy>, int> = 0>
+  TypedEnum &operator=(EnumTy value) {
+    this->value = static_cast<int64_t>(value);
+    this->typeID = mlir::TypeID::get<EnumTy>();
+    return *this;
+  }
+
+  template <typename EnumTy, std::enable_if_t<is_valid_enum_v<EnumTy>, int> = 0>
+  static bool classof(const TypedEnum &e) {
+    return e.typeID == mlir::TypeID::get<EnumTy>();
+  }
+
+  /// Create a TypedEnum from a specific enum value.
+  template <typename EnumTy, std::enable_if_t<is_valid_enum_v<EnumTy>, int> = 0>
+  static TypedEnum get(EnumTy value) {
+    return TypedEnum(static_cast<int64_t>(value), mlir::TypeID::get<EnumTy>());
+  }
+
+  bool operator==(const TypedEnum &other) const {
+    return typeID == other.typeID && value == other.value;
+  }
+  bool operator!=(const TypedEnum &other) const { return !(*this == other); }
+
+  /// Compares this enum against using three-way comparison semantics. Returns
+  /// std::nullopt if the enums are of different types.
+  std::optional<int> compare(const TypedEnum &other) const {
+    if (typeID != other.typeID)
+      return std::nullopt;
+    if (value < other.value)
+      return -1;
+    if (value > other.value)
+      return 1;
+    return 0;
+  }
+
+  /// Returns the enum value as an integer.
+  int64_t getValue() const { return value; }
+
+  /// Returns the TypeID of the enum type.
+  mlir::TypeID getTypeID() const { return typeID; }
+
+  /// Try to get the enum value as a specific enum type. Returns std::nullopt if
+  /// the type does not match.
+  template <typename EnumTy, std::enable_if_t<is_valid_enum_v<EnumTy>, int> = 0>
+  std::optional<EnumTy> getValueAs() const {
+    if (typeID != mlir::TypeID::get<EnumTy>())
+      return std::nullopt;
+    return static_cast<EnumTy>(value);
+  }
+
+protected:
+  TypedEnum(int64_t value, mlir::TypeID typeID)
+      : value(value), typeID(typeID) {}
+  int64_t value = 0;
+  mlir::TypeID typeID;
+};
+} // namespace mlir::aster
+
+#endif // ASTER_SUPPORT_ENUMUTILS_H

--- a/lib/Dialect/AMDGCN/IR/AMDGCNAttrs.cpp
+++ b/lib/Dialect/AMDGCN/IR/AMDGCNAttrs.cpp
@@ -15,6 +15,7 @@
 #include "aster/Dialect/AMDGCN/IR/Utils.h"
 #include "aster/Dialect/LSIR/IR/LSIROps.h"
 #include "aster/Interfaces/RegisterType.h"
+#include "aster/Interfaces/TargetAttr.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/DialectImplementation.h"
@@ -419,4 +420,35 @@ AllInlinedAttr::verifyOperation(function_ref<InFlightDiagnostic()> emitError,
                        << cast<func::CallOp>(op).getCallee() << "'";
 
   return success();
+}
+
+//===----------------------------------------------------------------------===//
+// TargetAttr - TargetAttrInterface implementation
+//===----------------------------------------------------------------------===//
+
+mlir::aster::TargetArch TargetAttr::getTarget() const {
+  mlir::aster::TargetArch result;
+  result = getValue();
+  return result;
+}
+
+mlir::aster::TargetFamily TargetAttr::getTargetFamily() const {
+  ISAVersion isa;
+  switch (getValue()) {
+  case amdgcn::Target::GFX940:
+  case amdgcn::Target::GFX942:
+    isa = ISAVersion::CDNA3;
+    break;
+  case amdgcn::Target::GFX950:
+    isa = ISAVersion::CDNA4;
+    break;
+  case amdgcn::Target::GFX1201:
+    isa = ISAVersion::RDNA4;
+    break;
+  case amdgcn::Target::Invalid:
+    llvm_unreachable("invalid target");
+  }
+  mlir::aster::TargetFamily result;
+  result = isa;
+  return result;
 }

--- a/lib/Interfaces/CMakeLists.txt
+++ b/lib/Interfaces/CMakeLists.txt
@@ -10,6 +10,7 @@ set(LLVM_OPTIONAL_SOURCES
   RegisterType.cpp
   ResourceInterfaces.cpp
   SchedInterfaces.cpp
+  TargetAttr.cpp
   UpstreamModelsImpl.cpp
   VerifierAttr.cpp
 )
@@ -26,6 +27,7 @@ add_mlir_library(AsterInterfaces
   RegisterType.cpp
   ResourceInterfaces.cpp
   SchedInterfaces.cpp
+  TargetAttr.cpp
   VerifierAttr.cpp
 
   DEPENDS
@@ -41,6 +43,7 @@ add_mlir_library(AsterInterfaces
   RegisterTypeIncGen
   ResourceInterfacesIncGen
   SchedInterfacesIncGen
+  TargetAttrIncGen
   VerifierAttrIncGen
 
   LINK_LIBS PUBLIC

--- a/lib/Interfaces/TargetAttr.cpp
+++ b/lib/Interfaces/TargetAttr.cpp
@@ -1,0 +1,20 @@
+//===- TargetAttr.cpp - Target attribute interface ----------------------===//
+//
+// Copyright 2025 The ASTER Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the TargetAttr attribute interface.
+//
+//===----------------------------------------------------------------------===//
+
+#include "aster/Interfaces/TargetAttr.h"
+
+using namespace mlir;
+using namespace mlir::aster;
+
+#include "aster/Interfaces/TargetAttr.cpp.inc"

--- a/mlir_kernels/nanobenchmarks/nanobench_global_load.mlir
+++ b/mlir_kernels/nanobenchmarks/nanobench_global_load.mlir
@@ -15,7 +15,7 @@
 //   - wave_size: number of threads per wave
 !transfer_descriptor_2d = !aster_utils.struct<num_rows: index, transfer_size: index, wave_size: index>
 
-amdgcn.module @nanobench_module target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @nanobench_module target = #amdgcn.target<gfx942> {
   // From indexing.mlir
   func.func private @wave_id() -> index
   func.func private @wave_count() -> index

--- a/mlir_kernels/nanobenchmarks/nanobench_lds_read_mfma_A_wave_16x16_f16.mlir
+++ b/mlir_kernels/nanobenchmarks/nanobench_lds_read_mfma_A_wave_16x16_f16.mlir
@@ -5,7 +5,7 @@
 !vx2 = !amdgcn.vgpr<[? + 2]>
 !lds_position_descriptor_2d = !aster_utils.struct<lds_base: index, m_pos: index, n_pos: index, lds_stride_in_bytes: index, elt_size: index>
 
-amdgcn.module @nanobench_module target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @nanobench_module target = #amdgcn.target<gfx942> {
   // From copies.mlir
   func.func private @lds_read_A_wave_16x16_f16_fragment_wait(
     !lds_position_descriptor_2d, i1) -> !vx2

--- a/mlir_kernels/nanobenchmarks/nanobench_lds_read_swizzled_wave_16x16_f16.mlir
+++ b/mlir_kernels/nanobenchmarks/nanobench_lds_read_swizzled_wave_16x16_f16.mlir
@@ -5,7 +5,7 @@
 !vx2 = !amdgcn.vgpr<[? + 2]>
 !lds_position_descriptor_2d = !aster_utils.struct<lds_base: index, m_pos: index, n_pos: index, lds_stride_in_bytes: index, elt_size: index>
 
-amdgcn.module @nanobench_module target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @nanobench_module target = #amdgcn.target<gfx942> {
   // From copies.mlir
   func.func private @lds_read_swizzled_wave_16x16_f16_fragment_wait(
     !lds_position_descriptor_2d) -> !vx2

--- a/mlir_kernels/nanobenchmarks/nanobench_lds_read_write_overlaps.mlir
+++ b/mlir_kernels/nanobenchmarks/nanobench_lds_read_write_overlaps.mlir
@@ -19,7 +19,7 @@
 !future_lds_read_any = !aster_utils.struct<value: !aster_utils.any, token: !amdgcn.read_token<shared>>
 !future_global_read_descriptor_1d = !aster_utils.struct<memref: memref<?x!future_global_read_any>, offset: index>
 
-amdgcn.module @nanobench_module target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @nanobench_module target = #amdgcn.target<gfx942> {
   //===--------------------------------------------------------------------===//
   // Library function declarations
   //===--------------------------------------------------------------------===//

--- a/mlir_kernels/nanobenchmarks/nanobench_lds_write_multi_tile.mlir
+++ b/mlir_kernels/nanobenchmarks/nanobench_lds_write_multi_tile.mlir
@@ -6,7 +6,7 @@
 !lds_position_descriptor_2level_2d = !aster_utils.struct<lds_base: index, mm_pos: index, nn_pos: index, lds_stride_in_bytes: index, elt_size: index>
 !return_value_descriptor_1d_vx2 = !aster_utils.struct<memref: memref<?x!vx2>, offset: index>
 
-amdgcn.module @nanobench_module target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @nanobench_module target = #amdgcn.target<gfx942> {
   // From multi-tile-copies.mlir
   func.func private @lds_write_wave_multi_tile_256_f16_via_dwordx2_wait(
     !lds_position_descriptor_2level_2d, index, index, !return_value_descriptor_1d_vx2)

--- a/mlir_kernels/test/unit/test_global_load_ds_write.mlir
+++ b/mlir_kernels/test/unit/test_global_load_ds_write.mlir
@@ -11,7 +11,7 @@
 !tensor_position_descriptor_2level_2d = !aster_utils.struct<ptr: !sx2, m_pos: index, n_pos: index, global_stride_in_bytes: index, mm_pos: index, nn_pos: index, elt_size: index>
 !transfer_descriptor_2d = !aster_utils.struct<num_rows: index, transfer_size: index, wave_size: index>
 
-amdgcn.module @test_global_load_ds_write target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @test_global_load_ds_write target = #amdgcn.target<gfx942> {
   // From register-init.mlir
   func.func private @alloc_vgprx2() -> !vx2
   // From indexing.mlir

--- a/mlir_kernels/test/unit/test_global_load_multi_tile.mlir
+++ b/mlir_kernels/test/unit/test_global_load_multi_tile.mlir
@@ -26,7 +26,7 @@
 //   - NT_I, NT_J: multi-tile factors (process NT_I x NT_J tiles at once)
 !conditional_execution_descriptor_2d = !aster_utils.struct<k: index, cond_iter: index, NT_I: index, NT_J: index>
 
-amdgcn.module @test_copies target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @test_copies target = #amdgcn.target<gfx942> {
   // From simple-copies.mlir
   func.func private @simple_lds_to_global_wave_16x16_f16_wait(!lds_position_descriptor_2d, !tensor_position_descriptor_2d)
   // From multi-tile-copies.mlir (1D linearized memrefs)

--- a/mlir_kernels/test/unit/test_global_load_wave.mlir
+++ b/mlir_kernels/test/unit/test_global_load_wave.mlir
@@ -17,7 +17,7 @@
 //   - wave_size: number of threads per wave
 !transfer_descriptor_2d = !aster_utils.struct<num_rows: index, transfer_size: index, wave_size: index>
 
-amdgcn.module @test_copies target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @test_copies target = #amdgcn.target<gfx942> {
   //===--------------------------------------------------------------------===//
   // From copies.mlir
   func.func private @global_load_wave_128_f16_via_dword_wait(!tensor_position_descriptor_2level_2d, !transfer_descriptor_2d) -> (!vx1)

--- a/mlir_kernels/test/unit/test_global_store_wave.mlir
+++ b/mlir_kernels/test/unit/test_global_store_wave.mlir
@@ -20,7 +20,7 @@
 //   - cond_iter: condition index (execute only when cond_iter == 0)
 //   - NT_I, NT_J: multi-tile factors (process NT_I x NT_J tiles at once)
 
-amdgcn.module @test_copies target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @test_copies target = #amdgcn.target<gfx942> {
   //===--------------------------------------------------------------------===//
   // From register-init.mlir
   // From indexing.mlir

--- a/mlir_kernels/test/unit/test_global_to_lds_and_back.mlir
+++ b/mlir_kernels/test/unit/test_global_to_lds_and_back.mlir
@@ -6,7 +6,7 @@
 !tensor_position_descriptor_2d = !aster_utils.struct<ptr: !sx2, m_pos: index, n_pos: index, global_stride_in_bytes: index, elt_size: index>
 !lds_position_descriptor_2d = !aster_utils.struct<lds_base: index, m_pos: index, n_pos: index, lds_stride_in_bytes: index, elt_size: index>
 
-amdgcn.module @test_global_to_lds_and_back target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @test_global_to_lds_and_back target = #amdgcn.target<gfx942> {
   // From simple-copies.mlir
   func.func private @simple_global_to_lds_wave_16x16_f16_wait(!tensor_position_descriptor_2d, !lds_position_descriptor_2d)
   func.func private @simple_lds_to_global_wave_16x16_f16_wait(!lds_position_descriptor_2d, !tensor_position_descriptor_2d)

--- a/mlir_kernels/test/unit/test_indexing.mlir
+++ b/mlir_kernels/test/unit/test_indexing.mlir
@@ -10,7 +10,7 @@
 !index_descriptor_2level_2d = !aster_utils.struct<i: index, j: index, ii: index, jj: index, stride: index, elt_size_b: index>
 !index_descriptor_3level_2d = !aster_utils.struct<i: index, j: index, ii: index, jj: index, iii: index, jjj: index, stride: index, elt_size_b: index>
 
-amdgcn.module @test_indexing target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @test_indexing target = #amdgcn.target<gfx942> {
   // From indexing.mlir
   func.func private @lane_id() -> index
   func.func private @wave_id() -> index

--- a/mlir_kernels/test/unit/test_lds_banks.mlir
+++ b/mlir_kernels/test/unit/test_lds_banks.mlir
@@ -7,7 +7,7 @@
 !index_tuple_8 = !aster_utils.struct<b0: index, b1: index, b2: index, b3: index, b4: index, b5: index, b6: index, b7: index>
 !tensor_position_descriptor_2d = !aster_utils.struct<ptr: !sx2, m_pos: index, n_pos: index, global_stride_in_bytes: index, elt_size: index>
 
-amdgcn.module @test_indexing target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @test_indexing target = #amdgcn.target<gfx942> {
   //===--------------------------------------------------------------------===//
   // From indexing.mlir
   func.func private @tiled_matrix_offset(!index_descriptor_2level_2d) -> !v

--- a/mlir_kernels/test/unit/test_lds_read_swizzled_A_fragment.mlir
+++ b/mlir_kernels/test/unit/test_lds_read_swizzled_A_fragment.mlir
@@ -25,7 +25,7 @@
 //   - NT_I, NT_J: multi-tile factors (process NT_I x NT_J tiles at once)
 !conditional_execution_descriptor_2d = !aster_utils.struct<k: index, cond_iter: index, NT_I: index, NT_J: index>
 
-amdgcn.module @test_lds_read_swizzled_A_fragment target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @test_lds_read_swizzled_A_fragment target = #amdgcn.target<gfx942> {
   // From simple-copies.mlir
   func.func private @simple_global_to_lds_wave_16x16_f16_wait(!tensor_position_descriptor_2d, !lds_position_descriptor_2d)
   func.func private @simple_global_store_wave_16x16_f16_wait(!vx2, !tensor_position_descriptor_2d)

--- a/mlir_kernels/test/unit/test_load_and_lds_read_A_fragment.mlir
+++ b/mlir_kernels/test/unit/test_load_and_lds_read_A_fragment.mlir
@@ -9,7 +9,7 @@
 !lds_position_descriptor_2d = !aster_utils.struct<lds_base: index, m_pos: index, n_pos: index, lds_stride_in_bytes: index, elt_size: index>
 !tensor_position_descriptor_2level_2d = !aster_utils.struct<ptr: !sx2, m_pos: index, n_pos: index, global_stride_in_bytes: index, mm_pos: index, nn_pos: index, elt_size: index>
 
-amdgcn.module @test_load_and_lds_read_A_fragment target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @test_load_and_lds_read_A_fragment target = #amdgcn.target<gfx942> {
   // From copies.mlir
   func.func private @global_load_to_lds_wave_16x16_f16_wait(!tensor_position_descriptor_2level_2d, index, index)
   func.func private @lds_read_A_wave_16x16_f16_fragment_wait(!lds_position_descriptor_2d, i1) -> !vx2

--- a/mlir_kernels/test/unit/test_load_and_lds_read_A_fragment_transposed.mlir
+++ b/mlir_kernels/test/unit/test_load_and_lds_read_A_fragment_transposed.mlir
@@ -9,7 +9,7 @@
 !lds_position_descriptor_2d = !aster_utils.struct<lds_base: index, m_pos: index, n_pos: index, lds_stride_in_bytes: index, elt_size: index>
 !tensor_position_descriptor_2level_2d = !aster_utils.struct<ptr: !sx2, m_pos: index, n_pos: index, global_stride_in_bytes: index, mm_pos: index, nn_pos: index, elt_size: index>
 
-amdgcn.module @test_load_and_lds_read_A_fragment_transposed target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @test_load_and_lds_read_A_fragment_transposed target = #amdgcn.target<gfx942> {
   // From copies.mlir
   func.func private @global_load_to_lds_wave_16x16_f16_wait(!tensor_position_descriptor_2level_2d, index, index)
   func.func private @lds_read_A_wave_16x16_f16_fragment_wait(!lds_position_descriptor_2d, i1) -> !vx2

--- a/mlir_kernels/test/unit/test_loops.mlir
+++ b/mlir_kernels/test/unit/test_loops.mlir
@@ -1,6 +1,6 @@
 // Unit tests for loop lowering
 
-amdgcn.module @test_uniform_loop target = <gfx942> isa = <cdna3> {
+amdgcn.module @test_uniform_loop target = <gfx942> {
   kernel @test_uniform_loop arguments <[#amdgcn.buffer_arg<address_space = generic, access = read_only>, #amdgcn.buffer_arg<address_space = generic>]> {
     %0 = load_arg 0 : !amdgcn.sgpr<[? + 2]>
     %1 = load_arg 1 : !amdgcn.sgpr<[? + 2]>

--- a/mlir_kernels/test/unit/test_scf_pipeline.mlir
+++ b/mlir_kernels/test/unit/test_scf_pipeline.mlir
@@ -7,7 +7,7 @@
 // Stage 1: store to output[0] (no IV use)
 // Expected: output[0] = 42
 // ============================================================================
-amdgcn.module @test_two_stage_no_iv target = <gfx942> isa = <cdna3> {
+amdgcn.module @test_two_stage_no_iv target = <gfx942> {
   kernel @test_two_stage_no_iv arguments <[
     #amdgcn.buffer_arg<address_space = generic, access = read_write>
   ]> {
@@ -45,7 +45,7 @@ amdgcn.module @test_two_stage_no_iv target = <gfx942> isa = <cdna3> {
 // Stage 1: store val to output at byte offset val (no IV use)
 // Expected: output viewed as int32[8] = [0, 4, 8, 12, 16, 20, 24, 28]
 // ============================================================================
-amdgcn.module @test_two_stage_iv_s0_only target = <gfx942> isa = <cdna3> {
+amdgcn.module @test_two_stage_iv_s0_only target = <gfx942> {
   kernel @test_two_stage_iv_s0_only arguments <[
     #amdgcn.buffer_arg<address_space = generic, access = read_write>
   ]> {
@@ -84,7 +84,7 @@ amdgcn.module @test_two_stage_iv_s0_only target = <gfx942> isa = <cdna3> {
 // Tests that the kernel adjusts the IV correctly for stage 1.
 // Expected: output[i] = i * 3, i.e. [0, 3, 6, 9, 12, 15, 18, 21]
 // ============================================================================
-amdgcn.module @test_two_stage_iv_dep target = <gfx942> isa = <cdna3> {
+amdgcn.module @test_two_stage_iv_dep target = <gfx942> {
   kernel @test_two_stage_iv_dep arguments <[
     #amdgcn.buffer_arg<address_space = generic, access = read_write>
   ]> {
@@ -133,7 +133,7 @@ amdgcn.module @test_two_stage_iv_dep target = <gfx942> isa = <cdna3> {
 //
 // Stage 4 uses IV for the store offset, testing IV adjustment at depth 4.
 // ============================================================================
-amdgcn.module @test_five_stage target = <gfx942> isa = <cdna3> {
+amdgcn.module @test_five_stage target = <gfx942> {
   kernel @test_five_stage arguments <[
     #amdgcn.buffer_arg<address_space = generic, access = read_write>
   ]> {

--- a/mlir_kernels/test/unit/test_scf_pipeline_gaps.mlir
+++ b/mlir_kernels/test/unit/test_scf_pipeline_gaps.mlir
@@ -2,7 +2,7 @@
 !v   = !amdgcn.vgpr
 
 // Two-stage pipeline with gap: stages {0, 2}.
-amdgcn.module @test_gap_0_2 target = <gfx942> isa = <cdna3> {
+amdgcn.module @test_gap_0_2 target = <gfx942> {
   kernel @test_gap_0_2 arguments <[
     #amdgcn.buffer_arg<address_space = generic, access = read_write>
   ]> {
@@ -40,7 +40,7 @@ amdgcn.module @test_gap_0_2 target = <gfx942> isa = <cdna3> {
 }
 
 // Two-stage pipeline with wide gap: stages {0, 3}.
-amdgcn.module @test_gap_0_3 target = <gfx942> isa = <cdna3> {
+amdgcn.module @test_gap_0_3 target = <gfx942> {
   kernel @test_gap_0_3 arguments <[
     #amdgcn.buffer_arg<address_space = generic, access = read_write>
   ]> {
@@ -78,7 +78,7 @@ amdgcn.module @test_gap_0_3 target = <gfx942> isa = <cdna3> {
 }
 
 // Three-stage pipeline with gaps: stages {0, 2, 5}.
-amdgcn.module @test_gap_0_2_5 target = <gfx942> isa = <cdna3> {
+amdgcn.module @test_gap_0_2_5 target = <gfx942> {
   kernel @test_gap_0_2_5 arguments <[
     #amdgcn.buffer_arg<address_space = generic, access = read_write>
   ]> {
@@ -121,7 +121,7 @@ amdgcn.module @test_gap_0_2_5 target = <gfx942> isa = <cdna3> {
 }
 
 // Two-stage pipeline with gap {0, 2} and scalar iter_arg accumulator.
-amdgcn.module @test_gap_0_2_iter_args target = <gfx942> isa = <cdna3> {
+amdgcn.module @test_gap_0_2_iter_args target = <gfx942> {
   kernel @test_gap_0_2_iter_args arguments <[
     #amdgcn.buffer_arg<address_space = generic, access = read_write>
   ]> {

--- a/mlir_kernels/test/unit/test_scf_pipeline_iter_args.mlir
+++ b/mlir_kernels/test/unit/test_scf_pipeline_iter_args.mlir
@@ -6,7 +6,7 @@
 !v   = !amdgcn.vgpr
 
 // 2-stage, scalar iter_arg, no iv.
-amdgcn.module @test_iter_args_scalar_no_iv target = <gfx942> isa = <cdna3> {
+amdgcn.module @test_iter_args_scalar_no_iv target = <gfx942> {
   kernel @test_iter_args_scalar_no_iv arguments <[
     #amdgcn.buffer_arg<address_space = generic, access = read_write>
   ]> {
@@ -44,7 +44,7 @@ amdgcn.module @test_iter_args_scalar_no_iv target = <gfx942> isa = <cdna3> {
 }
 
 // 2-stage, scalar iter_arg, with iv
-amdgcn.module @test_iter_args_scalar_with_iv target = <gfx942> isa = <cdna3> {
+amdgcn.module @test_iter_args_scalar_with_iv target = <gfx942> {
   kernel @test_iter_args_scalar_with_iv arguments <[
     #amdgcn.buffer_arg<address_space = generic, access = read_write>
   ]> {
@@ -80,7 +80,7 @@ amdgcn.module @test_iter_args_scalar_with_iv target = <gfx942> isa = <cdna3> {
 }
 
 // 2-stage, VGPR iter_arg (exercises bufferization), no iv
-amdgcn.module @test_iter_args_vgpr_no_iv target = <gfx942> isa = <cdna3> {
+amdgcn.module @test_iter_args_vgpr_no_iv target = <gfx942> {
   kernel @test_iter_args_vgpr_no_iv arguments <[
     #amdgcn.buffer_arg<address_space = generic, access = read_write>
   ]> {
@@ -128,7 +128,7 @@ amdgcn.module @test_iter_args_vgpr_no_iv target = <gfx942> isa = <cdna3> {
 
 // 2-stage, VGPR iter_arg (exercises bufferization), with iv
 // Combines IV dependence, cross-stage value, VGPR iter_arg, and bufferization.
-amdgcn.module @test_iter_args_vgpr_with_iv target = <gfx942> isa = <cdna3> {
+amdgcn.module @test_iter_args_vgpr_with_iv target = <gfx942> {
   kernel @test_iter_args_vgpr_with_iv arguments <[
     #amdgcn.buffer_arg<address_space = generic, access = read_write>
   ]> {
@@ -175,7 +175,7 @@ amdgcn.module @test_iter_args_vgpr_with_iv target = <gfx942> isa = <cdna3> {
 // Stage 0: to_reg, stage 1: alloca+vop1 (unused vgpr, cross-stage lifetime),
 // stages 2-4: independent scalar work (exercises prologue/epilogue depth),
 // stage 5: accumulate constant 5 into scalar iter_arg.
-amdgcn.module @test_scf_pipeline_iter_args target = <gfx942> isa = <cdna3> {
+amdgcn.module @test_scf_pipeline_iter_args target = <gfx942> {
   kernel @test_iter_args arguments <[#amdgcn.buffer_arg<address_space = generic>]> {
     %out = load_arg 0 : !amdgcn.sgpr<[? + 2]>
     wait lgkm_cnt 0

--- a/mlir_kernels/test/unit/test_scf_pipeline_lds.mlir
+++ b/mlir_kernels/test/unit/test_scf_pipeline_lds.mlir
@@ -2,7 +2,7 @@
 !v   = !amdgcn.vgpr
 
 // Two-stage LDS pass-through (no IV dependence in LDS path).
-amdgcn.module @test_lds_passthrough target = <gfx942> isa = <cdna3> {
+amdgcn.module @test_lds_passthrough target = <gfx942> {
   kernel @test_lds_passthrough arguments <[
     #amdgcn.buffer_arg<address_space = generic, access = read_write>
   ]> attributes {shared_memory_size = 1024 : i32} {
@@ -55,7 +55,7 @@ amdgcn.module @test_lds_passthrough target = <gfx942> isa = <cdna3> {
 }
 
 // Two-stage LDS with IV-dependent data.
-amdgcn.module @test_lds_iv_dep target = <gfx942> isa = <cdna3> {
+amdgcn.module @test_lds_iv_dep target = <gfx942> {
   kernel @test_lds_iv_dep arguments <[
     #amdgcn.buffer_arg<address_space = generic, access = read_write>
   ]> attributes {shared_memory_size = 1024 : i32} {
@@ -114,7 +114,7 @@ amdgcn.module @test_lds_iv_dep target = <gfx942> isa = <cdna3> {
 // Six-stage double-LDS hop:
 //   global_load -> ds_write_A -> ds_read_A -> ds_write_B -> ds_read_B -> global_store
 // Two alloc_lds each spanning all 6 stages -> 6 buffers each -> 12 total after multibuffer prep.
-amdgcn.module @test_lds_six_stage target = <gfx942> isa = <cdna3> {
+amdgcn.module @test_lds_six_stage target = <gfx942> {
   kernel @test_lds_six_stage arguments <[
     #amdgcn.buffer_arg<address_space = generic, access = read_only>,
     #amdgcn.buffer_arg<address_space = generic, access = read_write>
@@ -196,7 +196,7 @@ amdgcn.module @test_lds_six_stage target = <gfx942> isa = <cdna3> {
 }
 
 // Two-stage LDS with accumulator iter_arg.
-amdgcn.module @test_lds_accum target = <gfx942> isa = <cdna3> {
+amdgcn.module @test_lds_accum target = <gfx942> {
   kernel @test_lds_accum arguments <[
     #amdgcn.buffer_arg<address_space = generic, access = read_write>
   ]> attributes {shared_memory_size = 1024 : i32} {

--- a/mlir_kernels/test/unit/test_store_global_C_fragment.mlir
+++ b/mlir_kernels/test/unit/test_store_global_C_fragment.mlir
@@ -8,7 +8,7 @@
 !vx4 = !amdgcn.vgpr<[? + 4]>
 !tensor_position_descriptor_2level_2d = !aster_utils.struct<ptr: !sx2, m_pos: index, n_pos: index, global_stride_in_bytes: index, mm_pos: index, nn_pos: index, elt_size: index>
 
-amdgcn.module @test_store_global_C_fragment target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @test_store_global_C_fragment target = #amdgcn.target<gfx942> {
   // From register-init.mlir
   func.func private @init_vgprx4_reg(!v) -> !vx4
   // From indexing.mlir

--- a/mlir_kernels/test/unit/test_store_global_C_fragment_transposed.mlir
+++ b/mlir_kernels/test/unit/test_store_global_C_fragment_transposed.mlir
@@ -8,7 +8,7 @@
 !vx4 = !amdgcn.vgpr<[? + 4]>
 !tensor_position_descriptor_2level_2d = !aster_utils.struct<ptr: !sx2, m_pos: index, n_pos: index, global_stride_in_bytes: index, mm_pos: index, nn_pos: index, elt_size: index>
 
-amdgcn.module @test_store_global_C_fragment_transposed target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @test_store_global_C_fragment_transposed target = #amdgcn.target<gfx942> {
   // From register-init.mlir
   func.func private @init_vgprx4_reg(!v) -> !vx4
   // From indexing.mlir

--- a/mlir_kernels/test/unit/test_struct_promotability.mlir
+++ b/mlir_kernels/test/unit/test_struct_promotability.mlir
@@ -11,7 +11,7 @@
 !future_global_read_any = !aster_utils.struct<value: !aster_utils.any, token: !amdgcn.read_token<flat>>
 
 // CHECK-LABEL: amdgcn.module @test_struct_promotability
-amdgcn.module @test_struct_promotability target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @test_struct_promotability target = #amdgcn.target<gfx942> {
   // From copies.mlir - function that returns a future
   func.func private @load_from_global_dwordx2_future(!tensor_position_descriptor_2d) -> !future_global_read_any
 

--- a/mlir_kernels/test/unit/test_struct_promotability_simple.mlir
+++ b/mlir_kernels/test/unit/test_struct_promotability_simple.mlir
@@ -8,7 +8,7 @@
 !index_pair = !aster_utils.struct<i: index, j: index>
 
 // CHECK-LABEL: amdgcn.module @test_struct_promotability_simple
-amdgcn.module @test_struct_promotability_simple target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @test_struct_promotability_simple target = #amdgcn.target<gfx942> {
   // Test kernel that stores and loads a simple struct from memref
   // SROA and Mem2Reg should eliminate the memref operations
   // CHECK-LABEL: amdgcn.kernel @test_store_load_struct

--- a/python/aster/dialects/kernel_builder.py
+++ b/python/aster/dialects/kernel_builder.py
@@ -10,7 +10,7 @@ Usage::
     ctx = ir.Context()
     ctx.allow_unregistered_dialects = True
     with ctx:
-        b = KernelBuilder("my_mod", "my_kernel", target="gfx942", isa="cdna3")
+        b = KernelBuilder("my_mod", "my_kernel", target="gfx942")
         b.add_ptr_arg(AccessKind.ReadOnly)
         b.add_ptr_arg(AccessKind.WriteOnly)
         [a_ptr, b_ptr] = b.load_args()
@@ -129,7 +129,6 @@ class KernelBuilder:
         module_name: str,
         kernel_name: str,
         target: str = "gfx942",
-        isa: str = "cdna3",
     ):
         ctx = ir.Context.current
         self._ctx = ctx
@@ -137,7 +136,6 @@ class KernelBuilder:
         self._module_name = module_name
         self._kernel_name = kernel_name
         self._target = target
-        self._isa = isa
         self._ptr_args: List[AccessKind] = []
         self._kernel_attrs = {}
 
@@ -147,10 +145,8 @@ class KernelBuilder:
         # Build amdgcn.module inside the outer module.
         outer_ip = ir.InsertionPoint(self._outer.body)
         target_attr = ir.Attribute.parse(f"#amdgcn.target<{target}>")
-        isa_attr = ir.Attribute.parse(f"#amdgcn.isa<{isa}>")
         self._amdgcn_mod = ModuleOp(
             target=target_attr,
-            isa_version=isa_attr,
             sym_name=module_name,
             loc=self._loc,
             ip=outer_ip,

--- a/python/test/integration/test_layout_copy_e2e.py
+++ b/python/test/integration/test_layout_copy_e2e.py
@@ -27,14 +27,13 @@ def _build_copy_kernel(
     swizzle=None,
     use_global=False,
     target=MCPU,
-    isa="cdna3",
 ):
     """Copy kernel: load dwordx4 at layout(+swizzle) offset, store linear.
 
     If use_global=True, uses global load/store (ptr + offset -> VGPRx2).
     Otherwise uses buffer load/store (rsrc + voffset).
     """
-    b = KernelBuilder(f"{name}_mod", name, target=target, isa=isa)
+    b = KernelBuilder(f"{name}_mod", name, target=target)
     b.add_ptr_arg(AccessKind.ReadOnly)
     b.add_ptr_arg(AccessKind.WriteOnly)
     src_ptr, dst_ptr = b.load_args()

--- a/python/test/integration/test_layout_lds_copy_e2e.py
+++ b/python/test/integration/test_layout_lds_copy_e2e.py
@@ -25,9 +25,9 @@ LDS_SIZE = N_THREADS * ELEM_BYTES
 LINEAR = Layout(sizes=N_THREADS, strides=ELEM_BYTES)
 
 
-def _build_lds_copy_kernel(name, layout, swizzle=None, target=MCPU, isa="cdna3"):
+def _build_lds_copy_kernel(name, layout, swizzle=None, target=MCPU):
     """Global load -> LDS write (swizzled) -> LDS read -> global store."""
-    b = KernelBuilder(f"{name}_mod", name, target=target, isa=isa)
+    b = KernelBuilder(f"{name}_mod", name, target=target)
     b.set_shared_memory_size(LDS_SIZE)
     b.add_ptr_arg(AccessKind.ReadOnly)
     b.add_ptr_arg(AccessKind.WriteOnly)

--- a/python/test/integration/test_layout_mfma_e2e.py
+++ b/python/test/integration/test_layout_mfma_e2e.py
@@ -29,9 +29,9 @@ MFMA_AB_LAYOUT = Layout(sizes=(4, 16), strides=(8, 32))
 MFMA_C_LAYOUT = Layout(sizes=(4, 16), strides=(16, 64))
 
 
-def _build_mfma_kernel(name, target=MCPU, isa="cdna3"):
+def _build_mfma_kernel(name, target=MCPU):
     """Single-wave MFMA 16x16x16 f16: D = A @ B^T + C."""
-    b = KernelBuilder(f"{name}_mod", name, target=target, isa=isa)
+    b = KernelBuilder(f"{name}_mod", name, target=target)
     b.add_ptr_arg(AccessKind.ReadOnly)  # A
     b.add_ptr_arg(AccessKind.ReadOnly)  # B
     b.add_ptr_arg(AccessKind.WriteOnly)  # C/D
@@ -103,9 +103,9 @@ LDS_SWIZZLE = Swizzle(bits=2, base=4, shift=6)
 LDS_B_BASE = 512  # A occupies bytes 0..511, B occupies 512..1023
 
 
-def _build_mfma_lds_kernel(name, target=MCPU, isa="cdna3"):
+def _build_mfma_lds_kernel(name, target=MCPU):
     """Coalesced global load -> swizzled LDS write -> MFMA-layout LDS read -> MFMA."""
-    b = KernelBuilder(f"{name}_mod", name, target=target, isa=isa)
+    b = KernelBuilder(f"{name}_mod", name, target=target)
     b.set_shared_memory_size(1024)  # 512 A + 512 B
     b.add_ptr_arg(AccessKind.ReadOnly)  # A
     b.add_ptr_arg(AccessKind.ReadOnly)  # B
@@ -203,7 +203,7 @@ LDS_PER_WAVE = TILE_AB_BYTES * 2  # 1024 (512 A + 512 B)
 MWG_LDS_SIZE = WAVES_PER_WG * LDS_PER_WAVE  # 6144
 
 
-def _build_mfma_multiwg_kernel(name, target=MCPU, isa="cdna3"):
+def _build_mfma_multiwg_kernel(name, target=MCPU):
     """Multi-WG multi-wave MFMA: coalesced load -> LDS relayout -> MFMA -> store.
 
     Grid: (N_WG_X, N_WG_Y, 1), Block: (THREADS_PER_WG, 1, 1).
@@ -211,7 +211,7 @@ def _build_mfma_multiwg_kernel(name, target=MCPU, isa="cdna3"):
     B is [TOTAL_N, 16] f16 row-major.  Each wave's B tile: rows [n_start:n_start+16].
     C is tiled: N_TILES_M * N_TILES_N tiles of 16x16 f32, each tile contiguous.
     """
-    b = KernelBuilder(f"{name}_mod", name, target=target, isa=isa)
+    b = KernelBuilder(f"{name}_mod", name, target=target)
     b.set_shared_memory_size(MWG_LDS_SIZE)
     b.add_ptr_arg(AccessKind.ReadOnly)  # A
     b.add_ptr_arg(AccessKind.ReadOnly)  # B

--- a/python/test/test_kernel_builder.py
+++ b/python/test/test_kernel_builder.py
@@ -154,7 +154,7 @@ def test_kernel_builder_empty_kernel():
     """KernelBuilder produces a parseable amdgcn.module with an empty kernel."""
     ctx = _ctx()
     with ctx:
-        b = KernelBuilder("mymod", "empty_kernel", target="gfx942", isa="cdna3")
+        b = KernelBuilder("mymod", "empty_kernel", target="gfx942")
         module = b.build()
         assert module is not None
         text = str(module)
@@ -166,7 +166,7 @@ def test_kernel_builder_alloca_vgpr():
     """KernelBuilder.alloca_vgpr() produces an AllocaOp in the kernel body."""
     ctx = _ctx()
     with ctx:
-        b = KernelBuilder("m", "k", target="gfx942", isa="cdna3")
+        b = KernelBuilder("m", "k", target="gfx942")
         v = b.alloca_vgpr()
         assert v is not None
         module = b.build()
@@ -178,7 +178,7 @@ def test_kernel_builder_alloca_sgpr():
     """KernelBuilder.alloca_sgpr() produces an AllocaOp in the kernel body."""
     ctx = _ctx()
     with ctx:
-        b = KernelBuilder("m", "k", target="gfx942", isa="cdna3")
+        b = KernelBuilder("m", "k", target="gfx942")
         s = b.alloca_sgpr()
         assert s is not None
         module = b.build()
@@ -190,7 +190,7 @@ def test_kernel_builder_wait_vmcnt():
     """KernelBuilder.wait_vmcnt() inserts s_waitcnt vmcnt=0."""
     ctx = _ctx()
     with ctx:
-        b = KernelBuilder("m", "k", target="gfx942", isa="cdna3")
+        b = KernelBuilder("m", "k", target="gfx942")
         b.wait_vmcnt(0)
         module = b.build()
         text = str(module)
@@ -202,7 +202,7 @@ def test_kernel_builder_wait_lgkmcnt():
     """KernelBuilder.wait_lgkmcnt() inserts s_waitcnt lgkmcnt=0."""
     ctx = _ctx()
     with ctx:
-        b = KernelBuilder("m", "k", target="gfx942", isa="cdna3")
+        b = KernelBuilder("m", "k", target="gfx942")
         b.wait_lgkmcnt(0)
         module = b.build()
         text = str(module)
@@ -214,7 +214,7 @@ def test_kernel_builder_arith_constant():
     """KernelBuilder.constant_i32() produces an arith.constant op."""
     ctx = _ctx()
     with ctx:
-        b = KernelBuilder("m", "k", target="gfx942", isa="cdna3")
+        b = KernelBuilder("m", "k", target="gfx942")
         c = b.constant_i32(42)
         assert c is not None
         module = b.build()
@@ -228,7 +228,7 @@ def test_kernel_builder_with_ptr_args():
 
     ctx = _ctx()
     with ctx:
-        b = KernelBuilder("m", "k", target="gfx942", isa="cdna3")
+        b = KernelBuilder("m", "k", target="gfx942")
         b.add_ptr_arg(AccessKind.ReadOnly)
         b.add_ptr_arg(AccessKind.ReadWrite)
         ptrs = b.load_args()
@@ -243,7 +243,7 @@ def test_kernel_builder_with_ptr_args():
 # ---------------------------------------------------------------------------
 
 
-def build_tiledmma_module(target: str = "gfx942", isa: str = "cdna3") -> ir.Module:
+def build_tiledmma_module(target: str = "gfx942") -> ir.Module:
     """Build a tiledmma kernel: A[16x16 f16] x B[16x16 f16]^T -> C[16x16 f32].
 
     Uses MFMA register-to-matrix layout (ISA Section 7.1.4) for loads/stores:
@@ -258,7 +258,7 @@ def build_tiledmma_module(target: str = "gfx942", isa: str = "cdna3") -> ir.Modu
     from aster.dialects.amdgcn import AccessKind
     from aster.layout import Layout
 
-    b = KernelBuilder("tiledmma_mod", "tiledmma", target=target, isa=isa)
+    b = KernelBuilder("tiledmma_mod", "tiledmma", target=target)
     b.add_ptr_arg(AccessKind.ReadOnly)  # A
     b.add_ptr_arg(AccessKind.ReadOnly)  # B
     b.add_ptr_arg(AccessKind.WriteOnly)  # C/D
@@ -318,7 +318,7 @@ def _kernel_with(fn):
     """Build a minimal kernel, call fn(builder) inside, return module text."""
     ctx = _ctx()
     with ctx:
-        b = KernelBuilder("m", "k", target="gfx942", isa="cdna3")
+        b = KernelBuilder("m", "k", target="gfx942")
         b.add_ptr_arg(AccessKind.ReadOnly)
         b.load_args()
         fn(b)

--- a/python/test/test_layout_codegen.py
+++ b/python/test/test_layout_codegen.py
@@ -20,13 +20,12 @@ def build_copy_kernel(
     name: str,
     thread_layout: Layout,
     target: str = "gfx942",
-    isa: str = "cdna3",
 ):
     """Build a flat-global dwordx4 copy kernel using KernelBuilder + layout."""
     from aster.dialects.kernel_builder import KernelBuilder
     from aster.dialects.amdgcn import AccessKind
 
-    b = KernelBuilder(f"{name}_module", name, target=target, isa=isa)
+    b = KernelBuilder(f"{name}_module", name, target=target)
     b.add_ptr_arg(AccessKind.ReadOnly)
     b.add_ptr_arg(AccessKind.WriteOnly)
     src_ptr, dst_ptr = b.load_args()

--- a/test/CodeGen/legalizer-view-to-lds.mlir
+++ b/test/CodeGen/legalizer-view-to-lds.mlir
@@ -1,6 +1,6 @@
 // RUN: aster-opt %s --aster-legalizer | FileCheck %s
 
-amdgcn.module @mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @mod target = #amdgcn.target<gfx942> {
 // CHECK-LABEL: func.func @test_view_to_lds
 // CHECK:         amdgcn.alloc_lds 1024
 // CHECK:         amdgcn.get_lds_offset

--- a/test/Dialect/AMDGCN/Analysis/interference-opt-pipelining.mlir
+++ b/test/Dialect/AMDGCN/Analysis/interference-opt-pipelining.mlir
@@ -31,7 +31,7 @@
 // CHECK:   0 -- 2;
 // CHECK:   1 -- 2;
 // CHECK: }
-amdgcn.module @t1 target = <gfx942> isa = <cdna3> {
+amdgcn.module @t1 target = <gfx942> {
   func.func private @rand() -> i1
   kernel @two_stage_load_basic {
     %cond = func.call @rand() : () -> i1
@@ -99,7 +99,7 @@ amdgcn.module @t1 target = <gfx942> isa = <cdna3> {
 // CHECK:   1 -- 4;
 // CHECK:   2 -- 4;
 // CHECK: }
-amdgcn.module @t2 target = <gfx942> isa = <cdna3> {
+amdgcn.module @t2 target = <gfx942> {
   func.func private @rand() -> i1
   kernel @two_independent_loads {
     %cond = func.call @rand() : () -> i1
@@ -171,7 +171,7 @@ amdgcn.module @t2 target = <gfx942> isa = <cdna3> {
 // CHECK:   1 -- 3;
 // CHECK:   2 -- 3;
 // CHECK: }
-amdgcn.module @t3 target = <gfx942> isa = <cdna3> {
+amdgcn.module @t3 target = <gfx942> {
   func.func private @rand() -> i1
   kernel @two_stage_load_dwordx2 {
     %cond = func.call @rand() : () -> i1
@@ -224,7 +224,7 @@ amdgcn.module @t3 target = <gfx942> isa = <cdna3> {
 // CHECK:   3 -- 4;
 // CHECK: }
 // CHECK-NOT: EquivalenceClasses
-amdgcn.module @t4 target = <gfx942> isa = <cdna3> {
+amdgcn.module @t4 target = <gfx942> {
   func.func private @rand() -> i1
   kernel @three_stage_load_compute_store {
     %cond = func.call @rand() : () -> i1
@@ -274,7 +274,7 @@ amdgcn.module @t4 target = <gfx942> isa = <cdna3> {
 // CHECK:   2 -- 3;
 // CHECK: }
 // CHECK-NOT: EquivalenceClasses
-amdgcn.module @t5 target = <gfx942> isa = <cdna3> {
+amdgcn.module @t5 target = <gfx942> {
   func.func private @rand() -> i1
   kernel @pipeline_copy_interferes {
     %cond = func.call @rand() : () -> i1
@@ -348,7 +348,7 @@ amdgcn.module @t5 target = <gfx942> isa = <cdna3> {
 // CHECK:   2 -- 5;
 // CHECK:   4 -- 5;
 // CHECK: }
-amdgcn.module @t6 target = <gfx942> isa = <cdna3> {
+amdgcn.module @t6 target = <gfx942> {
   func.func private @rand() -> i1
   kernel @mixed_coalesce_and_no_coalesce {
     %cond = func.call @rand() : () -> i1
@@ -410,7 +410,7 @@ amdgcn.module @t6 target = <gfx942> isa = <cdna3> {
 // CHECK:   0 -- 2;
 // CHECK:   1 -- 2;
 // CHECK: }
-amdgcn.module @t7 target = <gfx942> isa = <cdna3> {
+amdgcn.module @t7 target = <gfx942> {
   func.func private @rand() -> i1
   kernel @pipeline_chain_copies {
     %cond = func.call @rand() : () -> i1
@@ -514,7 +514,7 @@ amdgcn.module @t7 target = <gfx942> isa = <cdna3> {
 // CHECK:   3 -- 8;
 // CHECK:   3 -- 9;
 // CHECK: }
-amdgcn.module @t8 target = <gfx942> isa = <cdna3> {
+amdgcn.module @t8 target = <gfx942> {
   func.func private @rand() -> i1
   kernel @two_stage_load_dwordx4 {
     %cond = func.call @rand() : () -> i1
@@ -597,7 +597,7 @@ amdgcn.module @t8 target = <gfx942> isa = <cdna3> {
 // CHECK:   1 -- 6;
 // CHECK:   2 -- 4;
 // CHECK: }
-amdgcn.module @t9 target = <gfx942> isa = <cdna3> {
+amdgcn.module @t9 target = <gfx942> {
   func.func private @rand() -> i1
   kernel @two_loads_to_compute {
     %cond = func.call @rand() : () -> i1

--- a/test/Dialect/AMDGCN/Analysis/interference-opt.mlir
+++ b/test/Dialect/AMDGCN/Analysis/interference-opt.mlir
@@ -1,6 +1,6 @@
 // RUN: aster-opt %s --test-amdgcn-interference-analysis=optimize=true --split-input-file 2>&1 | FileCheck %s
 
-amdgcn.module @reg_alloc target = <gfx942> isa = <cdna3> {
+amdgcn.module @reg_alloc target = <gfx942> {
 // CHECK-LABEL: Function: coalescing_load
 // CHECK: graph RegisterInterference {
 // CHECK:   0 [label="0, %0"];

--- a/test/Dialect/AMDGCN/Analysis/memory-dependence-analysis.mlir
+++ b/test/Dialect/AMDGCN/Analysis/memory-dependence-analysis.mlir
@@ -4,7 +4,7 @@
 // This test will be enabled once we integrate the analysis into a test pass
 
 //   CHECK-LABEL: Kernel: test_kernel
-amdgcn.module @test_memory_dependence target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @test_memory_dependence target = #amdgcn.target<gfx942> {
   amdgcn.kernel @test_kernel {
     %0 = amdgcn.alloca : !amdgcn.vgpr
     %1 = amdgcn.alloca : !amdgcn.vgpr
@@ -147,7 +147,7 @@ amdgcn.module @test_memory_dependence target = #amdgcn.target<gfx942> isa = #amd
 // The analysis detects this cross-resource dependency: LoadToLDSOp
 // conservatively aliases with all LDS operations.
 //   CHECK-LABEL: Kernel: test_g2s_lds_dep
-amdgcn.module @test_g2s_lds_dep target = #amdgcn.target<gfx950> isa = #amdgcn.isa<cdna4> {
+amdgcn.module @test_g2s_lds_dep target = #amdgcn.target<gfx950> {
   amdgcn.kernel @test_g2s_lds_dep {
     %m0 = amdgcn.alloca : !amdgcn.m0<0>
     %s0 = amdgcn.alloca : !amdgcn.sgpr

--- a/test/Dialect/AMDGCN/Analysis/range-constraints.mlir
+++ b/test/Dialect/AMDGCN/Analysis/range-constraints.mlir
@@ -10,7 +10,7 @@
 // CHECK:  Symbol: simple_range
 // CHECK:  Range constraints:
 // CHECK:    Constraint 0: range_constraint<alignment = 2, allocations = [0 = `%{{.*}}`, 1 = `%{{.*}}`]>
-amdgcn.module @range_tests target = <gfx942> isa = <cdna3> {
+amdgcn.module @range_tests target = <gfx942> {
   kernel @simple_range {
     %0 = alloca : !amdgcn.vgpr<?>
     %1 = alloca : !amdgcn.vgpr<?>
@@ -30,7 +30,7 @@ amdgcn.module @range_tests target = <gfx942> isa = <cdna3> {
 // CHECK:  results: [1 = `%{{.*}}`]
 // CHECK:  Symbol: no_ranges
 // CHECK:  No range constraints
-amdgcn.module @range_tests target = <gfx942> isa = <cdna3> {
+amdgcn.module @range_tests target = <gfx942> {
   kernel @no_ranges {
     %0 = alloca : !amdgcn.vgpr<?>
     %1 = alloca : !amdgcn.vgpr<?>
@@ -59,7 +59,7 @@ amdgcn.module @range_tests target = <gfx942> isa = <cdna3> {
 // CHECK:  Range constraints:
 // CHECK:    Constraint 0: range_constraint<alignment = 2, allocations = [0 = `%{{.*}}`, 1 = `%{{.*}}`]>
 // CHECK:    Constraint 1: range_constraint<alignment = 2, allocations = [2 = `%{{.*}}`, 3 = `%{{.*}}`]>
-amdgcn.module @range_tests target = <gfx942> isa = <cdna3> {
+amdgcn.module @range_tests target = <gfx942> {
   kernel @disjoint_ranges {
     %0 = alloca : !amdgcn.vgpr<?>
     %1 = alloca : !amdgcn.vgpr<?>
@@ -92,7 +92,7 @@ amdgcn.module @range_tests target = <gfx942> isa = <cdna3> {
 // CHECK:  Symbol: subset_range
 // CHECK:  Range constraints:
 // CHECK:    Constraint 0: range_constraint<alignment = 4, allocations = [0 = `%{{.*}}`, 1 = `%{{.*}}`, 2 = `%{{.*}}`]>
-amdgcn.module @range_tests target = <gfx942> isa = <cdna3> {
+amdgcn.module @range_tests target = <gfx942> {
   kernel @subset_range {
     %0 = alloca : !amdgcn.vgpr<?>
     %1 = alloca : !amdgcn.vgpr<?>
@@ -130,7 +130,7 @@ amdgcn.module @range_tests target = <gfx942> isa = <cdna3> {
 // CHECK:  Range constraints:
 // CHECK:    Constraint 0: range_constraint<alignment = 2, allocations = [1 = `%{{.*}}`, 2 = `%{{.*}}`]>
 // CHECK:    Constraint 1: range_constraint<alignment = 2, allocations = [3 = `%{{.*}}`, 4 = `%{{.*}}`]>
-amdgcn.module @range_tests target = <gfx942> isa = <cdna3> {
+amdgcn.module @range_tests target = <gfx942> {
   func.func private @rand() -> i1
   kernel @cf_disjoint_branch_ranges {
     %0 = func.call @rand() : () -> i1
@@ -160,7 +160,7 @@ amdgcn.module @range_tests target = <gfx942> isa = <cdna3> {
 // CHECK-LABEL:  SSA map
 // CHECK:  Symbol: empty_kernel
 // CHECK:  No range constraints
-amdgcn.module @range_tests target = <gfx942> isa = <cdna3> {
+amdgcn.module @range_tests target = <gfx942> {
   kernel @empty_kernel {
     end_kernel
   }
@@ -181,7 +181,7 @@ amdgcn.module @range_tests target = <gfx942> isa = <cdna3> {
 // CHECK:  Symbol: large_range
 // CHECK:  Range constraints:
 // CHECK:    Constraint 0: range_constraint<alignment = 4, allocations = [0 = `%{{.*}}`, 1 = `%{{.*}}`, 2 = `%{{.*}}`, 3 = `%{{.*}}`]>
-amdgcn.module @range_tests target = <gfx942> isa = <cdna3> {
+amdgcn.module @range_tests target = <gfx942> {
   kernel @large_range {
     %0 = alloca : !amdgcn.vgpr<?>
     %1 = alloca : !amdgcn.vgpr<?>
@@ -208,7 +208,7 @@ amdgcn.module @range_tests target = <gfx942> isa = <cdna3> {
 // CHECK:  Symbol: same_range_twice
 // CHECK:  Range constraints:
 // CHECK:    Constraint 0: range_constraint<alignment = 2, allocations = [0 = `%{{.*}}`, 1 = `%{{.*}}`]>
-amdgcn.module @range_tests target = <gfx942> isa = <cdna3> {
+amdgcn.module @range_tests target = <gfx942> {
   kernel @same_range_twice {
     %0 = alloca : !amdgcn.vgpr<?>
     %1 = alloca : !amdgcn.vgpr<?>
@@ -232,7 +232,7 @@ amdgcn.module @range_tests target = <gfx942> isa = <cdna3> {
 // CHECK:  Symbol: sgpr_range
 // CHECK:  Range constraints:
 // CHECK:    Constraint 0: range_constraint<alignment = 2, allocations = [0 = `%{{.*}}`, 1 = `%{{.*}}`]>
-amdgcn.module @range_tests target = <gfx942> isa = <cdna3> {
+amdgcn.module @range_tests target = <gfx942> {
   kernel @sgpr_range {
     %0 = alloca : !amdgcn.sgpr<?>
     %1 = alloca : !amdgcn.sgpr<?>
@@ -270,7 +270,7 @@ amdgcn.module @range_tests target = <gfx942> isa = <cdna3> {
 // CHECK:  results: [10 = `%{{.*}}`]
 // CHECK:  Symbol: phi_coalescing_2
 // CHECK:  No range constraints
-amdgcn.module @range_tests target = <gfx942> isa = <cdna3> {
+amdgcn.module @range_tests target = <gfx942> {
   kernel @phi_coalescing_2 {
     %c0_i32 = arith.constant 0 : i32
     %0 = alloca : !amdgcn.vgpr<?>
@@ -320,7 +320,7 @@ amdgcn.module @range_tests target = <gfx942> isa = <cdna3> {
 // CHECK:  results: [6 = `%{{.*}}`]
 // CHECK:  Symbol: phi_coalescing_3
 // CHECK:  No range constraints
-amdgcn.module @range_tests target = <gfx942> isa = <cdna3> {
+amdgcn.module @range_tests target = <gfx942> {
   kernel @phi_coalescing_3 {
     %c0_i32 = arith.constant 0 : i32
     %0 = alloca : !amdgcn.vgpr<?>
@@ -346,7 +346,7 @@ amdgcn.module @range_tests target = <gfx942> isa = <cdna3> {
 
 // -----
 
-amdgcn.module @range_tests target = <gfx942> isa = <cdna3> {
+amdgcn.module @range_tests target = <gfx942> {
   // expected-error@+1 {{Failed to run range constraint analysis}}
   amdgcn.kernel @overlapping_ranges {
     %0 = alloca : !amdgcn.vgpr
@@ -365,7 +365,7 @@ amdgcn.module @range_tests target = <gfx942> isa = <cdna3> {
 
 // -----
 
-amdgcn.module @range_tests target = <gfx942> isa = <cdna3> {
+amdgcn.module @range_tests target = <gfx942> {
   // expected-error@+1 {{Failed to run range constraint analysis}}
   amdgcn.kernel @alignment_conflict {
     %0 = alloca : !amdgcn.vgpr
@@ -391,7 +391,7 @@ amdgcn.module @range_tests target = <gfx942> isa = <cdna3> {
 //CHECK: Range constraints:
 //CHECK:   Constraint 0: range_constraint<alignment = 4, allocations = [0 = `%{{.*}}`, 1 = `%{{.*}}`, 2 = `%{{.*}}`, 3 = `%{{.*}}`]>
 //CHECK:   Constraint 1: range_constraint<alignment = 2, allocations = [4 = `%{{.*}}`, 5 = `%{{.*}}`]>
-amdgcn.module @range_tests target = <gfx942> isa = <cdna3> {
+amdgcn.module @range_tests target = <gfx942> {
   kernel @constraintrs_descending_order {
     %0 = alloca : !amdgcn.vgpr<?>
     %1 = alloca : !amdgcn.vgpr<?>

--- a/test/Dialect/AMDGCN/Analysis/register-interference.mlir
+++ b/test/Dialect/AMDGCN/Analysis/register-interference.mlir
@@ -6,7 +6,7 @@
 // CHECK:   0 [label="0
 // CHECK:   1 [label="1
 // CHECK: }
-amdgcn.module @interference_tests target = <gfx942> isa = <cdna3> {
+amdgcn.module @interference_tests target = <gfx942> {
   kernel @no_interference {
     %0 = alloca : !amdgcn.vgpr<?>
     %1 = alloca : !amdgcn.vgpr<?>
@@ -23,7 +23,7 @@ amdgcn.module @interference_tests target = <gfx942> isa = <cdna3> {
 // CHECK:   1 [label="1
 // CHECK:   0 -- 1;
 // CHECK: }
-amdgcn.module @interference_tests target = <gfx942> isa = <cdna3> {
+amdgcn.module @interference_tests target = <gfx942> {
   kernel @basic_interference {
     %0 = alloca : !amdgcn.vgpr<?>
     %1 = alloca : !amdgcn.vgpr<?>
@@ -44,7 +44,7 @@ amdgcn.module @interference_tests target = <gfx942> isa = <cdna3> {
 // CHECK:   0 -- 2;
 // CHECK:   1 -- 2;
 // CHECK: }
-amdgcn.module @interference_tests target = <gfx942> isa = <cdna3> {
+amdgcn.module @interference_tests target = <gfx942> {
   kernel @three_way_interference {
     %0 = alloca : !amdgcn.vgpr<?>
     %1 = alloca : !amdgcn.vgpr<?>
@@ -63,7 +63,7 @@ amdgcn.module @interference_tests target = <gfx942> isa = <cdna3> {
 // CHECK:   0 [label="0
 // CHECK:   1 [label="1
 // CHECK: }
-amdgcn.module @interference_tests target = <gfx942> isa = <cdna3> {
+amdgcn.module @interference_tests target = <gfx942> {
   kernel @no_cross_type_interference {
     %0 = alloca : !amdgcn.vgpr<?>
     %1 = alloca : !amdgcn.sgpr<?>
@@ -84,7 +84,7 @@ amdgcn.module @interference_tests target = <gfx942> isa = <cdna3> {
 // CHECK:   0 -- 2;
 // CHECK:   1 -- 2;
 // CHECK: }
-amdgcn.module @interference_tests target = <gfx942> isa = <cdna3> {
+amdgcn.module @interference_tests target = <gfx942> {
   kernel @reg_interference_op {
     %0 = alloca : !amdgcn.sgpr<?>
     %1 = alloca : !amdgcn.sgpr<?>
@@ -105,7 +105,7 @@ amdgcn.module @interference_tests target = <gfx942> isa = <cdna3> {
 // CHECK:   2 [label="2
 // CHECK:   0 -- 1;
 // CHECK: }
-amdgcn.module @interference_tests target = <gfx942> isa = <cdna3> {
+amdgcn.module @interference_tests target = <gfx942> {
   kernel @partial_interference {
     %0 = alloca : !amdgcn.vgpr<?>
     %1 = alloca : !amdgcn.vgpr<?>
@@ -125,7 +125,7 @@ amdgcn.module @interference_tests target = <gfx942> isa = <cdna3> {
 // CHECK:   0 [label="0
 // CHECK:   1 [label="1
 // CHECK: }
-amdgcn.module @interference_tests target = <gfx942> isa = <cdna3> {
+amdgcn.module @interference_tests target = <gfx942> {
   func.func private @rand() -> i1
   kernel @diamond_cf {
     %0 = func.call @rand() : () -> i1
@@ -154,7 +154,7 @@ amdgcn.module @interference_tests target = <gfx942> isa = <cdna3> {
 // CHECK:   0 -- 1;
 // CHECK:   0 -- 2;
 // CHECK: }
-amdgcn.module @interference_tests target = <gfx942> isa = <cdna3> {
+amdgcn.module @interference_tests target = <gfx942> {
   func.func private @rand() -> i1
   kernel @live_across_diamond {
     %0 = func.call @rand() : () -> i1
@@ -183,7 +183,7 @@ amdgcn.module @interference_tests target = <gfx942> isa = <cdna3> {
 // CHECK:   0 [label="0
 // CHECK:   1 [label="1
 // CHECK: }
-amdgcn.module @interference_tests target = <gfx942> isa = <cdna3> {
+amdgcn.module @interference_tests target = <gfx942> {
   kernel @sequential_use {
     %0 = alloca : !amdgcn.vgpr<?>
     %1 = alloca : !amdgcn.vgpr<?>
@@ -214,7 +214,7 @@ amdgcn.module @interference_tests target = <gfx942> isa = <cdna3> {
 // CHECK:   2 -- 4;
 // CHECK:   3 -- 4;
 // CHECK: }
-amdgcn.module @interference_tests target = <gfx942> isa = <cdna3> {
+amdgcn.module @interference_tests target = <gfx942> {
   kernel @many_overlapping {
     %0 = alloca : !amdgcn.vgpr<?>
     %1 = alloca : !amdgcn.vgpr<?>
@@ -245,7 +245,7 @@ amdgcn.module @interference_tests target = <gfx942> isa = <cdna3> {
 // CHECK:   8 [label="8
 // CHECK:   0 -- 1;
 // CHECK: }
-amdgcn.module @interference_tests target = <gfx942> isa = <cdna3> {
+amdgcn.module @interference_tests target = <gfx942> {
   kernel @phi_coalescing_2 {
     %c0_i32 = arith.constant 0 : i32
     %0 = alloca : !amdgcn.vgpr<?>
@@ -289,7 +289,7 @@ amdgcn.module @interference_tests target = <gfx942> isa = <cdna3> {
 // CHECK:   0 -- 4;
 // CHECK:   1 -- 4;
 // CHECK: }
-amdgcn.module @interference_tests target = <gfx942> isa = <cdna3> {
+amdgcn.module @interference_tests target = <gfx942> {
   kernel @phi_coalescing_3 {
     %c0_i32 = arith.constant 0 : i32
     %0 = alloca : !amdgcn.vgpr<?>
@@ -321,7 +321,7 @@ amdgcn.module @interference_tests target = <gfx942> isa = <cdna3> {
 // CHECK:   1 [label="1, %1"];
 // CHECK:   0 -- 1;
 // }
-amdgcn.module @interference_tests target = <gfx942> isa = <cdna3> {
+amdgcn.module @interference_tests target = <gfx942> {
   kernel @multi_out {
     %0 = alloca : !amdgcn.vgpr<?>
     %1 = alloca : !amdgcn.vgpr<?>
@@ -343,7 +343,7 @@ amdgcn.module @interference_tests target = <gfx942> isa = <cdna3> {
 // CHECK:   0 -- 2;
 // CHECK:   1 -- 2;
 // CHECK: }
-amdgcn.module @interference_tests target = <gfx942> isa = <cdna3> {
+amdgcn.module @interference_tests target = <gfx942> {
   func.func private @rand() -> i1
   kernel @block_entry_interference {
     %0 = func.call @rand() : () -> i1
@@ -379,7 +379,7 @@ amdgcn.module @interference_tests target = <gfx942> isa = <cdna3> {
 // CHECK:   1 -- 2;
 // CHECK:   1 -- 3;
 // FULL:  2 -- 3;
-amdgcn.module @interference_tests target = <gfx942> isa = <cdna3> {
+amdgcn.module @interference_tests target = <gfx942> {
   kernel @full_interference {
     %0 = alloca : !amdgcn.vgpr<?>
     %1 = alloca : !amdgcn.vgpr<?>

--- a/test/Dialect/AMDGCN/IR/normal-forms-all-allocated-invalid.mlir
+++ b/test/Dialect/AMDGCN/IR/normal-forms-all-allocated-invalid.mlir
@@ -1,7 +1,7 @@
 // RUN: aster-opt %s --split-input-file --verify-diagnostics
 
 // Violation: unallocated register (?) inside module with all_registers_allocated.
-amdgcn.module @unalloc target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> attributes {normal_forms = [#amdgcn.all_registers_allocated]} {
+amdgcn.module @unalloc target = #amdgcn.target<gfx942> attributes {normal_forms = [#amdgcn.all_registers_allocated]} {
   amdgcn.kernel @k {
   ^bb0:
     // expected-error @below {{normal form violation: all registers must have allocated semantics but found}}
@@ -13,7 +13,7 @@ amdgcn.module @unalloc target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> 
 // -----
 
 // Violation: value-semantic register inside module with all_registers_allocated.
-amdgcn.module @value target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> attributes {normal_forms = [#amdgcn.all_registers_allocated]} {
+amdgcn.module @value target = #amdgcn.target<gfx942> attributes {normal_forms = [#amdgcn.all_registers_allocated]} {
   amdgcn.kernel @k {
   ^bb0:
     // expected-error @below {{normal form violation: all registers must have allocated semantics but found}}
@@ -25,7 +25,7 @@ amdgcn.module @value target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> at
 // -----
 
 // Violation: on kernel directly.
-amdgcn.module @mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @mod target = #amdgcn.target<gfx942> {
   amdgcn.kernel @k attributes {normal_forms = [#amdgcn.all_registers_allocated]} {
   ^bb0:
     // expected-error @below {{normal form violation: all registers must have allocated semantics but found}}

--- a/test/Dialect/AMDGCN/IR/normal-forms-all-allocated.mlir
+++ b/test/Dialect/AMDGCN/IR/normal-forms-all-allocated.mlir
@@ -3,9 +3,9 @@
 
 // Roundtrip: #amdgcn.all_registers_allocated on amdgcn.module.
 
-// CHECK: amdgcn.module @with_nf target = <gfx942> isa = <cdna3>
+// CHECK: amdgcn.module @with_nf target = <gfx942>
 // CHECK-SAME: attributes {normal_forms = [#amdgcn.all_registers_allocated]}
-amdgcn.module @with_nf target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> attributes {normal_forms = [#amdgcn.all_registers_allocated]} {
+amdgcn.module @with_nf target = #amdgcn.target<gfx942> attributes {normal_forms = [#amdgcn.all_registers_allocated]} {
   amdgcn.kernel @k {
   ^bb0:
     %0 = amdgcn.alloca : !amdgcn.vgpr<3>
@@ -17,7 +17,7 @@ amdgcn.module @with_nf target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> 
 
 // CHECK: amdgcn.module @both_nf
 // CHECK-SAME: normal_forms = [#amdgcn.no_value_semantic_registers, #amdgcn.all_registers_allocated]
-amdgcn.module @both_nf target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> attributes {normal_forms = [#amdgcn.no_value_semantic_registers, #amdgcn.all_registers_allocated]} {
+amdgcn.module @both_nf target = #amdgcn.target<gfx942> attributes {normal_forms = [#amdgcn.no_value_semantic_registers, #amdgcn.all_registers_allocated]} {
   amdgcn.kernel @k {
   ^bb0:
     %0 = amdgcn.alloca : !amdgcn.vgpr<3>

--- a/test/Dialect/AMDGCN/IR/normal-forms-all-inlined-invalid.mlir
+++ b/test/Dialect/AMDGCN/IR/normal-forms-all-inlined-invalid.mlir
@@ -1,7 +1,7 @@
 // RUN: aster-opt %s --split-input-file --verify-diagnostics
 
 // Violation: func.call inside kernel with all_inlined (kernel-level).
-amdgcn.module @mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @mod target = #amdgcn.target<gfx942> {
   func.func private @helper(%x: index) -> index {
     return %x : index
   }
@@ -17,7 +17,7 @@ amdgcn.module @mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
 // -----
 
 // Violation: func.call inside module with all_inlined (module-level).
-amdgcn.module @mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> attributes {normal_forms = [#amdgcn.all_inlined]} {
+amdgcn.module @mod target = #amdgcn.target<gfx942> attributes {normal_forms = [#amdgcn.all_inlined]} {
   func.func private @helper(%x: index) -> index {
     return %x : index
   }

--- a/test/Dialect/AMDGCN/IR/normal-forms-kernel-invalid.mlir
+++ b/test/Dialect/AMDGCN/IR/normal-forms-kernel-invalid.mlir
@@ -1,7 +1,7 @@
 // RUN: aster-opt %s --split-input-file --verify-diagnostics
 
 // Normal form violation on amdgcn.kernel: value-semantic vgpr.
-amdgcn.module @mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @mod target = #amdgcn.target<gfx942> {
   amdgcn.kernel @k attributes {normal_forms = [#amdgcn.no_value_semantic_registers]} {
   ^bb0:
     // expected-error @below {{normal form violation: register types with value semantics are disallowed but found}}
@@ -13,7 +13,7 @@ amdgcn.module @mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
 // -----
 
 // Normal form violation on amdgcn.kernel: value-semantic sgpr.
-amdgcn.module @mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @mod target = #amdgcn.target<gfx942> {
   amdgcn.kernel @k attributes {normal_forms = [#amdgcn.no_value_semantic_registers]} {
   ^bb0:
     // expected-error @below {{normal form violation: register types with value semantics are disallowed but found}}

--- a/test/Dialect/AMDGCN/IR/normal-forms-kernel.mlir
+++ b/test/Dialect/AMDGCN/IR/normal-forms-kernel.mlir
@@ -5,7 +5,7 @@
 
 // CHECK: kernel @with_nf
 // CHECK-SAME: attributes {normal_forms = [#amdgcn.no_value_semantic_registers]}
-amdgcn.module @test target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @test target = #amdgcn.target<gfx942> {
   amdgcn.kernel @with_nf attributes {normal_forms = [#amdgcn.no_value_semantic_registers]} {
   ^bb0:
     %0 = amdgcn.alloca : !amdgcn.vgpr<?>

--- a/test/Dialect/AMDGCN/IR/normal-forms-module-invalid.mlir
+++ b/test/Dialect/AMDGCN/IR/normal-forms-module-invalid.mlir
@@ -1,7 +1,7 @@
 // RUN: aster-opt %s --split-input-file --verify-diagnostics
 
 // Normal form violation on amdgcn.module: value-semantic vgpr inside module.
-amdgcn.module @nf_vgpr target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> attributes {normal_forms = [#amdgcn.no_value_semantic_registers]} {
+amdgcn.module @nf_vgpr target = #amdgcn.target<gfx942> attributes {normal_forms = [#amdgcn.no_value_semantic_registers]} {
   amdgcn.kernel @k {
   ^bb0:
     // expected-error @below {{normal form violation: register types with value semantics are disallowed but found}}
@@ -13,7 +13,7 @@ amdgcn.module @nf_vgpr target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> 
 // -----
 
 // Normal form violation on amdgcn.module: value-semantic sgpr.
-amdgcn.module @nf_sgpr target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> attributes {normal_forms = [#amdgcn.no_value_semantic_registers]} {
+amdgcn.module @nf_sgpr target = #amdgcn.target<gfx942> attributes {normal_forms = [#amdgcn.no_value_semantic_registers]} {
   amdgcn.kernel @k {
   ^bb0:
     // expected-error @below {{normal form violation: register types with value semantics are disallowed but found}}
@@ -25,7 +25,7 @@ amdgcn.module @nf_sgpr target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> 
 // -----
 
 // Normal form violation: lsir.reg_cast surviving past aster-to-amdgcn.
-amdgcn.module @nf_reg_cast target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> attributes {normal_forms = [#amdgcn.no_reg_cast_ops]} {
+amdgcn.module @nf_reg_cast target = #amdgcn.target<gfx942> attributes {normal_forms = [#amdgcn.no_reg_cast_ops]} {
   amdgcn.kernel @k {
   ^bb0:
     %0 = amdgcn.alloca : !amdgcn.vgpr<0>

--- a/test/Dialect/AMDGCN/IR/normal-forms-module.mlir
+++ b/test/Dialect/AMDGCN/IR/normal-forms-module.mlir
@@ -3,18 +3,18 @@
 
 // Roundtrip: normal_forms on amdgcn.module.
 
-// CHECK: amdgcn.module @with_nf target = <gfx942> isa = <cdna3>
+// CHECK: amdgcn.module @with_nf target = <gfx942>
 // CHECK-SAME: attributes {normal_forms = [#amdgcn.no_value_semantic_registers]}
-amdgcn.module @with_nf target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> attributes {normal_forms = [#amdgcn.no_value_semantic_registers]} {
+amdgcn.module @with_nf target = #amdgcn.target<gfx942> attributes {normal_forms = [#amdgcn.no_value_semantic_registers]} {
   amdgcn.kernel @k {
   ^bb0:
     amdgcn.end_kernel
   }
 }
 
-// CHECK: amdgcn.module @with_no_reg_cast target = <gfx942> isa = <cdna3>
+// CHECK: amdgcn.module @with_no_reg_cast target = <gfx942>
 // CHECK-SAME: attributes {normal_forms = [#amdgcn.no_reg_cast_ops]}
-amdgcn.module @with_no_reg_cast target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> attributes {normal_forms = [#amdgcn.no_reg_cast_ops]} {
+amdgcn.module @with_no_reg_cast target = #amdgcn.target<gfx942> attributes {normal_forms = [#amdgcn.no_reg_cast_ops]} {
   amdgcn.kernel @k {
   ^bb0:
     %0 = amdgcn.alloca : !amdgcn.vgpr<0>
@@ -22,10 +22,10 @@ amdgcn.module @with_no_reg_cast target = #amdgcn.target<gfx942> isa = #amdgcn.is
   }
 }
 
-// CHECK: amdgcn.module @without_nf target = <gfx942> isa = <cdna3>
+// CHECK: amdgcn.module @without_nf target = <gfx942>
 // CHECK-NOT: normal_forms
 // CHECK-SAME: {
-amdgcn.module @without_nf target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @without_nf target = #amdgcn.target<gfx942> {
   amdgcn.kernel @k {
   ^bb0:
     amdgcn.end_kernel

--- a/test/Dialect/AMDGCN/IR/normal-forms-no-affine-ops-invalid.mlir
+++ b/test/Dialect/AMDGCN/IR/normal-forms-no-affine-ops-invalid.mlir
@@ -1,7 +1,7 @@
 // RUN: aster-opt %s --split-input-file --verify-diagnostics
 
 // Violation: affine.apply inside module with no_affine_ops.
-amdgcn.module @has_affine target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> attributes {normal_forms = [#amdgcn.no_affine_ops]} {
+amdgcn.module @has_affine target = #amdgcn.target<gfx942> attributes {normal_forms = [#amdgcn.no_affine_ops]} {
   amdgcn.kernel @k {
   ^bb0:
     %c = arith.constant 42 : index
@@ -14,7 +14,7 @@ amdgcn.module @has_affine target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna
 // -----
 
 // Violation: affine.apply inside kernel with no_affine_ops.
-amdgcn.module @mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @mod target = #amdgcn.target<gfx942> {
   amdgcn.kernel @k attributes {normal_forms = [#amdgcn.no_affine_ops]} {
   ^bb0:
     %c = arith.constant 42 : index

--- a/test/Dialect/AMDGCN/IR/normal-forms-no-affine-ops.mlir
+++ b/test/Dialect/AMDGCN/IR/normal-forms-no-affine-ops.mlir
@@ -3,9 +3,9 @@
 
 // Roundtrip: #amdgcn.no_affine_ops on amdgcn.module.
 
-// CHECK: amdgcn.module @with_nf target = <gfx942> isa = <cdna3>
+// CHECK: amdgcn.module @with_nf target = <gfx942>
 // CHECK-SAME: attributes {normal_forms = [#amdgcn.no_affine_ops]}
-amdgcn.module @with_nf target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> attributes {normal_forms = [#amdgcn.no_affine_ops]} {
+amdgcn.module @with_nf target = #amdgcn.target<gfx942> attributes {normal_forms = [#amdgcn.no_affine_ops]} {
   amdgcn.kernel @k {
   ^bb0:
     %0 = amdgcn.alloca : !amdgcn.vgpr<3>

--- a/test/Dialect/AMDGCN/IR/normal-forms-no-cf-branches-invalid.mlir
+++ b/test/Dialect/AMDGCN/IR/normal-forms-no-cf-branches-invalid.mlir
@@ -1,7 +1,7 @@
 // RUN: aster-opt %s --split-input-file --verify-diagnostics
 
 // Violation: cf.br inside module with no_cf_branches.
-amdgcn.module @has_br target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> attributes {normal_forms = [#amdgcn.no_cf_branches]} {
+amdgcn.module @has_br target = #amdgcn.target<gfx942> attributes {normal_forms = [#amdgcn.no_cf_branches]} {
   amdgcn.kernel @k {
   ^bb0:
     %0 = amdgcn.alloca : !amdgcn.vgpr<3>
@@ -15,7 +15,7 @@ amdgcn.module @has_br target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> a
 // -----
 
 // Violation: cf.cond_br inside module with no_cf_branches.
-amdgcn.module @has_cond_br target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> attributes {normal_forms = [#amdgcn.no_cf_branches]} {
+amdgcn.module @has_cond_br target = #amdgcn.target<gfx942> attributes {normal_forms = [#amdgcn.no_cf_branches]} {
   amdgcn.kernel @k {
   ^bb0:
     %c = arith.constant true
@@ -31,7 +31,7 @@ amdgcn.module @has_cond_br target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdn
 // -----
 
 // Violation: cf.br on kernel directly.
-amdgcn.module @mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @mod target = #amdgcn.target<gfx942> {
   amdgcn.kernel @k attributes {normal_forms = [#amdgcn.no_cf_branches]} {
   ^bb0:
     %0 = amdgcn.alloca : !amdgcn.vgpr<3>

--- a/test/Dialect/AMDGCN/IR/normal-forms-no-cf-branches.mlir
+++ b/test/Dialect/AMDGCN/IR/normal-forms-no-cf-branches.mlir
@@ -3,9 +3,9 @@
 
 // Roundtrip: #amdgcn.no_cf_branches on amdgcn.module.
 
-// CHECK: amdgcn.module @with_nf target = <gfx942> isa = <cdna3>
+// CHECK: amdgcn.module @with_nf target = <gfx942>
 // CHECK-SAME: attributes {normal_forms = [#amdgcn.no_cf_branches]}
-amdgcn.module @with_nf target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> attributes {normal_forms = [#amdgcn.no_cf_branches]} {
+amdgcn.module @with_nf target = #amdgcn.target<gfx942> attributes {normal_forms = [#amdgcn.no_cf_branches]} {
   amdgcn.kernel @k {
   ^bb0:
     %0 = amdgcn.alloca : !amdgcn.vgpr<3>

--- a/test/Dialect/AMDGCN/IR/normal-forms-no-lsir-compute-ops-invalid.mlir
+++ b/test/Dialect/AMDGCN/IR/normal-forms-no-lsir-compute-ops-invalid.mlir
@@ -2,7 +2,7 @@
 
 // Verify that lsir.addi (compute op) is rejected under no_lsir_compute_ops.
 
-amdgcn.module @rejected_addi target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3>
+amdgcn.module @rejected_addi target = #amdgcn.target<gfx942>
     attributes {normal_forms = [#amdgcn.no_lsir_compute_ops]} {
   func.func @f(%dst: !amdgcn.vgpr, %a: !amdgcn.vgpr, %b: !amdgcn.vgpr) -> !amdgcn.vgpr {
     // expected-error @+1 {{normal form violation: LSIR compute/memory operations are disallowed but found: lsir.addi}}

--- a/test/Dialect/AMDGCN/IR/normal-forms-no-lsir-compute-ops.mlir
+++ b/test/Dialect/AMDGCN/IR/normal-forms-no-lsir-compute-ops.mlir
@@ -2,7 +2,7 @@
 
 // Verify that lsir.cmpi (control op) is allowed under no_lsir_compute_ops.
 
-amdgcn.module @allowed_cmpi target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3>
+amdgcn.module @allowed_cmpi target = #amdgcn.target<gfx942>
     attributes {normal_forms = [#amdgcn.no_lsir_compute_ops]} {
   func.func @f(%a: !amdgcn.sgpr, %b: !amdgcn.sgpr) -> i1 {
     %cmp = lsir.cmpi i32 slt %a, %b : !amdgcn.sgpr, !amdgcn.sgpr
@@ -14,7 +14,7 @@ amdgcn.module @allowed_cmpi target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cd
 
 // Verify that lsir.copy (regalloc primitive) is allowed under no_lsir_compute_ops.
 
-amdgcn.module @allowed_copy target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3>
+amdgcn.module @allowed_copy target = #amdgcn.target<gfx942>
     attributes {normal_forms = [#amdgcn.no_lsir_compute_ops]} {
   func.func @f(%dst: !amdgcn.vgpr, %src: !amdgcn.vgpr) -> !amdgcn.vgpr {
     %result = lsir.copy %dst, %src : !amdgcn.vgpr, !amdgcn.vgpr

--- a/test/Dialect/AMDGCN/IR/normal-forms-no-lsir-control-ops-invalid.mlir
+++ b/test/Dialect/AMDGCN/IR/normal-forms-no-lsir-control-ops-invalid.mlir
@@ -2,7 +2,7 @@
 
 // Verify that lsir.cmpi is rejected under no_lsir_control_ops.
 
-amdgcn.module @rejected_cmpi target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3>
+amdgcn.module @rejected_cmpi target = #amdgcn.target<gfx942>
     attributes {normal_forms = [#amdgcn.no_lsir_control_ops]} {
   func.func @f(%a: !amdgcn.sgpr, %b: !amdgcn.sgpr) -> i1 {
     // expected-error @+1 {{normal form violation: LSIR control-flow operations are disallowed but found: lsir.cmpi}}

--- a/test/Dialect/AMDGCN/IR/normal-forms-no-lsir-control-ops.mlir
+++ b/test/Dialect/AMDGCN/IR/normal-forms-no-lsir-control-ops.mlir
@@ -2,7 +2,7 @@
 
 // Verify that lsir.addi (compute op) is allowed under no_lsir_control_ops.
 
-amdgcn.module @allowed_addi target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3>
+amdgcn.module @allowed_addi target = #amdgcn.target<gfx942>
     attributes {normal_forms = [#amdgcn.no_lsir_control_ops]} {
   func.func @f(%dst: !amdgcn.vgpr, %a: !amdgcn.vgpr, %b: !amdgcn.vgpr) -> !amdgcn.vgpr {
     %result = lsir.addi i32 %dst, %a, %b : !amdgcn.vgpr, !amdgcn.vgpr, !amdgcn.vgpr

--- a/test/Dialect/AMDGCN/IR/normal-forms-no-lsir-ops-invalid.mlir
+++ b/test/Dialect/AMDGCN/IR/normal-forms-no-lsir-ops-invalid.mlir
@@ -1,7 +1,7 @@
 // RUN: aster-opt %s --split-input-file --verify-diagnostics
 
 // Violation: lsir.to_reg inside module with no_lsir_ops.
-amdgcn.module @has_lsir target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> attributes {normal_forms = [#amdgcn.no_lsir_ops]} {
+amdgcn.module @has_lsir target = #amdgcn.target<gfx942> attributes {normal_forms = [#amdgcn.no_lsir_ops]} {
   amdgcn.kernel @k {
   ^bb0:
     %c = arith.constant 42 : i32
@@ -14,7 +14,7 @@ amdgcn.module @has_lsir target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3>
 // -----
 
 // Violation: lsir.to_reg inside kernel with no_lsir_ops.
-amdgcn.module @mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @mod target = #amdgcn.target<gfx942> {
   amdgcn.kernel @k attributes {normal_forms = [#amdgcn.no_lsir_ops]} {
   ^bb0:
     %c = arith.constant 42 : i32

--- a/test/Dialect/AMDGCN/IR/normal-forms-no-lsir-ops.mlir
+++ b/test/Dialect/AMDGCN/IR/normal-forms-no-lsir-ops.mlir
@@ -3,9 +3,9 @@
 
 // Roundtrip: #amdgcn.no_lsir_ops on amdgcn.module.
 
-// CHECK: amdgcn.module @with_nf target = <gfx942> isa = <cdna3>
+// CHECK: amdgcn.module @with_nf target = <gfx942>
 // CHECK-SAME: attributes {normal_forms = [#amdgcn.no_lsir_ops]}
-amdgcn.module @with_nf target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> attributes {normal_forms = [#amdgcn.no_lsir_ops]} {
+amdgcn.module @with_nf target = #amdgcn.target<gfx942> attributes {normal_forms = [#amdgcn.no_lsir_ops]} {
   amdgcn.kernel @k {
   ^bb0:
     %0 = amdgcn.alloca : !amdgcn.vgpr<3>

--- a/test/Dialect/AMDGCN/IR/normal-forms-no-metadata-ops-invalid.mlir
+++ b/test/Dialect/AMDGCN/IR/normal-forms-no-metadata-ops-invalid.mlir
@@ -1,7 +1,7 @@
 // RUN: aster-opt %s --split-input-file --verify-diagnostics
 
 // Violation: amdgcn.load_arg inside kernel with no_metadata_ops.
-amdgcn.module @mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @mod target = #amdgcn.target<gfx942> {
   amdgcn.kernel @k
       arguments <[#amdgcn.buffer_arg<>]>
       attributes {normal_forms = [#amdgcn.no_metadata_ops]} {
@@ -15,7 +15,7 @@ amdgcn.module @mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
 // -----
 
 // Violation: amdgcn.thread_id inside kernel with no_metadata_ops.
-amdgcn.module @mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @mod target = #amdgcn.target<gfx942> {
   amdgcn.kernel @k attributes {normal_forms = [#amdgcn.no_metadata_ops]} {
   ^bb0:
     // expected-error @below {{normal form violation: AMDGCN metadata operations are disallowed but found}}
@@ -27,7 +27,7 @@ amdgcn.module @mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
 // -----
 
 // Violation: amdgcn.block_id inside kernel with no_metadata_ops.
-amdgcn.module @mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @mod target = #amdgcn.target<gfx942> {
   amdgcn.kernel @k attributes {normal_forms = [#amdgcn.no_metadata_ops]} {
   ^bb0:
     // expected-error @below {{normal form violation: AMDGCN metadata operations are disallowed but found}}

--- a/test/Dialect/AMDGCN/IR/normal-forms-no-metadata-ops.mlir
+++ b/test/Dialect/AMDGCN/IR/normal-forms-no-metadata-ops.mlir
@@ -5,7 +5,7 @@
 
 // CHECK: kernel @k
 // CHECK-SAME: attributes {normal_forms = [#amdgcn.no_metadata_ops]}
-amdgcn.module @mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @mod target = #amdgcn.target<gfx942> {
   amdgcn.kernel @k attributes {normal_forms = [#amdgcn.no_metadata_ops]} {
   ^bb0:
     %0 = amdgcn.alloca : !amdgcn.vgpr<3>

--- a/test/Dialect/AMDGCN/IR/normal-forms-no-register-block-args-invalid.mlir
+++ b/test/Dialect/AMDGCN/IR/normal-forms-no-register-block-args-invalid.mlir
@@ -1,7 +1,7 @@
 // RUN: aster-opt %s --split-input-file --verify-diagnostics
 
 // Violation: vgpr block argument inside module with no_register_block_args.
-amdgcn.module @has_reg_bbarg target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> attributes {normal_forms = [#amdgcn.no_register_block_args]} {
+amdgcn.module @has_reg_bbarg target = #amdgcn.target<gfx942> attributes {normal_forms = [#amdgcn.no_register_block_args]} {
   // expected-error @below {{normal form violation: block arguments with register types are disallowed but found}}
   amdgcn.kernel @k {
   ^bb0:
@@ -15,7 +15,7 @@ amdgcn.module @has_reg_bbarg target = #amdgcn.target<gfx942> isa = #amdgcn.isa<c
 // -----
 
 // Violation: sgpr block argument inside module with no_register_block_args.
-amdgcn.module @has_sgpr_bbarg target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> attributes {normal_forms = [#amdgcn.no_register_block_args]} {
+amdgcn.module @has_sgpr_bbarg target = #amdgcn.target<gfx942> attributes {normal_forms = [#amdgcn.no_register_block_args]} {
   // expected-error @below {{normal form violation: block arguments with register types are disallowed but found}}
   amdgcn.kernel @k {
   ^bb0:
@@ -29,7 +29,7 @@ amdgcn.module @has_sgpr_bbarg target = #amdgcn.target<gfx942> isa = #amdgcn.isa<
 // -----
 
 // Violation: on kernel directly.
-amdgcn.module @mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @mod target = #amdgcn.target<gfx942> {
   // expected-error @below {{normal form violation: block arguments with register types are disallowed but found}}
   amdgcn.kernel @k attributes {normal_forms = [#amdgcn.no_register_block_args]} {
   ^bb0:

--- a/test/Dialect/AMDGCN/IR/normal-forms-no-register-block-args.mlir
+++ b/test/Dialect/AMDGCN/IR/normal-forms-no-register-block-args.mlir
@@ -3,9 +3,9 @@
 
 // Roundtrip: #amdgcn.no_register_block_args on amdgcn.module.
 
-// CHECK: amdgcn.module @with_nf target = <gfx942> isa = <cdna3>
+// CHECK: amdgcn.module @with_nf target = <gfx942>
 // CHECK-SAME: attributes {normal_forms = [#amdgcn.no_register_block_args]}
-amdgcn.module @with_nf target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> attributes {normal_forms = [#amdgcn.no_register_block_args]} {
+amdgcn.module @with_nf target = #amdgcn.target<gfx942> attributes {normal_forms = [#amdgcn.no_register_block_args]} {
   amdgcn.kernel @k {
   ^bb0:
     %0 = amdgcn.alloca : !amdgcn.vgpr<3>

--- a/test/Dialect/AMDGCN/IR/normal-forms-no-scf-ops-invalid.mlir
+++ b/test/Dialect/AMDGCN/IR/normal-forms-no-scf-ops-invalid.mlir
@@ -1,7 +1,7 @@
 // RUN: aster-opt %s --split-input-file --verify-diagnostics
 
 // Violation: scf.for inside module with no_scf_ops.
-amdgcn.module @has_scf_for target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> attributes {normal_forms = [#amdgcn.no_scf_ops]} {
+amdgcn.module @has_scf_for target = #amdgcn.target<gfx942> attributes {normal_forms = [#amdgcn.no_scf_ops]} {
   amdgcn.kernel @k {
   ^bb0:
     %c0 = arith.constant 0 : index
@@ -17,7 +17,7 @@ amdgcn.module @has_scf_for target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdn
 // -----
 
 // Violation: scf.if inside kernel with no_scf_ops.
-amdgcn.module @mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @mod target = #amdgcn.target<gfx942> {
   amdgcn.kernel @k attributes {normal_forms = [#amdgcn.no_scf_ops]} {
   ^bb0:
     %c = arith.constant true

--- a/test/Dialect/AMDGCN/IR/normal-forms-no-scf-ops.mlir
+++ b/test/Dialect/AMDGCN/IR/normal-forms-no-scf-ops.mlir
@@ -3,9 +3,9 @@
 
 // Roundtrip: #amdgcn.no_scf_ops on amdgcn.module.
 
-// CHECK: amdgcn.module @with_nf target = <gfx942> isa = <cdna3>
+// CHECK: amdgcn.module @with_nf target = <gfx942>
 // CHECK-SAME: attributes {normal_forms = [#amdgcn.no_scf_ops]}
-amdgcn.module @with_nf target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> attributes {normal_forms = [#amdgcn.no_scf_ops]} {
+amdgcn.module @with_nf target = #amdgcn.target<gfx942> attributes {normal_forms = [#amdgcn.no_scf_ops]} {
   amdgcn.kernel @k {
   ^bb0:
     %0 = amdgcn.alloca : !amdgcn.vgpr<3>

--- a/test/Dialect/AMDGCN/IR/sopp-setprio-sleep-wakeup.mlir
+++ b/test/Dialect/AMDGCN/IR/sopp-setprio-sleep-wakeup.mlir
@@ -3,7 +3,7 @@
 // Roundtrip test for s_setprio, s_sleep, s_wakeup instructions.
 
 // CHECK-LABEL: amdgcn.module @setprio_test
-amdgcn.module @setprio_test target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @setprio_test target = #amdgcn.target<gfx942> {
   // CHECK: kernel @test_setprio_sleep_wakeup
   amdgcn.kernel @test_setprio_sleep_wakeup arguments <[
     #amdgcn.buffer_arg<address_space = generic, access = read_only>

--- a/test/Dialect/AMDGCN/Transforms/amdgcn-nop-insertion.mlir
+++ b/test/Dialect/AMDGCN/Transforms/amdgcn-nop-insertion.mlir
@@ -4,7 +4,7 @@
 //       CHECK:   amdgcn.vop1.v_nop
 //       CHECK:   amdgcn.vop1.v_nop
 //  CHECK-NEXT:   v_mov_b32_e32
-amdgcn.module @test_case8_9_store_x4 target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @test_case8_9_store_x4 target = #amdgcn.target<gfx942> {
   amdgcn.kernel @test_kernel attributes {normal_forms = [#amdgcn.all_registers_allocated]} {
     // Allocate VGPRs for data (4 VGPRs for dwordx4) - using registers 0-3
     %data0 = amdgcn.alloca : !amdgcn.vgpr<0>
@@ -39,7 +39,7 @@ amdgcn.module @test_case8_9_store_x4 target = #amdgcn.target<gfx942> isa = #amdg
 //       CHECK:   amdgcn.vop1.v_nop
 //       CHECK:   amdgcn.vop1.v_nop
 //  CHECK-NEXT:   load global_load_dword
-amdgcn.module @test_case10_valu_sgpr_vmem target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @test_case10_valu_sgpr_vmem target = #amdgcn.target<gfx942> {
   amdgcn.kernel @test_kernel attributes {normal_forms = [#amdgcn.all_registers_allocated]} {
     // Allocate SGPRs for address (2 SGPRs) - using registers 0-1
     %addr0 = amdgcn.alloca : !amdgcn.sgpr<0>
@@ -82,7 +82,7 @@ amdgcn.module @test_case10_valu_sgpr_vmem target = #amdgcn.target<gfx942> isa = 
 // CHECK-LABEL: kernel @test_kernel
 //   CHECK-NOT:  s_nop
 //   CHECK-NOT:  v_nop
-amdgcn.module @test_case8_no_overlap target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @test_case8_no_overlap target = #amdgcn.target<gfx942> {
   amdgcn.kernel @test_kernel attributes {normal_forms = [#amdgcn.all_registers_allocated]} {
     // Allocate VGPRs for data (3 VGPRs for dwordx3) - using registers 0-2
     %data0 = amdgcn.alloca : !amdgcn.vgpr<0>
@@ -116,7 +116,7 @@ amdgcn.module @test_case8_no_overlap target = #amdgcn.target<gfx942> isa = #amdg
 // CHECK-LABEL: kernel @test_kernel
 //   CHECK-NOT:  s_nop
 //   CHECK-NOT:  v_nop
-amdgcn.module @test_case9_no_overlap_valu target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @test_case9_no_overlap_valu target = #amdgcn.target<gfx942> {
   amdgcn.kernel @test_kernel attributes {normal_forms = [#amdgcn.all_registers_allocated]} {
     // Allocate VGPRs for data (3 VGPRs for dwordx3) - using registers 0-2
     %data0 = amdgcn.alloca : !amdgcn.vgpr<0>
@@ -149,7 +149,7 @@ amdgcn.module @test_case9_no_overlap_valu target = #amdgcn.target<gfx942> isa = 
 // CHECK-LABEL: kernel @test_kernel
 //   CHECK-NOT:  s_nop
 //   CHECK-NOT:  v_nop
-amdgcn.module @test_case10_no_overlap_sgpr target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @test_case10_no_overlap_sgpr target = #amdgcn.target<gfx942> {
   amdgcn.kernel @test_kernel attributes {normal_forms = [#amdgcn.all_registers_allocated]} {
     // Allocate SGPRs for address (2 SGPRs) - using registers 0-1
     %addr0 = amdgcn.alloca : !amdgcn.sgpr<0>
@@ -185,7 +185,7 @@ amdgcn.module @test_case10_no_overlap_sgpr target = #amdgcn.target<gfx942> isa =
 // Expects 7 v_nop insertions (conservative for 2-pass)
 // CHECK-LABEL: kernel @test_kernel
 // TODO: recheck when we have CDNA4 support
-amdgcn.module @test_case106_scaled_mfma_16x16x128 target = #amdgcn.target<gfx950> isa = #amdgcn.isa<cdna4> {
+amdgcn.module @test_case106_scaled_mfma_16x16x128 target = #amdgcn.target<gfx950> {
   amdgcn.kernel @test_kernel attributes {normal_forms = [#amdgcn.all_registers_allocated]} {
     // A operands: 8 VGPRs [0:8)
     %a0 = amdgcn.alloca : !amdgcn.vgpr<0>
@@ -245,7 +245,7 @@ amdgcn.module @test_case106_scaled_mfma_16x16x128 target = #amdgcn.target<gfx950
 // Expects 7 v_nop insertions (4-pass)
 // CHECK-LABEL: kernel @test_kernel
 // TODO: recheck when we have CDNA4 support
-amdgcn.module @test_case106_scaled_mfma_32x32x64 target = #amdgcn.target<gfx950> isa = #amdgcn.isa<cdna4> {
+amdgcn.module @test_case106_scaled_mfma_32x32x64 target = #amdgcn.target<gfx950> {
   amdgcn.kernel @test_kernel attributes {normal_forms = [#amdgcn.all_registers_allocated]} {
     // A operands: 8 VGPRs [0:8)
     %a0 = amdgcn.alloca : !amdgcn.vgpr<0>
@@ -329,7 +329,7 @@ amdgcn.module @test_case106_scaled_mfma_32x32x64 target = #amdgcn.target<gfx950>
 //       CHECK:   amdgcn.vop1.v_nop
 //       CHECK:   amdgcn.vop1.v_nop
 //  CHECK-NEXT:   v_mov_b32_e32
-amdgcn.module @test_case106_fp8_mfma_16x16x32 target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @test_case106_fp8_mfma_16x16x32 target = #amdgcn.target<gfx942> {
   amdgcn.kernel @test_kernel attributes {normal_forms = [#amdgcn.all_registers_allocated]} {
     // A operands: 2 VGPRs [0:2)
     %a0 = amdgcn.alloca : !amdgcn.vgpr<0>
@@ -379,7 +379,7 @@ amdgcn.module @test_case106_fp8_mfma_16x16x32 target = #amdgcn.target<gfx942> is
 //       CHECK:   amdgcn.vop1.v_nop
 //       CHECK:   amdgcn.vop1.v_nop
 //  CHECK-NEXT:   v_mov_b32_e32
-amdgcn.module @test_case106_cdna4_mfma_16x16x32_f16 target = #amdgcn.target<gfx950> isa = #amdgcn.isa<cdna4> {
+amdgcn.module @test_case106_cdna4_mfma_16x16x32_f16 target = #amdgcn.target<gfx950> {
   amdgcn.kernel @test_kernel attributes {normal_forms = [#amdgcn.all_registers_allocated]} {
     // A operands: 4 VGPRs [0:4)
     %a0 = amdgcn.alloca : !amdgcn.vgpr<0>
@@ -431,7 +431,7 @@ amdgcn.module @test_case106_cdna4_mfma_16x16x32_f16 target = #amdgcn.target<gfx9
 //       CHECK:   amdgcn.vop1.v_nop
 //       CHECK:   amdgcn.vop1.v_nop
 //  CHECK-NEXT:   v_mov_b32_e32
-amdgcn.module @test_case106_cdna4_mfma_16x16x32_bf16 target = #amdgcn.target<gfx950> isa = #amdgcn.isa<cdna4> {
+amdgcn.module @test_case106_cdna4_mfma_16x16x32_bf16 target = #amdgcn.target<gfx950> {
   amdgcn.kernel @test_kernel attributes {normal_forms = [#amdgcn.all_registers_allocated]} {
     // A operands: 4 VGPRs [0:4)
     %a0 = amdgcn.alloca : !amdgcn.vgpr<0>
@@ -487,7 +487,7 @@ amdgcn.module @test_case106_cdna4_mfma_16x16x32_bf16 target = #amdgcn.target<gfx
 //       CHECK:   amdgcn.vop1.v_nop
 //       CHECK:   amdgcn.vop1.v_nop
 //  CHECK-NEXT:   v_mov_b32_e32
-amdgcn.module @test_case106_cdna4_mfma_32x32x16_bf16 target = #amdgcn.target<gfx950> isa = #amdgcn.isa<cdna4> {
+amdgcn.module @test_case106_cdna4_mfma_32x32x16_bf16 target = #amdgcn.target<gfx950> {
   amdgcn.kernel @test_kernel attributes {normal_forms = [#amdgcn.all_registers_allocated]} {
     // A operands: 4 VGPRs [0:4)
     %a0 = amdgcn.alloca : !amdgcn.vgpr<0>
@@ -559,7 +559,7 @@ amdgcn.module @test_case106_cdna4_mfma_32x32x16_bf16 target = #amdgcn.target<gfx
 //       CHECK:   amdgcn.vop1.v_nop
 //       CHECK:   amdgcn.vop1.v_nop
 //  CHECK-NEXT:   v_mov_b32_e32
-amdgcn.module @test_case106_cdna4_mfma_32x32x16_f16 target = #amdgcn.target<gfx950> isa = #amdgcn.isa<cdna4> {
+amdgcn.module @test_case106_cdna4_mfma_32x32x16_f16 target = #amdgcn.target<gfx950> {
   amdgcn.kernel @test_kernel attributes {normal_forms = [#amdgcn.all_registers_allocated]} {
     // A operands: 4 VGPRs [0:4)
     %a0 = amdgcn.alloca : !amdgcn.vgpr<0>

--- a/test/Dialect/AMDGCN/Transforms/backend-pipeline.mlir
+++ b/test/Dialect/AMDGCN/Transforms/backend-pipeline.mlir
@@ -8,7 +8,7 @@
 // CHECK:         test_inst ins %[[V0]], %[[V1]]
 // CHECK-NOT:     alloca : !amdgcn.vgpr{{$}}
 // CHECK-NOT:     amdgcn.wait
-amdgcn.module @test_two_vgpr target = <gfx942> isa = <cdna3> {
+amdgcn.module @test_two_vgpr target = <gfx942> {
   amdgcn.kernel @two_vgpr_alloc {
     %a = amdgcn.alloca : !amdgcn.vgpr
     %b = amdgcn.alloca : !amdgcn.vgpr
@@ -34,7 +34,7 @@ amdgcn.module @test_two_vgpr target = <gfx942> isa = <cdna3> {
 // CHECK-NOT:     amdgcn.wait
 // CHECK-NOT:     alloca : !amdgcn.vgpr{{$}}
 // CHECK-NOT:     load_arg
-amdgcn.module @test_load_store target = <gfx942> isa = <cdna3> {
+amdgcn.module @test_load_store target = <gfx942> {
   amdgcn.kernel @load_then_store arguments <[
       #amdgcn.buffer_arg<address_space = generic, access = read_only>,
       #amdgcn.buffer_arg<address_space = generic>

--- a/test/Dialect/AMDGCN/Transforms/chained-select-dps-violation.mlir
+++ b/test/Dialect/AMDGCN/Transforms/chained-select-dps-violation.mlir
@@ -17,7 +17,7 @@
 // CHECK:   lsir.select %{{[0-9]+}},
 // CHECK:   test_inst ins %{{[0-9]+}} : (!amdgcn.sgpr<{{[0-9]+}}>)
 // CHECK:   cf.cond_br %{{.*}}, ^bb1, ^bb2
-amdgcn.module @chained_select target = <gfx942> isa = <cdna3> {
+amdgcn.module @chained_select target = <gfx942> {
   kernel @chained_select_loop_3_way_buffer_mux {
     %c0_i32 = arith.constant 0 : i32
     %c1_i32 = arith.constant 1 : i32

--- a/test/Dialect/AMDGCN/Transforms/expand-md-ops-nf.mlir
+++ b/test/Dialect/AMDGCN/Transforms/expand-md-ops-nf.mlir
@@ -8,7 +8,7 @@
 
 // CHECK: kernel @k
 // CHECK-SAME: attributes {{{.*}}normal_forms = [#amdgcn.no_metadata_ops]
-amdgcn.module @mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @mod target = #amdgcn.target<gfx942> {
   amdgcn.kernel @k attributes {normal_forms = [#amdgcn.no_metadata_ops]} {
   ^bb0:
     %0 = amdgcn.alloca : !amdgcn.vgpr<3>

--- a/test/Dialect/AMDGCN/Transforms/expand-ops-idempotent.mlir
+++ b/test/Dialect/AMDGCN/Transforms/expand-ops-idempotent.mlir
@@ -5,7 +5,7 @@
 // workitem_id_mode) is only modified when the corresponding ops are present,
 // so the second run (with all ops already expanded) preserves everything.
 
-amdgcn.module @idempotent_test target = <gfx942> isa = <cdna3> {
+amdgcn.module @idempotent_test target = <gfx942> {
 
 // block_id x + y + z: workgroup_id enables must survive second run.
 // CHECK-LABEL: kernel @bid_xyz

--- a/test/Dialect/AMDGCN/Transforms/expand-ops-unpacked-tid.mlir
+++ b/test/Dialect/AMDGCN/Transforms/expand-ops-unpacked-tid.mlir
@@ -6,7 +6,7 @@
 // This path is selected by force-unpacked-tid=true or by targeting an ISA
 // without FeaturePackedTID.
 
-amdgcn.module @unpacked_tid_test target = <gfx942> isa = <cdna3> {
+amdgcn.module @unpacked_tid_test target = <gfx942> {
 
 // Thread X only (unpacked): X comes directly from VGPR0.
 // Same as packed when only X is used (no masking needed in either case).

--- a/test/Dialect/AMDGCN/Transforms/expand-ops.mlir
+++ b/test/Dialect/AMDGCN/Transforms/expand-ops.mlir
@@ -1,6 +1,6 @@
 // RUN: aster-opt %s --pass-pipeline="builtin.module(amdgcn.module(amdgcn.kernel(aster-amdgcn-expand-md-ops, aster-hoist-ops, canonicalize)))" | FileCheck %s
 
-amdgcn.module @kernel_with_ptr target = <gfx940> isa = <cdna3> {
+amdgcn.module @kernel_with_ptr target = <gfx940> {
 // CHECK-LABEL: kernel @kernel_ptr arguments <[#amdgcn.buffer_arg<address_space = generic, access = write_only>, #amdgcn.buffer_arg<address_space = private, access = read_only, flags = const|volatile>, #amdgcn.buffer_arg<address_space = generic, type = !ptr.ptr<#ptr.generic_space>>]> attributes {enable_workgroup_id_x = false{{.*}}} {
 // CHECK-DAG:     %[[CONSTANT_0:.*]] = arith.constant 16 : i32
 // CHECK-DAG:     %[[CONSTANT_1:.*]] = arith.constant 8 : i32

--- a/test/Dialect/AMDGCN/Transforms/func-to-kernel-asm.mlir
+++ b/test/Dialect/AMDGCN/Transforms/func-to-kernel-asm.mlir
@@ -12,7 +12,7 @@
 //   ASM:        s_endpgm
 
 module attributes {dlti.dl_spec = #dlti.dl_spec<!ptr.ptr<#amdgcn.addr_space<local, read_write>> = #ptr.spec<size = 32, abi = 32, preferred = 32>, !ptr.ptr<#amdgcn.addr_space<global, read_write>> = #ptr.spec<size = 64, abi = 64, preferred = 64>>} {
-  amdgcn.module @m target = <gfx942> isa = <cdna3> attributes {normal_forms = [#amdgcn.no_reg_cast_ops]} {
+  amdgcn.module @m target = <gfx942> attributes {normal_forms = [#amdgcn.no_reg_cast_ops]} {
     kernel @copy_kernel arguments <[#amdgcn.buffer_arg<type = !ptr.ptr<#ptr.generic_space>>, #amdgcn.buffer_arg<type = !ptr.ptr<#ptr.generic_space>>, #amdgcn.block_dim_arg<x>, #amdgcn.block_dim_arg<y>, #amdgcn.block_dim_arg<z>, #amdgcn.grid_dim_arg<x>, #amdgcn.grid_dim_arg<y>, #amdgcn.grid_dim_arg<z>]> {
       %0 = load_arg 1 : !amdgcn.sgpr<[? + 2]>
       %1 = load_arg 0 : !amdgcn.sgpr<[? + 2]>

--- a/test/Dialect/AMDGCN/Transforms/legalize-cf.mlir
+++ b/test/Dialect/AMDGCN/Transforms/legalize-cf.mlir
@@ -11,7 +11,7 @@
 // CHECK:         end_kernel
 // CHECK:       ^bb2:
 // CHECK:         end_kernel
-amdgcn.module @test_slt target = <gfx942> isa = <cdna3> {
+amdgcn.module @test_slt target = <gfx942> {
   amdgcn.kernel @test_cond_branch_slt {
     %c0_i32 = arith.constant 0 : i32
     %c10_i32 = arith.constant 10 : i32
@@ -34,7 +34,7 @@ amdgcn.module @test_slt target = <gfx942> isa = <cdna3> {
 // CHECK:         branch s_branch ^bb1
 // CHECK:       ^bb1:
 // CHECK:         end_kernel
-amdgcn.module @test_br target = <gfx942> isa = <cdna3> {
+amdgcn.module @test_br target = <gfx942> {
   amdgcn.kernel @test_unconditional_branch {
     cf.br ^bb1
   ^bb1:
@@ -62,7 +62,7 @@ amdgcn.module @test_br target = <gfx942> isa = <cdna3> {
 //       CHECK:     cbranch s_cbranch_scc1 %{{.*}} ^bb1 fallthrough(^bb2)
 //       CHECK:   ^bb2:
 //       CHECK:     end_kernel
-amdgcn.module @ds_kernels target = <gfx942> isa = <cdna3> {
+amdgcn.module @ds_kernels target = <gfx942> {
 
   amdgcn.kernel @test_cf_cond_br_lsir_cmpi arguments <[
         #amdgcn.buffer_arg<address_space = generic, access = read_only>,
@@ -122,7 +122,7 @@ amdgcn.module @ds_kernels target = <gfx942> isa = <cdna3> {
 // The range should NOT appear as a block argument after legalization
 // Instead, values should flow through allocas and be reconstructed at block entry
 // CHECK-LABEL: kernel @test_br_vgpr_range_simple
-amdgcn.module @test_br_vgpr_range target = <gfx942> isa = <cdna3> {
+amdgcn.module @test_br_vgpr_range target = <gfx942> {
   amdgcn.kernel @test_br_vgpr_range_simple {
     // Allocate constituent registers - verify they appear in order
     // CHECK:       %[[V0:.*]] = alloca : !amdgcn.vgpr<0>
@@ -178,7 +178,7 @@ amdgcn.module @test_br_vgpr_range target = <gfx942> isa = <cdna3> {
 // This is the real-world use case: 4-register accumulator passed through iterations
 // Verifies range decomposition in backedge and reconstruction at loop header
 // CHECK-LABEL: kernel @test_loop_vgpr_range_carried
-amdgcn.module @test_loop target = <gfx942> isa = <cdna3> {
+amdgcn.module @test_loop target = <gfx942> {
   amdgcn.kernel @test_loop_vgpr_range_carried {
     // Constants
     %c0_i32 = arith.constant 0 : i32
@@ -282,7 +282,7 @@ amdgcn.module @test_loop target = <gfx942> isa = <cdna3> {
 // CHECK:         cmpi s_cmp_eq_i32 outs %[[SCC]] ins %[[A]], %[[B]]
 // CHECK:         sop2 s_cselect_b32 outs %{{.*}} ins
 // CHECK:         end_kernel
-amdgcn.module @test_select_i1_mod target = <gfx942> isa = <cdna3> {
+amdgcn.module @test_select_i1_mod target = <gfx942> {
   amdgcn.kernel @test_select_i1 {
     %c0 = arith.constant 0 : i32
     %c10 = arith.constant 10 : i32
@@ -314,7 +314,7 @@ amdgcn.module @test_select_i1_mod target = <gfx942> isa = <cdna3> {
 // CHECK:         sop2 s_cselect_b32
 // CHECK:         sop2 s_cselect_b32
 // CHECK:         end_kernel
-amdgcn.module @test_select_fanout_mod target = <gfx942> isa = <cdna3> {
+amdgcn.module @test_select_fanout_mod target = <gfx942> {
   amdgcn.kernel @test_select_fanout {
     %c0 = arith.constant 0 : i32
     %c10 = arith.constant 10 : i32
@@ -352,7 +352,7 @@ amdgcn.module @test_select_fanout_mod target = <gfx942> isa = <cdna3> {
 // CHECK:         end_kernel
 // CHECK:       ^bb2:
 // CHECK:         end_kernel
-amdgcn.module @test_mixed_mod target = <gfx942> isa = <cdna3> {
+amdgcn.module @test_mixed_mod target = <gfx942> {
   amdgcn.kernel @test_mixed_consumers {
     %c0 = arith.constant 0 : i32
     %c10 = arith.constant 10 : i32
@@ -385,7 +385,7 @@ amdgcn.module @test_mixed_mod target = <gfx942> isa = <cdna3> {
 // CHECK-NOT:     cmpi
 // CHECK:         sop2 s_cselect_b32
 // CHECK:         end_kernel
-amdgcn.module @test_sequential_mod target = <gfx942> isa = <cdna3> {
+amdgcn.module @test_sequential_mod target = <gfx942> {
   amdgcn.kernel @test_sequential_i1 {
     %c0 = arith.constant 0 : i32
     %c10 = arith.constant 10 : i32
@@ -418,7 +418,7 @@ amdgcn.module @test_sequential_mod target = <gfx942> isa = <cdna3> {
 // CHECK-NOT:     cmpi
 // CHECK:         sop2 s_cselect_b32
 // CHECK:         end_kernel
-amdgcn.module @test_dead_cmpi_mod target = <gfx942> isa = <cdna3> {
+amdgcn.module @test_dead_cmpi_mod target = <gfx942> {
   amdgcn.kernel @test_dead_cmpi_then_live {
     %c0 = arith.constant 0 : i32
     %c10 = arith.constant 10 : i32
@@ -443,7 +443,7 @@ amdgcn.module @test_dead_cmpi_mod target = <gfx942> isa = <cdna3> {
 // Overlapping i1 lifetimes: cmpi2 executes while cmpi1's result is still live.
 // This would silently clobber SCC.
 
-amdgcn.module @test_overlap_mod target = <gfx942> isa = <cdna3> {
+amdgcn.module @test_overlap_mod target = <gfx942> {
   amdgcn.kernel @test_overlapping_i1 {
     %c0 = arith.constant 0 : i32
     %c10 = arith.constant 10 : i32
@@ -467,7 +467,7 @@ amdgcn.module @test_overlap_mod target = <gfx942> isa = <cdna3> {
 // Cross-block i1 usage: flag register (SCC/VCC) is not preserved across
 // block boundaries (any branch clobbers it).
 
-amdgcn.module @test_crossblock_mod target = <gfx942> isa = <cdna3> {
+amdgcn.module @test_crossblock_mod target = <gfx942> {
   amdgcn.kernel @test_cross_block_i1 {
     %c0 = arith.constant 0 : i32
     %c10 = arith.constant 10 : i32
@@ -500,7 +500,7 @@ amdgcn.module @test_crossblock_mod target = <gfx942> isa = <cdna3> {
 // CHECK:         end_kernel
 // CHECK:       ^bb2:
 // CHECK:         end_kernel
-amdgcn.module @test_vopc_mod target = <gfx942> isa = <cdna3> {
+amdgcn.module @test_vopc_mod target = <gfx942> {
   amdgcn.kernel @test_vopc_cond_branch {
     %c0_i32 = arith.constant 0 : i32
     %v0 = alloca : !amdgcn.vgpr<0>
@@ -523,7 +523,7 @@ amdgcn.module @test_vopc_mod target = <gfx942> isa = <cdna3> {
 // CHECK-LABEL: kernel @test_vopc_operand_swap
 // CHECK:         cmpi v_cmp_gt_i32 outs %{{.*}} ins %{{.*}}, %{{.*}} : outs(!amdgcn.vcc<0>) ins(i32, !amdgcn.vgpr<0>)
 // CHECK:         cbranch s_cbranch_vccz %{{.*}} ^bb2 fallthrough(^bb1) : !amdgcn.vcc<0>
-amdgcn.module @test_vopc_swap_mod target = <gfx942> isa = <cdna3> {
+amdgcn.module @test_vopc_swap_mod target = <gfx942> {
   amdgcn.kernel @test_vopc_operand_swap {
     %c32_i32 = arith.constant 32 : i32
     %v0 = alloca : !amdgcn.vgpr<0>
@@ -544,7 +544,7 @@ amdgcn.module @test_vopc_swap_mod target = <gfx942> isa = <cdna3> {
 // CHECK-LABEL: kernel @test_vopc_two_vgprs
 // CHECK:         cmpi v_cmp_eq_i32 outs %{{.*}} ins %{{.*}}, %{{.*}} : outs(!amdgcn.vcc<0>) ins(!amdgcn.vgpr<0>, !amdgcn.vgpr<1>)
 // CHECK:         cbranch s_cbranch_vccz %{{.*}} ^bb2 fallthrough(^bb1) : !amdgcn.vcc<0>
-amdgcn.module @test_vopc_vv_mod target = <gfx942> isa = <cdna3> {
+amdgcn.module @test_vopc_vv_mod target = <gfx942> {
   amdgcn.kernel @test_vopc_two_vgprs {
     %v0 = alloca : !amdgcn.vgpr<0>
     %v1 = alloca : !amdgcn.vgpr<1>
@@ -568,7 +568,7 @@ amdgcn.module @test_vopc_vv_mod target = <gfx942> isa = <cdna3> {
 // CHECK:         cmpi v_cmp_eq_i32 outs %[[VCC]] ins %{{.*}}, %{{.*}} : outs(!amdgcn.vcc<0>) ins(!amdgcn.vgpr<0>, !amdgcn.vgpr<1>)
 // CHECK:         vop2 v_cndmask_b32 outs %{{.*}} ins %{{.*}}, %{{.*}} src2 = %[[VCC]]
 // CHECK:         end_kernel
-amdgcn.module @test_vopc_select_mod target = <gfx942> isa = <cdna3> {
+amdgcn.module @test_vopc_select_mod target = <gfx942> {
   amdgcn.kernel @test_vopc_select {
     %v0 = alloca : !amdgcn.vgpr<0>
     %v1 = alloca : !amdgcn.vgpr<1>
@@ -592,7 +592,7 @@ amdgcn.module @test_vopc_select_mod target = <gfx942> isa = <cdna3> {
 // CHECK:         vop1.vop1 <v_mov_b32_e32> %{{.*}}, %{{.*}} : (!amdgcn.vgpr<2>, i32) -> ()
 // CHECK:         vop2 v_cndmask_b32 outs %{{.*}} ins %{{.*}}, %{{.*}} src2 = %[[VCC]]
 // CHECK:         end_kernel
-amdgcn.module @test_vopc_select_imm_true_mod target = <gfx942> isa = <cdna3> {
+amdgcn.module @test_vopc_select_imm_true_mod target = <gfx942> {
   amdgcn.kernel @test_vopc_select_nonvgpr_true {
     %v0 = alloca : !amdgcn.vgpr<0>
     %v1 = alloca : !amdgcn.vgpr<1>
@@ -614,7 +614,7 @@ amdgcn.module @test_vopc_select_imm_true_mod target = <gfx942> isa = <cdna3> {
 // CHECK:         vop1.vop1 <v_mov_b32_e32> %{{.*}}, %{{.*}} : (!amdgcn.vgpr<2>, !amdgcn.sgpr<0>) -> ()
 // CHECK:         vop2 v_cndmask_b32 outs %{{.*}} ins %{{.*}}, %{{.*}} src2 = %[[VCC]]
 // CHECK:         end_kernel
-amdgcn.module @test_vopc_select_sgpr_true_mod target = <gfx942> isa = <cdna3> {
+amdgcn.module @test_vopc_select_sgpr_true_mod target = <gfx942> {
   amdgcn.kernel @test_vopc_select_sgpr_true {
     %v0 = alloca : !amdgcn.vgpr<0>
     %v1 = alloca : !amdgcn.vgpr<1>

--- a/test/Dialect/AMDGCN/Transforms/legalize-operands.mlir
+++ b/test/Dialect/AMDGCN/Transforms/legalize-operands.mlir
@@ -8,7 +8,7 @@
 // CHECK:         %[[OUT:.*]] = alloca : !amdgcn.sgpr
 // CHECK:         %[[MOV:.*]] = sop1 s_mov_b32 outs %[[OUT]] ins %{{.*}} : !amdgcn.sgpr, i32
 // CHECK:         lsir.select %{{.*}}, %{{.*}}, %[[MOV]], %{{.*}} : !amdgcn.sgpr, i1, !amdgcn.sgpr, i32
-amdgcn.module @dual_literal_mod target = <gfx942> isa = <cdna3> {
+amdgcn.module @dual_literal_mod target = <gfx942> {
   amdgcn.kernel @dual_literal_select {
     %c0 = arith.constant 0 : i32
     %c544 = arith.constant 544 : i32
@@ -30,7 +30,7 @@ amdgcn.module @dual_literal_mod target = <gfx942> isa = <cdna3> {
 // CHECK-LABEL: kernel @one_inline_select
 // CHECK-NOT:     sop1 s_mov_b32
 // CHECK:         lsir.select %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : !amdgcn.sgpr, i1, i32, i32
-amdgcn.module @one_inline_mod target = <gfx942> isa = <cdna3> {
+amdgcn.module @one_inline_mod target = <gfx942> {
   amdgcn.kernel @one_inline_select {
     %c0 = arith.constant 0 : i32
     %c10 = arith.constant 10 : i32
@@ -52,7 +52,7 @@ amdgcn.module @one_inline_mod target = <gfx942> isa = <cdna3> {
 // CHECK-LABEL: kernel @both_inline_select
 // CHECK-NOT:     sop1 s_mov_b32
 // CHECK:         lsir.select %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : !amdgcn.sgpr, i1, i32, i32
-amdgcn.module @both_inline_mod target = <gfx942> isa = <cdna3> {
+amdgcn.module @both_inline_mod target = <gfx942> {
   amdgcn.kernel @both_inline_select {
     %c0 = arith.constant 0 : i32
     %c10 = arith.constant 10 : i32
@@ -75,7 +75,7 @@ amdgcn.module @both_inline_mod target = <gfx942> isa = <cdna3> {
 // CHECK:         %[[A:.*]] = sop1 s_mov_b32
 // CHECK:         %[[B:.*]] = sop1 s_mov_b32
 // CHECK:         lsir.select %{{.*}}, %{{.*}}, %[[A]], %[[B]] : !amdgcn.sgpr, i1, !amdgcn.sgpr, !amdgcn.sgpr
-amdgcn.module @non_constant_mod target = <gfx942> isa = <cdna3> {
+amdgcn.module @non_constant_mod target = <gfx942> {
   amdgcn.kernel @non_constant_select {
     %c0 = arith.constant 0 : i32
     %s0 = alloca : !amdgcn.sgpr
@@ -98,7 +98,7 @@ amdgcn.module @non_constant_mod target = <gfx942> isa = <cdna3> {
 // CHECK-LABEL: kernel @boundary_inline_select
 // CHECK-NOT:     sop1 s_mov_b32
 // CHECK:         lsir.select {{.*}} : !amdgcn.sgpr, i1, i32, i32
-amdgcn.module @boundary_inline_mod target = <gfx942> isa = <cdna3> {
+amdgcn.module @boundary_inline_mod target = <gfx942> {
   amdgcn.kernel @boundary_inline_select {
     %c0 = arith.constant 0 : i32
     %cn16 = arith.constant -16 : i32
@@ -122,7 +122,7 @@ amdgcn.module @boundary_inline_mod target = <gfx942> isa = <cdna3> {
 // CHECK:         %[[OUT:.*]] = alloca : !amdgcn.sgpr
 // CHECK:         sop1 s_mov_b32 outs %[[OUT]]
 // CHECK:         lsir.select {{.*}} : !amdgcn.sgpr, i1, !amdgcn.sgpr, i32
-amdgcn.module @boundary_non_inline_mod target = <gfx942> isa = <cdna3> {
+amdgcn.module @boundary_non_inline_mod target = <gfx942> {
   amdgcn.kernel @boundary_non_inline_select {
     %c0 = arith.constant 0 : i32
     %cn17 = arith.constant -17 : i32

--- a/test/Dialect/AMDGCN/Transforms/ll-sched.mlir
+++ b/test/Dialect/AMDGCN/Transforms/ll-sched.mlir
@@ -6,7 +6,7 @@
 !s   = !amdgcn.sgpr
 !sx2 = !amdgcn.sgpr<[? + 2]>
 
-amdgcn.module @test target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @test target = #amdgcn.target<gfx942> {
 
   // Two independent cmpi+select chains must NOT be interleaved.
   // All i1 producers write to VCC/SCC, so overlapping lifetimes = clobber.

--- a/test/Dialect/AMDGCN/Transforms/preload-library-inline.mlir
+++ b/test/Dialect/AMDGCN/Transforms/preload-library-inline.mlir
@@ -13,7 +13,7 @@ module {
     }
   }
 
-  amdgcn.module @mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+  amdgcn.module @mod target = #amdgcn.target<gfx942> {
     func.func private @compute(index) -> index
 
     func.func @use_compute(%x: index) -> index {
@@ -38,7 +38,7 @@ module {
     }
   }
 
-  amdgcn.module @mod_with_own_def_takes_priority target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+  amdgcn.module @mod_with_own_def_takes_priority target = #amdgcn.target<gfx942> {
     func.func @helper(%x: index) -> index {
       %c99 = arith.constant 99 : index
       return %c99 : index

--- a/test/Dialect/AMDGCN/Transforms/preload-library.mlir
+++ b/test/Dialect/AMDGCN/Transforms/preload-library.mlir
@@ -13,7 +13,7 @@
 // CHECK:   return
 // CHECK: }
 // CHECK: func.func @test_kernel_func
-amdgcn.module @test_module target = #amdgcn.target<gfx940> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @test_module target = #amdgcn.target<gfx940> {
   // Declare library functions that will be imported.
   func.func private @wave_index(index) -> index
   func.func private @lane_index(index) -> index

--- a/test/Dialect/AMDGCN/Transforms/reg-alloc.mlir
+++ b/test/Dialect/AMDGCN/Transforms/reg-alloc.mlir
@@ -1,7 +1,7 @@
 // RUN: aster-opt %s --amdgcn-reg-alloc | FileCheck %s
 // RUN: aster-opt %s --amdgcn-reg-alloc="mode=full optimize=false" | FileCheck %s --check-prefix=CHECK-FULL
 
-amdgcn.module @reg_alloc target = <gfx942> isa = <cdna3> {
+amdgcn.module @reg_alloc target = <gfx942> {
   // CHECK-LABEL: reg_alloc
   // CHECK-FULL-LABEL: reg_alloc
   func.func private @rand() -> i1

--- a/test/Dialect/AMDGCN/Transforms/register-coloring.mlir
+++ b/test/Dialect/AMDGCN/Transforms/register-coloring.mlir
@@ -866,7 +866,7 @@ func.func @alloc_order() {
   return
 }
 
-amdgcn.module @reg_alloc target = <gfx942> isa = <cdna3> {
+amdgcn.module @reg_alloc target = <gfx942> {
   func.func private @rand() -> i1
   // CHECK-LABEL: coalescing_load
   // CHECK-NOT: v_mov

--- a/test/Dialect/AMDGCN/Transforms/set-normal-forms.mlir
+++ b/test/Dialect/AMDGCN/Transforms/set-normal-forms.mlir
@@ -17,7 +17,7 @@
 // BOTH:       kernel @k
 // BOTH-SAME:  normal_forms = [#amdgcn.no_scf_ops, #amdgcn.no_cf_branches]
 
-amdgcn.module @test target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @test target = #amdgcn.target<gfx942> {
   amdgcn.kernel @k {
   ^bb0:
     amdgcn.end_kernel

--- a/test/Dialect/AMDGCN/Transforms/to-amdgcn-func.mlir
+++ b/test/Dialect/AMDGCN/Transforms/to-amdgcn-func.mlir
@@ -13,7 +13,7 @@
 module attributes {dlti.dl_spec = #dlti.dl_spec<
   !ptr.ptr<#amdgcn.addr_space<global, read_write>> = #ptr.spec<size = 64, abi = 64, preferred = 64>,
   !ptr.ptr<#amdgcn.addr_space<local, read_write>> = #ptr.spec<size = 32, abi = 32, preferred = 32>>} {
-  amdgcn.module @m target = <gfx942> isa = <cdna3> {
+  amdgcn.module @m target = <gfx942> {
     func.func @memref_kernel_to_gpu_kernel(
       %a: memref<4xf32>,
       %b: memref<4xf32>

--- a/test/Dialect/AMDGCN/Transforms/to-amdgcn-nf.mlir
+++ b/test/Dialect/AMDGCN/Transforms/to-amdgcn-nf.mlir
@@ -5,7 +5,7 @@
 
 // CHECK-LABEL: amdgcn.module @sets_postcondition
 // CHECK-SAME: attributes {normal_forms = [#amdgcn.no_reg_cast_ops]}
-amdgcn.module @sets_postcondition target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @sets_postcondition target = #amdgcn.target<gfx942> {
   amdgcn.kernel @k {
   ^bb0:
     amdgcn.end_kernel

--- a/test/Dialect/AMDGCN/Transforms/to-amdgcn.mlir
+++ b/test/Dialect/AMDGCN/Transforms/to-amdgcn.mlir
@@ -1375,7 +1375,7 @@ func.func @ptr_add_sgpr_i64_all(%ptr: !amdgcn.sgpr<[? + 2]>, %d_off: !amdgcn.vgp
 // CHECK-LABEL: kernel @test_load
 // CHECK: load_arg 0 : !amdgcn.sgpr<[? + 2]>
 module attributes {dlti.dl_spec = #dlti.dl_spec<!ptr.ptr<#amdgcn.addr_space<local, read_write>> = #ptr.spec<size = 32, abi = 32, preferred = 32>, !ptr.ptr<#amdgcn.addr_space<global, read_write>> = #ptr.spec<size = 64, abi = 64, preferred = 64>>} {
-  amdgcn.module @test_module target = <gfx942> isa = <cdna3> {
+  amdgcn.module @test_module target = <gfx942> {
     func.func @test_load(%arg0: !amdgcn.sgpr<[? + 2]>) attributes {gpu.host_abi = {align = array<i32: 8>, size = array<i32: 8>, type = (!ptr.ptr<#amdgcn.addr_space<global, read_write>>) -> ()}, gpu.kernel} {
       %c10_i32 = arith.constant 10 : i32
       %c2_i32 = arith.constant 2 : i32

--- a/test/Dialect/AMDGCN/Transforms/to-int-arith-nf.mlir
+++ b/test/Dialect/AMDGCN/Transforms/to-int-arith-nf.mlir
@@ -5,7 +5,7 @@
 
 // CHECK: amdgcn.module @sets_postcondition
 // CHECK-SAME: attributes {normal_forms = [#amdgcn.no_affine_ops]}
-amdgcn.module @sets_postcondition target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @sets_postcondition target = #amdgcn.target<gfx942> {
   amdgcn.kernel @k {
   ^bb0:
     %0 = amdgcn.alloca : !amdgcn.vgpr<3>

--- a/test/Dialect/AMDGCN/effects.mlir
+++ b/test/Dialect/AMDGCN/effects.mlir
@@ -158,7 +158,7 @@ func.func @same_allocated_chained_mov() -> (!amdgcn.vgpr<1>, !amdgcn.vgpr<1>) {
 }
 
 
-amdgcn.module @mod target = <gfx942> isa = <cdna3> {
+amdgcn.module @mod target = <gfx942> {
 // CHECK-LABEL: kernel @gpu_copy_kernel_unchecked
 //      CHECK:    %[[R7:.*]] = alloca : !amdgcn.vgpr<10>
 // CHECK-NEXT:    %[[R8:.*]] = alloca : !amdgcn.vgpr<11>

--- a/test/Dialect/AMDGCN/inline-graph-region.mlir
+++ b/test/Dialect/AMDGCN/inline-graph-region.mlir
@@ -5,7 +5,7 @@
 // CHECK:         arith.addi %{{.*}}, %[[C1]] : index
 // CHECK-NOT:     call @helper
 module {
-  amdgcn.module @mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+  amdgcn.module @mod target = #amdgcn.target<gfx942> {
     func.func @helper(%x: index) -> index {
       %c1 = arith.constant 1 : index
       %r = arith.addi %x, %c1 : index
@@ -25,7 +25,7 @@ module {
 // CHECK-LABEL: kernel @kernel_main
 // CHECK-NOT:     call @kernel_helper
 module {
-  amdgcn.module @mod2 target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+  amdgcn.module @mod2 target = #amdgcn.target<gfx942> {
     func.func @kernel_helper(%x: index) -> index {
       %c2 = arith.constant 2 : index
       %r = arith.addi %x, %c2 : index

--- a/test/Dialect/AMDGCN/inline.mlir
+++ b/test/Dialect/AMDGCN/inline.mlir
@@ -45,7 +45,7 @@ func.func @ptr_caller(%base: !gptr, %off: i32) -> !vx2 {
 //===----------------------------------------------------------------------===//
 
 module {
-  amdgcn.module @kernel_module target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+  amdgcn.module @kernel_module target = #amdgcn.target<gfx942> {
     func.func @kernel_helper(%x: !amdgcn.vgpr<0>) -> !amdgcn.vgpr<1> {
       %0 = amdgcn.alloca : !amdgcn.vgpr<1>
       amdgcn.vop1.vop1 #amdgcn.inst<v_mov_b32_e32> %0, %x : (!amdgcn.vgpr<1>, !amdgcn.vgpr<0>) -> ()

--- a/test/Dialect/AMDGCN/ops.mlir
+++ b/test/Dialect/AMDGCN/ops.mlir
@@ -19,7 +19,7 @@ func.func @test_make_register_range_single() {
   return
 }
 
-amdgcn.module @test_module target = #amdgcn.target<gfx940> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @test_module target = #amdgcn.target<gfx940> {
   amdgcn.kernel @test_kernel {
     %0 = amdgcn.alloca : !amdgcn.vgpr
     amdgcn.end_kernel
@@ -30,14 +30,14 @@ amdgcn.module @test_module target = #amdgcn.target<gfx940> isa = #amdgcn.isa<cdn
   }
 }
 
-amdgcn.module @named_module target = #amdgcn.target<gfx940> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @named_module target = #amdgcn.target<gfx940> {
   amdgcn.kernel @kernel_in_named_module {
     amdgcn.end_kernel
   }
 }
 
 // Test kernel with ptr argument
-amdgcn.module @kernel_with_ptr target = #amdgcn.target<gfx940> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @kernel_with_ptr target = #amdgcn.target<gfx940> {
   amdgcn.kernel @kernel_ptr arguments <[
     #amdgcn.buffer_arg<address_space = generic, access = write_only>,
     #amdgcn.buffer_arg<address_space = private, access = read_only, flags = const | volatile>,
@@ -48,7 +48,7 @@ amdgcn.module @kernel_with_ptr target = #amdgcn.target<gfx940> isa = #amdgcn.isa
 }
 
 // Test kernel with by value argument
-amdgcn.module @kernel_with_int target = #amdgcn.target<gfx940> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @kernel_with_int target = #amdgcn.target<gfx940> {
   amdgcn.kernel @kernel_by_val arguments <[
     #amdgcn.by_val_arg<size = 4, name = "int_arg", type = i32>,
     #amdgcn.by_val_arg<size = 8, alignment = 8, name = "long_arg", type = i64>
@@ -58,7 +58,7 @@ amdgcn.module @kernel_with_int target = #amdgcn.target<gfx940> isa = #amdgcn.isa
 }
 
 // Test gfx950/cdna4 module
-amdgcn.module @cdna4_module target = #amdgcn.target<gfx950> isa = #amdgcn.isa<cdna4> {
+amdgcn.module @cdna4_module target = #amdgcn.target<gfx950> {
   amdgcn.kernel @cdna4_kernel {
     amdgcn.end_kernel
   }

--- a/test/Dialect/LSIR/Transforms/codegen-cf.mlir
+++ b/test/Dialect/LSIR/Transforms/codegen-cf.mlir
@@ -28,7 +28,7 @@
 // CHECK:         ^bb2:
 // CHECK:           end_kernel
 
-amdgcn.module @test_uniform_loop target = <gfx942> isa = <cdna3> {
+amdgcn.module @test_uniform_loop target = <gfx942> {
   kernel @test_uniform_loop arguments <[#amdgcn.buffer_arg<address_space = generic, access = read_only>, #amdgcn.buffer_arg<address_space = generic>]> {
     %c0_i32 = arith.constant 0 : i32
     %c1_i32 = arith.constant 1 : i32
@@ -80,7 +80,7 @@ amdgcn.module @test_uniform_loop target = <gfx942> isa = <cdna3> {
 // CHECK:         ^bb2:
 // CHECK:           end_kernel
 
-amdgcn.module @test_uniform_loop_with_load target = <gfx942> isa = <cdna3> {
+amdgcn.module @test_uniform_loop_with_load target = <gfx942> {
   kernel @test_uniform_loop_with_load arguments <[#amdgcn.buffer_arg<address_space = generic, access = read_only>, #amdgcn.buffer_arg<address_space = generic>]> {
     %c2_i32 = arith.constant 2 : i32
     %c1_i32 = arith.constant 1 : i32
@@ -125,7 +125,7 @@ amdgcn.module @test_uniform_loop_with_load target = <gfx942> isa = <cdna3> {
 // CHECK:           lsir.select %[[ALLOCA]], %[[CMP]], %{{.*}}, %{{.*}} : !amdgcn.sgpr, i1, i32, i32
 // CHECK-NOT:       unrealized_conversion_cast
 
-amdgcn.module @test_select_i1 target = <gfx942> isa = <cdna3> {
+amdgcn.module @test_select_i1 target = <gfx942> {
   kernel @test_select_i1 arguments <[#amdgcn.buffer_arg<address_space = generic, access = read_only>, #amdgcn.buffer_arg<address_space = generic>]> {
     %c0_i32 = arith.constant 0 : i32
     %c42_i32 = arith.constant 42 : i32

--- a/test/Dialect/LSIR/Transforms/codegen-func-cf.mlir
+++ b/test/Dialect/LSIR/Transforms/codegen-func-cf.mlir
@@ -7,7 +7,7 @@
 // CHECK:     cf.cond_br %{{.*}}, ^bb1(%{{.*}} : !amdgcn.sgpr), ^bb2
 // CHECK:   ^bb2:
 
-amdgcn.module @test target = <gfx942> isa = <cdna3> {
+amdgcn.module @test target = <gfx942> {
   func.func @loop_func(%arg0: i32, %n: i32) {
     %c0 = arith.constant 0 : i32
     %c1 = arith.constant 1 : i32

--- a/test/Dialect/NormalForm/amdgcn-no-value-semantic-registers.mlir
+++ b/test/Dialect/NormalForm/amdgcn-no-value-semantic-registers.mlir
@@ -40,7 +40,7 @@ normalform.module @value_in_func_result [#amdgcn.no_value_semantic_registers] {
 // -----
 
 // by_val_arg type is ABI metadata, not a value-semantic register in the body
-amdgcn.module @by_val_arg_metadata target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @by_val_arg_metadata target = #amdgcn.target<gfx942> {
   amdgcn.kernel @test arguments <[
     #amdgcn.by_val_arg<size = 4, type = !amdgcn.vgpr>
   ]> attributes {

--- a/test/Target/ASM/accvgpr.mlir
+++ b/test/Target/ASM/accvgpr.mlir
@@ -49,7 +49,7 @@
 // CHECK:       .amdhsa_accum_offset
 // CHECK:       .agpr_count:
 
-amdgcn.module @agpr_asm_mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @agpr_asm_mod target = #amdgcn.target<gfx942> {
 
   func.func private @alloc_vgpr() -> !amdgcn.vgpr
   func.func private @alloc_agprx1() -> !amdgcn.agpr

--- a/test/Target/ASM/arith-div-by-constant.mlir
+++ b/test/Target/ASM/arith-div-by-constant.mlir
@@ -8,7 +8,7 @@
 // RUN:     asm=sys.stdin.read(); r=compile_to_hsaco(asm); \
 // RUN:     assert r is not None, 'HSACO assembly failed'"
 
-amdgcn.module @arith_div_by_const target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @arith_div_by_const target = #amdgcn.target<gfx942> {
 
   amdgcn.kernel @sdiv_by_3 {
     %n = amdgcn.alloca : !amdgcn.vgpr

--- a/test/Target/ASM/branch.mlir
+++ b/test/Target/ASM/branch.mlir
@@ -83,7 +83,7 @@
 // CHECK:  - 2
 // CHECK:  ---
 // CHECK:.end_amdgpu_metadata
-amdgcn.module @mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @mod target = #amdgcn.target<gfx942> {
   amdgcn.kernel @test_branch {
   ^entry:
     amdgcn.branch s_branch ^next

--- a/test/Target/ASM/buffer-ops.mlir
+++ b/test/Target/ASM/buffer-ops.mlir
@@ -16,7 +16,7 @@
 // CHECK:    buffer_store_dwordx3 v[4:6], v0, s[0:3], s4 offen offset: 96
 // CHECK:    buffer_store_dwordx4 v[8:11], v0, s[0:3], s4 offen offset: 128
 // CHECK:    s_endpgm
-amdgcn.module @buffer_test target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @buffer_test target = #amdgcn.target<gfx942> {
   amdgcn.kernel @test_buffer_load_store {
     // Buffer descriptor (4 SGPRs, s[0:3])
     %s0 = amdgcn.alloca : !amdgcn.sgpr<0>
@@ -112,7 +112,7 @@ amdgcn.module @buffer_test target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdn
 // CHECK:    buffer_store_dwordx3 v[4:6], v0, s[0:3], s4 idxen offset: 96
 // CHECK:    buffer_store_dwordx4 v[8:11], v0, s[0:3], s4 idxen offset: 128
 // CHECK:    s_endpgm
-amdgcn.module @buffer_idxen_test target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @buffer_idxen_test target = #amdgcn.target<gfx942> {
   amdgcn.kernel @test_buffer_idxen {
     %s0 = amdgcn.alloca : !amdgcn.sgpr<0>
     %s1 = amdgcn.alloca : !amdgcn.sgpr<1>

--- a/test/Target/ASM/by-val-store-asm.mlir
+++ b/test/Target/ASM/by-val-store-asm.mlir
@@ -34,7 +34,7 @@
 // CHECK:             .size: 8
 // CHECK:             .value_kind: global_buffer
 
-amdgcn.module @by_val_store_mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @by_val_store_mod target = #amdgcn.target<gfx942> {
   amdgcn.kernel @by_val_store arguments <[
     #amdgcn.by_val_arg<size = 4, alignment = 4, type = i32>,
     #amdgcn.buffer_arg<address_space = generic, access = write_only>

--- a/test/Target/ASM/cbranch.mlir
+++ b/test/Target/ASM/cbranch.mlir
@@ -26,7 +26,7 @@
 // CHECK:.AMDGCN_BB_1:
 // CHECK:  s_endpgm
 
-amdgcn.module @mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @mod target = #amdgcn.target<gfx942> {
   amdgcn.kernel @test_cbranch_scc1 {
   ^entry:
     %s2 = amdgcn.alloca : !amdgcn.sgpr<2>

--- a/test/Target/ASM/cmp-e64.mlir
+++ b/test/Target/ASM/cmp-e64.mlir
@@ -13,7 +13,7 @@
 // CHECK:       v_cmp_eq_i32_e64 s[0:1], v0, v1
 // CHECK:       s_endpgm
 
-amdgcn.module @cmp_e64_mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @cmp_e64_mod target = #amdgcn.target<gfx942> {
 
   amdgcn.kernel @test_vcmp_eq_i32_e64 {
   ^entry:

--- a/test/Target/ASM/ds-perm.mlir
+++ b/test/Target/ASM/ds-perm.mlir
@@ -22,7 +22,7 @@
 // CHECK:       ds_bpermute_b32 v2, v0, v1 offset: 8
 // CHECK:       s_endpgm
 
-amdgcn.module @perm_mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @perm_mod target = #amdgcn.target<gfx942> {
 
   amdgcn.kernel @test_permute {
   ^entry:

--- a/test/Target/ASM/g2s-load-lds.mlir
+++ b/test/Target/ASM/g2s-load-lds.mlir
@@ -15,7 +15,7 @@
 // CHECK:       buffer_load_dwordx4 v0, s[0:3], s4 offen lds offset: 64
 // CHECK:       s_endpgm
 
-amdgcn.module @g2s_mod target = #amdgcn.target<gfx950> isa = #amdgcn.isa<cdna4> {
+amdgcn.module @g2s_mod target = #amdgcn.target<gfx950> {
 
   amdgcn.kernel @test_g2s_dword {
   ^entry:

--- a/test/Target/ASM/loops.mlir
+++ b/test/Target/ASM/loops.mlir
@@ -37,7 +37,7 @@
 // CHECK:.AMDGCN_BB_2:
 // CHECK:  s_endpgm
 
-amdgcn.module @mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @mod target = #amdgcn.target<gfx942> {
   // Test 1: Simple Conditional (If-Then-Else) with trap
   // Pattern: if (5 <= 4) { trap(); } else { end; }
   amdgcn.kernel @test_if_then_else {

--- a/test/Target/ASM/mfma-32x32.mlir
+++ b/test/Target/ASM/mfma-32x32.mlir
@@ -18,7 +18,7 @@
 // CHECK:       global_store_dwordx4
 // CHECK:       s_endpgm
 
-amdgcn.module @mfma_32x32_mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @mfma_32x32_mod target = #amdgcn.target<gfx942> {
 
   // From register-init.mlir (resolved by --amdgcn-preload-library)
   func.func private @alloc_vgpr() -> !amdgcn.vgpr

--- a/test/Target/ASM/mfma-cdna4-doubled-k.mlir
+++ b/test/Target/ASM/mfma-cdna4-doubled-k.mlir
@@ -28,7 +28,7 @@
 // CHECK:       global_store_dwordx4
 // CHECK:       s_endpgm
 
-amdgcn.module @cdna4_doubled_k_mod target = #amdgcn.target<gfx950> isa = #amdgcn.isa<cdna4> {
+amdgcn.module @cdna4_doubled_k_mod target = #amdgcn.target<gfx950> {
 
   func.func private @alloc_vgpr() -> !amdgcn.vgpr
   func.func private @alloc_vgprx4() -> (!amdgcn.vgpr<[? + 4]>)

--- a/test/Target/ASM/mfma-f8f6f4.mlir
+++ b/test/Target/ASM/mfma-f8f6f4.mlir
@@ -38,7 +38,7 @@
 // CHECK:       global_store_dwordx4
 // CHECK:       s_endpgm
 
-amdgcn.module @mfma_f8f6f4_mod target = #amdgcn.target<gfx950> isa = #amdgcn.isa<cdna4> {
+amdgcn.module @mfma_f8f6f4_mod target = #amdgcn.target<gfx950> {
 
   // From register-init.mlir (resolved by --amdgcn-preload-library)
   func.func private @alloc_vgpr() -> !amdgcn.vgpr

--- a/test/Target/ASM/mfma-fp8.mlir
+++ b/test/Target/ASM/mfma-fp8.mlir
@@ -33,7 +33,7 @@
 // CHECK:       global_store_dwordx4
 // CHECK:       s_endpgm
 
-amdgcn.module @mfma_fp8_mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @mfma_fp8_mod target = #amdgcn.target<gfx942> {
 
   // From register-init.mlir (resolved by --amdgcn-preload-library)
   func.func private @alloc_vgpr() -> !amdgcn.vgpr

--- a/test/Target/ASM/module-gfx942.mlir
+++ b/test/Target/ASM/module-gfx942.mlir
@@ -105,7 +105,7 @@
 // CHECK:    - 2
 // CHECK:  ---
 // CHECK:    .end_amdgpu_metadata
-amdgcn.module @mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @mod target = #amdgcn.target<gfx942> {
   amdgcn.kernel @test_args arguments <[
     #amdgcn.by_val_arg<size=4>,
     #amdgcn.by_val_arg<size=12, alignment=16>,

--- a/test/Target/ASM/module-gfx950.mlir
+++ b/test/Target/ASM/module-gfx950.mlir
@@ -78,7 +78,7 @@
 // CHECK:    - 2
 // CHECK:  ---
 // CHECK:    .end_amdgpu_metadata
-amdgcn.module @gfx950_mod target = #amdgcn.target<gfx950> isa = #amdgcn.isa<cdna4> {
+amdgcn.module @gfx950_mod target = #amdgcn.target<gfx950> {
   amdgcn.kernel @simple_kernel {
     %0 = amdgcn.alloca : !amdgcn.vgpr<2>
     %c42 = arith.constant 42 : i32

--- a/test/Target/ASM/s-mov-m0.mlir
+++ b/test/Target/ASM/s-mov-m0.mlir
@@ -13,7 +13,7 @@
 // CHECK:       s_mov_b32 m0, s0
 // CHECK:       s_endpgm
 
-amdgcn.module @m0_mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @m0_mod target = #amdgcn.target<gfx942> {
   amdgcn.kernel @test_s_mov_m0_imm {
   ^entry:
     %m0 = amdgcn.alloca : !amdgcn.m0<0>

--- a/test/Target/ASM/set-mfma-priority-asm.mlir
+++ b/test/Target/ASM/set-mfma-priority-asm.mlir
@@ -6,7 +6,7 @@
 // CHECK-NEXT: s_setprio 0
 // CHECK-NEXT: s_endpgm
 
-amdgcn.module @test_mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @test_mod target = #amdgcn.target<gfx942> {
   amdgcn.kernel @test_setprio_asm arguments <[
     #amdgcn.buffer_arg<address_space = generic, access = read_only>
   ]> attributes {block_dims = array<i32: 64, 1, 1>} {

--- a/test/Target/ASM/sopp-setprio-sleep-wakeup-asm.mlir
+++ b/test/Target/ASM/sopp-setprio-sleep-wakeup-asm.mlir
@@ -17,7 +17,7 @@
 // CHECK-NEXT: s_wakeup
 // CHECK: s_endpgm
 
-amdgcn.module @test_mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @test_mod target = #amdgcn.target<gfx942> {
   amdgcn.kernel @test_setprio_asm arguments <[
     #amdgcn.buffer_arg<address_space = generic, access = read_only>
   ]> attributes {block_dims = array<i32: 64, 1, 1>} {

--- a/test/Target/ASM/vop3.mlir
+++ b/test/Target/ASM/vop3.mlir
@@ -1,6 +1,6 @@
 // RUN: aster-translate %s --mlir-to-asm | FileCheck %s
 
-amdgcn.module @vop3 target = <gfx942> isa = <cdna3> {
+amdgcn.module @vop3 target = <gfx942> {
   // CHECK-LABEL: .globl v_lshl_add_u64
   kernel @v_lshl_add_u64 {
     %0 = alloca : !amdgcn.vgpr<0>

--- a/test/Target/ASM/vopc-branch.mlir
+++ b/test/Target/ASM/vopc-branch.mlir
@@ -27,7 +27,7 @@
 // CHECK:     .AMDGCN_BB_1:
 // CHECK:       s_endpgm
 
-amdgcn.module @vopc_branch_mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @vopc_branch_mod target = #amdgcn.target<gfx942> {
 
   // Test 1: imm < VGPR, branch on VCC non-zero
   amdgcn.kernel @test_vcmp_lt_i32_vccnz {

--- a/test/Target/ASM/vopc-cndmask.mlir
+++ b/test/Target/ASM/vopc-cndmask.mlir
@@ -14,7 +14,7 @@
 // CHECK:       v_cndmask_b32 v2, v0, v2, vcc
 // CHECK:       s_endpgm
 
-amdgcn.module @vopc_cndmask_mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @vopc_cndmask_mod target = #amdgcn.target<gfx942> {
 
   amdgcn.kernel @test_vcndmask_vgpr_operands {
   ^entry:

--- a/test/Transforms/scf-pipeline-drain-fail.mlir
+++ b/test/Transforms/scf-pipeline-drain-fail.mlir
@@ -59,7 +59,7 @@
 #map8 = affine_map<()[s0, s1, s2, s3, s4] -> (s2 * 4 + ((s3 + s1 * s4) * s0) * 4 + ((s2 + (s3 + s1 * s4) * s0) floordiv 16) * 192 - (((s2 + (s3 + s1 * s4) * s0) floordiv 16) floordiv 4) * 1024 + 128)>
 #map9 = affine_map<()[s0, s1, s2, s3, s4] -> (s2 * 4 + ((s3 + s1 * s4) * s0) * 4 + ((s2 + (s3 + s1 * s4) * s0) floordiv 16) * 192 - (((s2 + (s3 + s1 * s4) * s0) floordiv 16) floordiv 4) * 1024 + 192)>
 module {
-  amdgcn.module @gemm_cdna4_mod target = <gfx950> isa = <cdna4> {
+  amdgcn.module @gemm_cdna4_mod target = <gfx950> {
     func.func private @_read_b(%arg0: index) -> (!aster_utils.any, !aster_utils.any, !amdgcn.read_token<shared>, !amdgcn.read_token<shared>) {
       %c48_i32 = arith.constant 48 : i32
       %c4_i32 = arith.constant 4 : i32

--- a/test/integration/buffer-copy-e2e.mlir
+++ b/test/integration/buffer-copy-e2e.mlir
@@ -37,7 +37,7 @@
 //       ASM:   buffer_load_dword
 //       ASM:   buffer_store_dword
 //       ASM:   s_endpgm
-amdgcn.module @buffer_copy_mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @buffer_copy_mod target = #amdgcn.target<gfx942> {
 
   // Load the three pointer args from the kernarg segment, then dereference
   // the params pointer to get the scalar values (num_records are byte counts).

--- a/test/integration/buffer-idxen-e2e.mlir
+++ b/test/integration/buffer-idxen-e2e.mlir
@@ -43,7 +43,7 @@
 //       ASM:   buffer_load_dword{{.*}}idxen
 //       ASM:   buffer_store_dword{{.*}}idxen
 //       ASM:   s_endpgm
-amdgcn.module @buffer_idxen_mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @buffer_idxen_mod target = #amdgcn.target<gfx942> {
 
   // Load kernel args: three pointers, then dereference params to get scalars.
   func.func private @load_kernargs()

--- a/test/integration/by-val-store-e2e.mlir
+++ b/test/integration/by-val-store-e2e.mlir
@@ -1,5 +1,5 @@
 // RUN: aster-opt %s --verify-roundtrip
-amdgcn.module @by_val_store_mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @by_val_store_mod target = #amdgcn.target<gfx942> {
   amdgcn.kernel @by_val_store arguments <[
     #amdgcn.by_val_arg<size = 4, alignment = 4, type = i32>,
     #amdgcn.buffer_arg<address_space = generic, access = write_only>

--- a/test/integration/conversion-pack-e2e.mlir
+++ b/test/integration/conversion-pack-e2e.mlir
@@ -68,7 +68,7 @@
 //       ASM:   v_cvt_pk_bf8_f32
 //       ASM:   s_endpgm
 
-amdgcn.module @conversion_pack_mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @conversion_pack_mod target = #amdgcn.target<gfx942> {
 
   func.func private @load_two_ptrs()
       -> (!amdgcn.sgpr<[? + 2]>, !amdgcn.sgpr<[? + 2]>) {

--- a/test/integration/ds-perm-e2e.mlir
+++ b/test/integration/ds-perm-e2e.mlir
@@ -12,7 +12,7 @@
 //   2. permute_bpermute_idempotent: bpermute(permute(data, addr), addr) = data.
 //      Same rotate addr for both steps. Result: output[i] = i.
 
-amdgcn.module @perm_e2e_mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @perm_e2e_mod target = #amdgcn.target<gfx942> {
 
   func.func private @load_output_ptr() -> !amdgcn.sgpr<[? + 2]> {
     %out_ptr = amdgcn.load_arg 0 : !amdgcn.sgpr<[? + 2]>

--- a/test/integration/g2s-load-lds-e2e.mlir
+++ b/test/integration/g2s-load-lds-e2e.mlir
@@ -32,7 +32,7 @@
 // CHECK:       global_store_dword
 // CHECK:       s_endpgm
 
-amdgcn.module @g2s_e2e_mod target = #amdgcn.target<gfx950> isa = #amdgcn.isa<cdna4> {
+amdgcn.module @g2s_e2e_mod target = #amdgcn.target<gfx950> {
 
   func.func private @alloc_vgpr() -> !amdgcn.vgpr
 

--- a/test/integration/mfma-32x32-e2e.mlir
+++ b/test/integration/mfma-32x32-e2e.mlir
@@ -22,7 +22,7 @@
 // CHECK:       global_store_dwordx4
 // CHECK:       s_endpgm
 
-amdgcn.module @mfma_32x32_e2e_mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @mfma_32x32_e2e_mod target = #amdgcn.target<gfx942> {
 
   func.func private @alloc_vgpr() -> !amdgcn.vgpr
   func.func private @alloc_vgprx2() -> (!amdgcn.vgpr<[? + 2]>)

--- a/test/integration/mfma-agpr-e2e.mlir
+++ b/test/integration/mfma-agpr-e2e.mlir
@@ -37,7 +37,7 @@
 
 // ASM: .agpr_count: 4
 
-amdgcn.module @agpr_mfma_mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @agpr_mfma_mod target = #amdgcn.target<gfx942> {
 
   // From register-init.mlir (resolved by --amdgcn-preload-library)
   func.func private @alloc_vgpr() -> !amdgcn.vgpr

--- a/test/integration/mfma-agpr-f16-e2e.mlir
+++ b/test/integration/mfma-agpr-f16-e2e.mlir
@@ -36,7 +36,7 @@
 
 // CHECK: .agpr_count:
 
-amdgcn.module @mfma_agpr_f16_mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @mfma_agpr_f16_mod target = #amdgcn.target<gfx942> {
 
   func.func private @alloc_vgpr() -> !amdgcn.vgpr
   func.func private @init_vgprx2(%cst: i32) -> (!amdgcn.vgpr<[? + 2]>)

--- a/test/integration/mfma-cdna4-doubled-k-e2e.mlir
+++ b/test/integration/mfma-cdna4-doubled-k-e2e.mlir
@@ -42,7 +42,7 @@
 // CHECK:       global_store_dwordx4
 // CHECK:       s_endpgm
 
-amdgcn.module @mfma_cdna4_doubled_k_mod target = #amdgcn.target<gfx950> isa = #amdgcn.isa<cdna4> {
+amdgcn.module @mfma_cdna4_doubled_k_mod target = #amdgcn.target<gfx950> {
 
   func.func private @alloc_vgpr() -> !amdgcn.vgpr
   func.func private @init_vgprx4(%cst: i32) -> (!amdgcn.vgpr<[? + 4]>)

--- a/test/integration/mfma-e2e.mlir
+++ b/test/integration/mfma-e2e.mlir
@@ -21,7 +21,7 @@
 
 // ASM-LABEL: compute_kernel:
 //       ASM:   s_load_dwordx2 s[2:3], s[0:1], 0
-amdgcn.module @mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @mod target = #amdgcn.target<gfx942> {
 
   // From register-init.mlir (resolved by --amdgcn-preload-library)
   func.func private @alloc_vgprx2() -> (!amdgcn.vgpr<[? + 2]>)

--- a/test/integration/mfma-f8f6f4-e2e.mlir
+++ b/test/integration/mfma-f8f6f4-e2e.mlir
@@ -31,7 +31,7 @@
 // CHECK:       global_store_dwordx4
 // CHECK:       s_endpgm
 
-amdgcn.module @mfma_f8f6f4_mod target = #amdgcn.target<gfx950> isa = #amdgcn.isa<cdna4> {
+amdgcn.module @mfma_f8f6f4_mod target = #amdgcn.target<gfx950> {
 
   // From register-init.mlir (resolved by --amdgcn-preload-library)
   func.func private @alloc_vgpr() -> !amdgcn.vgpr

--- a/test/integration/mfma-fp8-e2e.mlir
+++ b/test/integration/mfma-fp8-e2e.mlir
@@ -31,7 +31,7 @@
 // CHECK:       global_store_dwordx4
 // CHECK:       s_endpgm
 
-amdgcn.module @mfma_fp8_e2e_mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @mfma_fp8_e2e_mod target = #amdgcn.target<gfx942> {
 
   // From register-init.mlir (resolved by --amdgcn-preload-library)
   func.func private @alloc_vgpr() -> !amdgcn.vgpr

--- a/test/integration/mfma-to-global-store-scheduled-allocated-1x1x1.mlir
+++ b/test/integration/mfma-to-global-store-scheduled-allocated-1x1x1.mlir
@@ -44,7 +44,7 @@
 // CHECK:   global_store_dwordx4 [[tidx_times_16]], [[C]], [[C_ptr]]
 // CHECK:   s_endpgm
 
-amdgcn.module @kernel_module target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @kernel_module target = #amdgcn.target<gfx942> {
   // From register-init.mlir (resolved by --amdgcn-preload-library)
   func.func private @alloc_vgprx2() -> (!amdgcn.vgpr<[? + 2]>)
   func.func private @init_vgprx4(%cst: i32) -> (!amdgcn.vgpr<[? + 4]>)

--- a/test/integration/mfma-to-global-store-scheduled-allocated.mlir
+++ b/test/integration/mfma-to-global-store-scheduled-allocated.mlir
@@ -27,7 +27,7 @@
 //  CHECK-NEXT:   global_store_dwordx4 {{.*}}, [[AC3]], off
 //  CHECK-NEXT:   s_endpgm
 
-amdgcn.module @kernel_module target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @kernel_module target = #amdgcn.target<gfx942> {
   // Function taking indices and memrefs of register ranges
   func.func private @simple_mfma(
     %m: index,

--- a/test/integration/readfirstlane-e2e.mlir
+++ b/test/integration/readfirstlane-e2e.mlir
@@ -1,6 +1,6 @@
 // RUN: aster-opt %s --verify-roundtrip
 
-amdgcn.module @readfirstlane_mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @readfirstlane_mod target = #amdgcn.target<gfx942> {
 
   func.func private @load_output_ptr() -> !amdgcn.sgpr<[? + 2]> {
     %out_ptr = amdgcn.load_arg 0 : !amdgcn.sgpr<[? + 2]>

--- a/test/integration/sreg-roundtrip-e2e.mlir
+++ b/test/integration/sreg-roundtrip-e2e.mlir
@@ -6,7 +6,7 @@
 // Verifies the M0 -> SGPR -> VGPR -> global memory pipeline works end-to-end.
 // Each lane stores the constant 42 to its slot in the output buffer.
 
-amdgcn.module @m0_roundtrip_mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @m0_roundtrip_mod target = #amdgcn.target<gfx942> {
 
   func.func private @load_output_ptr() -> !amdgcn.sgpr<[? + 2]> {
     %out_ptr = amdgcn.load_arg 0 : !amdgcn.sgpr<[? + 2]>

--- a/test/integration/test_conversion_pack_e2e.py
+++ b/test/integration/test_conversion_pack_e2e.py
@@ -16,8 +16,8 @@ from aster.execution.helpers import compile_and_run
 from aster.test_pass_pipelines import TEST_SROA_PASS_PIPELINE
 
 TARGET_CONFIGS = [
-    ("gfx942", "cdna3"),
-    ("gfx950", "cdna4"),
+    "gfx942",
+    "gfx950",
 ]
 
 WAVEFRONT_SIZE = 64
@@ -25,18 +25,16 @@ TOTAL_LANES = 64
 MLIR_FILE = "conversion-pack-e2e.mlir"
 
 
-def _retarget(target, isa):
-    """Return a preprocess function that rewrites the MLIR target and ISA."""
+def _retarget(target):
+    """Return a preprocess function that rewrites the MLIR target."""
 
     def preprocess(mlir_src):
-        s = re.sub(r"#amdgcn\.target<\w+>", f"#amdgcn.target<{target}>", mlir_src)
-        s = re.sub(r"#amdgcn\.isa<\w+>", f"#amdgcn.isa<{isa}>", s)
-        return s
+        return re.sub(r"#amdgcn\.target<\w+>", f"#amdgcn.target<{target}>", mlir_src)
 
     return preprocess
 
 
-def _run(mcpu, isa, kernel_name, input_data, output_data, verify_fn):
+def _run(mcpu, kernel_name, input_data, output_data, verify_fn):
     compile_and_run(
         MLIR_FILE,
         kernel_name,
@@ -48,7 +46,7 @@ def _run(mcpu, isa, kernel_name, input_data, output_data, verify_fn):
         block_dim=(TOTAL_LANES, 1, 1),
         verify_fn=verify_fn,
         library_paths=[],
-        preprocess=_retarget(mcpu, isa),
+        preprocess=_retarget(mcpu),
     )
 
 
@@ -87,7 +85,7 @@ def bits_to_f32(bits):
 # BF8 E5M2: 1 sign + 5 exp + 2 mantissa, bias=15 (OCP) or 16 (FNUZ)
 # ---------------------------------------------------------------------------
 
-_ISA_IS_FNUZ = {"cdna3": True, "cdna4": False}
+_TARGET_IS_FNUZ = {"gfx940": True, "gfx942": True, "gfx950": False, "gfx1201": False}
 
 
 def f32_to_fp8_e4m3(val, fnuz=True):
@@ -255,11 +253,11 @@ def f32_to_bf8_e5m2(val, fnuz=True):
 # ===========================================================================
 
 
-@pytest.mark.parametrize("mcpu,isa", TARGET_CONFIGS, ids=[t for t, _ in TARGET_CONFIGS])
+@pytest.mark.parametrize("mcpu", TARGET_CONFIGS)
 class TestCvtF32F16:
     """v_cvt_f32_f16: read f16 bits from low 16 of dword, produce f32."""
 
-    def test_basic_values(self, mcpu, isa):
+    def test_basic_values(self, mcpu):
         # Store f16 bit patterns in the low 16 bits of each dword.
         # Values: 0.0, 1.0, -1.0, 0.5, 65504.0 (max f16), tiny subnormal
         test_f32_vals = [0.0, 1.0, -1.0, 0.5, 65504.0, 5.96046448e-08]
@@ -281,14 +279,14 @@ class TestCvtF32F16:
                     f"lane {i}: expected {expected}, got {result_f32[i]}"
                 )
 
-        _run(mcpu, isa, "cvt_f32_f16_kernel", [src], [dst], verify)
+        _run(mcpu, "cvt_f32_f16_kernel", [src], [dst], verify)
 
 
-@pytest.mark.parametrize("mcpu,isa", TARGET_CONFIGS, ids=[t for t, _ in TARGET_CONFIGS])
+@pytest.mark.parametrize("mcpu", TARGET_CONFIGS)
 class TestCvtF16F32:
     """v_cvt_f16_f32: read f32, produce f16 bits in low 16 of dword."""
 
-    def test_basic_values(self, mcpu, isa):
+    def test_basic_values(self, mcpu):
         test_vals = [0.0, 1.0, -1.0, 0.5, 65504.0, 0.333251953125]
         src = np.zeros(TOTAL_LANES, dtype=np.float32)
         for i, v in enumerate(test_vals):
@@ -310,14 +308,14 @@ class TestCvtF16F32:
                     f"got 0x{actual_low16:04X}"
                 )
 
-        _run(mcpu, isa, "cvt_f16_f32_kernel", [src.view(np.int32)], [dst], verify)
+        _run(mcpu, "cvt_f16_f32_kernel", [src.view(np.int32)], [dst], verify)
 
 
-@pytest.mark.parametrize("mcpu,isa", TARGET_CONFIGS, ids=[t for t, _ in TARGET_CONFIGS])
+@pytest.mark.parametrize("mcpu", TARGET_CONFIGS)
 class TestCvtF32U32:
     """v_cvt_f32_u32: unsigned int -> f32."""
 
-    def test_basic_values(self, mcpu, isa):
+    def test_basic_values(self, mcpu):
         src = np.zeros(TOTAL_LANES, dtype=np.uint32)
         for i in range(TOTAL_LANES):
             src[i] = i * 1000  # 0, 1000, 2000, ...
@@ -338,14 +336,14 @@ class TestCvtF32U32:
                     f"got {result_f32[i]}"
                 )
 
-        _run(mcpu, isa, "cvt_f32_u32_kernel", [src.view(np.int32)], [dst], verify)
+        _run(mcpu, "cvt_f32_u32_kernel", [src.view(np.int32)], [dst], verify)
 
 
-@pytest.mark.parametrize("mcpu,isa", TARGET_CONFIGS, ids=[t for t, _ in TARGET_CONFIGS])
+@pytest.mark.parametrize("mcpu", TARGET_CONFIGS)
 class TestCvtF32I32:
     """v_cvt_f32_i32: signed int -> f32."""
 
-    def test_basic_values(self, mcpu, isa):
+    def test_basic_values(self, mcpu):
         src = np.zeros(TOTAL_LANES, dtype=np.int32)
         for i in range(TOTAL_LANES):
             src[i] = i * 100 - 3200  # -3200, -3100, ..., 3100
@@ -367,14 +365,14 @@ class TestCvtF32I32:
                     f"got {result_f32[i]}"
                 )
 
-        _run(mcpu, isa, "cvt_f32_i32_kernel", [src], [dst], verify)
+        _run(mcpu, "cvt_f32_i32_kernel", [src], [dst], verify)
 
 
-@pytest.mark.parametrize("mcpu,isa", TARGET_CONFIGS, ids=[t for t, _ in TARGET_CONFIGS])
+@pytest.mark.parametrize("mcpu", TARGET_CONFIGS)
 class TestCvtU32F32:
     """v_cvt_u32_f32: f32 -> unsigned int (truncate toward zero, clamp to [0, 2^32-1])."""
 
-    def test_basic_values(self, mcpu, isa):
+    def test_basic_values(self, mcpu):
         src = np.zeros(TOTAL_LANES, dtype=np.float32)
         for i in range(TOTAL_LANES):
             src[i] = float(i * 1000)
@@ -402,14 +400,14 @@ class TestCvtU32F32:
                     f"lane {i}: f32={val}, expected u32={expected}, got {result_u32[i]}"
                 )
 
-        _run(mcpu, isa, "cvt_u32_f32_kernel", [src.view(np.int32)], [dst], verify)
+        _run(mcpu, "cvt_u32_f32_kernel", [src.view(np.int32)], [dst], verify)
 
 
-@pytest.mark.parametrize("mcpu,isa", TARGET_CONFIGS, ids=[t for t, _ in TARGET_CONFIGS])
+@pytest.mark.parametrize("mcpu", TARGET_CONFIGS)
 class TestCvtI32F32:
     """v_cvt_i32_f32: f32 -> signed int (truncate toward zero, clamp)."""
 
-    def test_basic_values(self, mcpu, isa):
+    def test_basic_values(self, mcpu):
         src = np.zeros(TOTAL_LANES, dtype=np.float32)
         for i in range(TOTAL_LANES):
             src[i] = float(i * 100 - 3200)
@@ -439,7 +437,7 @@ class TestCvtI32F32:
                     f"lane {i}: f32={val}, expected i32={expected}, got {result_i32[i]}"
                 )
 
-        _run(mcpu, isa, "cvt_i32_f32_kernel", [src.view(np.int32)], [dst], verify)
+        _run(mcpu, "cvt_i32_f32_kernel", [src.view(np.int32)], [dst], verify)
 
 
 # ===========================================================================
@@ -447,14 +445,14 @@ class TestCvtI32F32:
 # ===========================================================================
 
 
-@pytest.mark.parametrize("mcpu,isa", TARGET_CONFIGS, ids=[t for t, _ in TARGET_CONFIGS])
+@pytest.mark.parametrize("mcpu", TARGET_CONFIGS)
 class TestPackB32F16:
     """v_pack_b32_f16: pack two f16 values (in low 16 bits of dwords) into one b32.
 
     result[15:0] = src0[15:0], result[31:16] = src1[15:0]
     """
 
-    def test_basic_values(self, mcpu, isa):
+    def test_basic_values(self, mcpu):
         # src0 and src1 contain f16 bit patterns in low 16 bits of each dword
         src0 = np.zeros(TOTAL_LANES, dtype=np.uint32)
         src1 = np.zeros(TOTAL_LANES, dtype=np.uint32)
@@ -479,7 +477,6 @@ class TestPackB32F16:
 
         _run(
             mcpu,
-            isa,
             "pack_b32_f16_kernel",
             [src0.view(np.int32), src1.view(np.int32)],
             [dst],
@@ -487,7 +484,7 @@ class TestPackB32F16:
         )
 
 
-@pytest.mark.parametrize("mcpu,isa", TARGET_CONFIGS, ids=[t for t, _ in TARGET_CONFIGS])
+@pytest.mark.parametrize("mcpu", TARGET_CONFIGS)
 class TestCvtPkFp8F32:
     """v_cvt_pk_fp8_f32: pack-convert two f32 to two fp8 (E4M3) in low 16 bits.
 
@@ -495,8 +492,8 @@ class TestCvtPkFp8F32:
     result[7:0] = fp8(src0), result[15:8] = fp8(src1)
     """
 
-    def test_basic_values(self, mcpu, isa):
-        fnuz = _ISA_IS_FNUZ[isa]
+    def test_basic_values(self, mcpu):
+        fnuz = _TARGET_IS_FNUZ[mcpu]
         src0 = np.zeros(TOTAL_LANES, dtype=np.float32)
         src1 = np.zeros(TOTAL_LANES, dtype=np.float32)
         for i in range(TOTAL_LANES):
@@ -525,7 +522,6 @@ class TestCvtPkFp8F32:
 
         _run(
             mcpu,
-            isa,
             "cvt_pk_fp8_f32_kernel",
             [src0.view(np.int32), src1.view(np.int32)],
             [dst],
@@ -533,7 +529,7 @@ class TestCvtPkFp8F32:
         )
 
 
-@pytest.mark.parametrize("mcpu,isa", TARGET_CONFIGS, ids=[t for t, _ in TARGET_CONFIGS])
+@pytest.mark.parametrize("mcpu", TARGET_CONFIGS)
 class TestCvtPkBf8F32:
     """v_cvt_pk_bf8_f32: pack-convert two f32 to two bf8 (E5M2) in low 16 bits.
 
@@ -541,8 +537,8 @@ class TestCvtPkBf8F32:
     result[7:0] = bf8(src0), result[15:8] = bf8(src1)
     """
 
-    def test_basic_values(self, mcpu, isa):
-        fnuz = _ISA_IS_FNUZ[isa]
+    def test_basic_values(self, mcpu):
+        fnuz = _TARGET_IS_FNUZ[mcpu]
         src0 = np.zeros(TOTAL_LANES, dtype=np.float32)
         src1 = np.zeros(TOTAL_LANES, dtype=np.float32)
         for i in range(TOTAL_LANES):
@@ -571,7 +567,6 @@ class TestCvtPkBf8F32:
 
         _run(
             mcpu,
-            isa,
             "cvt_pk_bf8_f32_kernel",
             [src0.view(np.int32), src1.view(np.int32)],
             [dst],

--- a/test/integration/test_hsaco.py
+++ b/test/integration/test_hsaco.py
@@ -9,13 +9,13 @@ from aster.compiler.core import translate_module, assemble_to_hsaco
 from aster.dialects import amdgcn
 
 TARGET_CONFIGS = [
-    ("gfx942", "cdna3"),
-    ("gfx950", "cdna4"),
-    ("gfx1201", "rdna4"),
+    "gfx942",
+    "gfx950",
+    "gfx1201",
 ]
 
 
-def _build_module_ir(target, isa):
+def _build_module_ir(target):
     """Return MLIR source for a kernel that uses instructions available on all ISAs.
 
     Uses s_mov_b32 (scalar move, all ISAs) and alloca/end_kernel
@@ -23,7 +23,7 @@ def _build_module_ir(target, isa):
     non-trivial instruction sequence.
     """
     return f"""\
-amdgcn.module @test_module target = #amdgcn.target<{target}> isa = #amdgcn.isa<{isa}> {{
+amdgcn.module @test_module target = #amdgcn.target<{target}> {{
   amdgcn.kernel @test_kernel {{
     %s0 = amdgcn.alloca : !amdgcn.sgpr<4>
     %s1 = amdgcn.alloca : !amdgcn.sgpr<5>
@@ -49,14 +49,12 @@ def _run_pipeline(module, ctx):
     return translate_module(amdgcn_mod)
 
 
-@pytest.mark.parametrize(
-    "target,isa", TARGET_CONFIGS, ids=[t for t, _ in TARGET_CONFIGS]
-)
-def test_translate_to_asm(target, isa):
+@pytest.mark.parametrize("target", TARGET_CONFIGS)
+def test_translate_to_asm(target):
     """Test MLIR -> regalloc -> ASM translation for each target."""
     with ir.Context(), ir.Location.unknown():
         ctx = ir.Context.current
-        module = ir.Module.parse(_build_module_ir(target, isa))
+        module = ir.Module.parse(_build_module_ir(target))
         asm = _run_pipeline(module, ctx)
 
         assert f"amdgcn-amd-amdhsa--{target}" in asm
@@ -65,14 +63,12 @@ def test_translate_to_asm(target, isa):
         assert ".amdhsa_kernel test_kernel" in asm
 
 
-@pytest.mark.parametrize(
-    "target,isa", TARGET_CONFIGS, ids=[t for t, _ in TARGET_CONFIGS]
-)
-def test_assemble_to_hsaco(target, isa):
+@pytest.mark.parametrize("target", TARGET_CONFIGS)
+def test_assemble_to_hsaco(target):
     """Test MLIR -> regalloc -> ASM -> HSACO assembly for each target."""
     with ir.Context(), ir.Location.unknown():
         ctx = ir.Context.current
-        module = ir.Module.parse(_build_module_ir(target, isa))
+        module = ir.Module.parse(_build_module_ir(target))
         asm = _run_pipeline(module, ctx)
 
         hsaco_path = assemble_to_hsaco(asm, target=target)
@@ -90,9 +86,9 @@ def test_assemble_to_hsaco(target, isa):
 
 
 if __name__ == "__main__":
-    test_translate_to_asm("gfx942", "cdna3")
-    test_translate_to_asm("gfx950", "cdna4")
-    test_translate_to_asm("gfx1201", "rdna4")
-    test_assemble_to_hsaco("gfx942", "cdna3")
-    test_assemble_to_hsaco("gfx950", "cdna4")
-    test_assemble_to_hsaco("gfx1201", "rdna4")
+    test_translate_to_asm("gfx942")
+    test_translate_to_asm("gfx950")
+    test_translate_to_asm("gfx1201")
+    test_assemble_to_hsaco("gfx942")
+    test_assemble_to_hsaco("gfx950")
+    test_assemble_to_hsaco("gfx1201")

--- a/test/integration/tid-bid-e2e.mlir
+++ b/test/integration/tid-bid-e2e.mlir
@@ -10,7 +10,7 @@
 //   thread_id: x=42 (1D/2D), x=10,y=5,z=7 (3D, fits 1024-thread WG limit)
 //   block_id:  x=42,y=5,z=7
 
-amdgcn.module @tid_bid_mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @tid_bid_mod target = #amdgcn.target<gfx942> {
 
   // Helper: load output pointer from kernel arg 0.
   func.func private @load_output_ptr() -> !amdgcn.sgpr<[? + 2]> {

--- a/test/integration/vopc-branch-e2e.mlir
+++ b/test/integration/vopc-branch-e2e.mlir
@@ -13,7 +13,7 @@
 //   per_lane:     tid < 32  (lanes 0-31 true)     -> lanes 0-31 output 42,
 //                                                    lanes 32-63 output 99.
 
-amdgcn.module @vopc_select_mod target = #amdgcn.target<gfx942> isa = #amdgcn.isa<cdna3> {
+amdgcn.module @vopc_select_mod target = #amdgcn.target<gfx942> {
 
   func.func private @load_out_ptr() -> !amdgcn.sgpr<[? + 2]> {
     %out_ptr = amdgcn.load_arg 0 : !amdgcn.sgpr<[? + 2]>

--- a/test/python/ir.py
+++ b/test/python/ir.py
@@ -6,10 +6,10 @@ from aster.dialects import builtin, amdgcn as a_d
 with ir.Context() as ctx, ir.Location.unknown() as loc:
     m = builtin.ModuleOp()
     with ir.InsertionPoint(m.body):
-        modOp = a_d.ModuleOp(a_d.Target.GFX942, a_d.ISAVersion.CDNA3, "module")
+        modOp = a_d.ModuleOp(a_d.Target.GFX942, "module")
         modOp.body_region.blocks.append()
     print(str(m))
-    # CHECK-LABEL: amdgcn.module @module target = <gfx942> isa = <cdna3>
+    # CHECK-LABEL: amdgcn.module @module target = <gfx942>
 
     # Test register types: VGPR, SGPR, AGPR
     # CHECK: vgpr<0>


### PR DESCRIPTION
Add TargetAttrInterface with getTarget() and getTargetFamily() methods. Introduce TypedEnum in Support/EnumUtils.h as a type-safe base for the Target and TargetFamily typed enum structs returned by the interface.

Remove `isa` from `amdgcn.module` as it can be deduced from the target.

Python script to update MLIR files:

```python
import re
import sys
from pathlib import Path

PATTERN = re.compile(r"\s+isa\s*=\s*(?:#amdgcn\.isa)?<[^>]*>")


def process_file(path: Path) -> bool:
    """Process a single file, returning True if it was modified."""
    text = path.read_text()
    new_text = PATTERN.sub("", text)
    if new_text != text:
        path.write_text(new_text)
        return True
    return False


def main():
    root = Path(__file__).resolve().parent.parent
    if len(sys.argv) > 1:
        root = Path(sys.argv[1])

    modified = 0
    for mlir_file in sorted(root.rglob("*.mlir")):
        if process_file(mlir_file):
            print(f"  Modified: {mlir_file.relative_to(root)}")
            modified += 1

    print(f"\nDone. Modified {modified} file(s).")


if __name__ == "__main__":
    main()

```