### PR TITLE
[amdgcn] Replace direct InstMetadata usage with AMDGCNInstOpInterface methods

### DIFF
--- a/include/aster/Dialect/AMDGCN/IR/AMDGCNOps.td
+++ b/include/aster/Dialect/AMDGCN/IR/AMDGCNOps.td
@@ -693,7 +693,6 @@ def AMDGCN_TestInstOp : AMDGCN_Op<"test_inst", [
 
     /// Get the opcode of the instruction.
     InstAttr getOpcodeAttr() {
-      assert(false && "not yet implemented");
       return InstAttr();
     }
     /// Get the instruction output operands.

--- a/include/aster/Dialect/AMDGCN/IR/Interfaces/AMDGCNInstOpInterface.td
+++ b/include/aster/Dialect/AMDGCN/IR/Interfaces/AMDGCNInstOpInterface.td
@@ -28,9 +28,20 @@ def AMDGCNInstOpInterface :
   let cppNamespace = "::mlir::aster::amdgcn";
   let methods = [
     InterfaceMethod<
-      // TODO: refine the Attribute type.
       "Returns the opcode of the instruction",
       "::mlir::aster::amdgcn::InstAttr", "getOpcodeAttr"
+    >,
+    InterfaceMethod<
+      "Returns whether the instruction has the given inst trait",
+      "bool", "hasInstProps", (ins "::llvm::ArrayRef<InstProp>":$props, "bool":$all), [{}], [{
+        ::mlir::aster::amdgcn::InstAttr attr = $_op.getOpcodeAttr();
+        if (!attr)
+          return false;
+        const ::mlir::aster::amdgcn::InstMetadata *md = attr.getMetadata();
+        if (!md)
+          return false;
+        return all ? md->hasProps(props) : md->hasAnyProps(props);
+      }]
     >
   ];
   let extraSharedClassDeclaration = [{
@@ -39,6 +50,40 @@ def AMDGCNInstOpInterface :
     const ::mlir::aster::amdgcn::InstMetadata* getInstMetadata() {
       ::mlir::aster::amdgcn::InstAttr attr = $_op.getOpcodeAttr();
       return attr ? attr.getMetadata() : nullptr;
+    }
+
+    bool hasProp(::mlir::aster::amdgcn::InstProp prop) {
+      return $_op.hasInstProps({prop}, true);
+    }
+
+    bool hasProps(::llvm::ArrayRef<::mlir::aster::amdgcn::InstProp> props) {
+      return $_op.hasInstProps(props, true);
+    }
+
+    bool hasAnyProps(::llvm::ArrayRef<::mlir::aster::amdgcn::InstProp> props) {
+      return $_op.hasInstProps(props, false);
+    }
+
+    ::mlir::aster::amdgcn::OpCode getOpCode() {
+      const ::mlir::aster::amdgcn::InstMetadata* md = $_op.getInstMetadata();
+      return md ? md->getOpCode() : ::mlir::aster::amdgcn::OpCode::Invalid;
+    }
+
+    /// Returns true if the instruction supports the given ISA version.
+    /// An instruction with no ISA version list is assumed to support all.
+    bool supportsISA(::mlir::aster::amdgcn::ISAVersion ver) {
+      const ::mlir::aster::amdgcn::InstMetadata* md = $_op.getInstMetadata();
+      if (!md)
+        return false;
+      ::llvm::ArrayRef<::mlir::aster::amdgcn::ISAVersion> isas = md->getISAVersions();
+      if (isas.empty())
+        return true;
+      return llvm::is_contained(isas, ver);
+    }
+
+    ::llvm::ArrayRef<::mlir::aster::amdgcn::ISAVersion> getISAVersions() {
+      const ::mlir::aster::amdgcn::InstMetadata* md = $_op.getInstMetadata();
+      return md ? md->getISAVersions() : ::llvm::ArrayRef<::mlir::aster::amdgcn::ISAVersion>();
     }
   }];
 }

--- a/include/aster/Dialect/AMDGCN/IR/Interfaces/HazardAttrInterface.td
+++ b/include/aster/Dialect/AMDGCN/IR/Interfaces/HazardAttrInterface.td
@@ -24,11 +24,11 @@ def HazardRaiserAttrInterface : AttrInterface<"HazardRaiserAttrInterface"> {
   }];
   let methods = [
     InterfaceMethod<[{
-      Determine whether populateHazardsFor should be called based on InstMetadata
-      and ISA version alone.
+      Determine whether populateHazardsFor should be called based on the
+      instruction interface and ISA version.
     }],
     "bool", "matchInst",
-    (ins "const ::mlir::aster::amdgcn::InstMetadata *":$md,
+    (ins "::mlir::aster::amdgcn::AMDGCNInstOpInterface":$instOp,
          "::mlir::aster::amdgcn::ISAVersion":$isaVer)
     >,
     InterfaceMethod<[{

--- a/include/aster/Dialect/AMDGCN/IR/Utils.h
+++ b/include/aster/Dialect/AMDGCN/IR/Utils.h
@@ -98,11 +98,6 @@ int64_t getLdsBytesPerCU(Target target);
 /// See LLVM's FeaturePackedTID and ISA manual Section 3.13.
 bool hasPackedTID(ISAVersion isa);
 
-/// Check if an instruction opcode is valid for all the given ISA versions.
-/// Returns true if the instruction is valid for ALL ISAs in the list.
-bool isOpcodeValidForAllIsas(OpCode opcode, ArrayRef<ISAVersion> isas,
-                             MLIRContext *ctx);
-
 /// Check if the given type is an AMD register type or an Immedate type.
 bool isAMDRegOrImm(Type type);
 

--- a/lib/Dialect/AMDGCN/Analysis/HazardAnalysis.cpp
+++ b/lib/Dialect/AMDGCN/Analysis/HazardAnalysis.cpp
@@ -173,20 +173,19 @@ MLIR_DEFINE_EXPLICIT_TYPE_ID(mlir::aster::amdgcn::HazardState)
 /// Update the hazards based on the instruction counts that are being flushed.
 /// Returns true if the hazards have changed.
 static bool updateHazards(SmallVectorImpl<Hazard> &hazards,
-                          InstCounts instCounts,
-                          const InstMetadata *instMetadata) {
+                          InstCounts instCounts, AMDGCNInstOpInterface instOp) {
   int8_t numVector = instCounts.getNumVector();
   int8_t numScalar = instCounts.getNumScalar();
   int8_t numDataShare = instCounts.getNumDataShare();
 
-  // Update the instruction counts based on the instruction metadata.
-  if (instMetadata) {
-    if (instMetadata->hasAnyProps({InstProp::IsValu, InstProp::IsVmem}))
+  // Update the instruction counts based on the instruction interface.
+  if (instOp) {
+    if (instOp.hasAnyProps({InstProp::IsValu, InstProp::IsVmem}))
       ++numVector;
-    if (instMetadata->hasAnyProps({InstProp::Salu, InstProp::Smem}))
+    if (instOp.hasAnyProps({InstProp::Salu, InstProp::Smem}))
       ++numScalar;
     // NOTE: It's unclear whether dsmem also affect vector instructions.
-    if (instMetadata->hasAnyProps({InstProp::Dsmem}))
+    if (instOp.hasAnyProps({InstProp::Dsmem}))
       ++numDataShare;
   }
 
@@ -250,8 +249,7 @@ LogicalResult HazardAnalysis::visitOperation(Operation *op,
   }
 
   // Update the hazards based on the instruction counts that are being flushed.
-  if (updateHazards(after->activeHazards, requiredInstCounts,
-                    instOp.getInstMetadata()))
+  if (updateHazards(after->activeHazards, requiredInstCounts, instOp))
     changed = ChangeResult::Change;
 
   // Update the flushed instruction counts if they have changed.

--- a/lib/Dialect/AMDGCN/IR/AMDGCNVerifiers.cpp
+++ b/lib/Dialect/AMDGCN/IR/AMDGCNVerifiers.cpp
@@ -268,8 +268,14 @@ amdgcn::verifyISAsSupportImpl(Region &region, ArrayRef<ISAVersion> isas,
   // the listed ISA targets.
   LogicalResult result = success();
   region.walk([&](AMDGCNInstOpInterface instOp) {
-    OpCode opcode = instOp.getOpcodeAttr().getValue();
-    if (!isOpcodeValidForAllIsas(opcode, isas, region.getContext())) {
+    OpCode opcode = instOp.getOpCode();
+    ArrayRef<ISAVersion> opIsas = instOp.getISAVersions();
+    // An instruction with no ISA list is available on all targets.
+    if (opIsas.empty())
+      return WalkResult::advance();
+    if (!llvm::all_of(isas, [&](ISAVersion isa) {
+          return llvm::is_contained(opIsas, isa);
+        })) {
       result = instOp->emitError("instruction '")
                << stringifyOpCode(opcode)
                << "' is not valid for all specified ISA targets";

--- a/lib/Dialect/AMDGCN/IR/Hazards.cpp
+++ b/lib/Dialect/AMDGCN/IR/Hazards.cpp
@@ -110,16 +110,6 @@ static bool isVcczOrExeczKind(RegisterKind kind) {
   return kind == RegisterKind::VCCZ || kind == RegisterKind::EXECZ;
 }
 
-/// Check if the instruction supports the given ISA version.
-static bool instSupportsIsa(const InstMetadata *md, ISAVersion isaVer) {
-  if (!md)
-    return false;
-  ArrayRef<ISAVersion> isas = md->getISAVersions();
-  if (isas.empty())
-    return true; // Available on all targets.
-  return llvm::is_contained(isas, isaVer);
-}
-
 //===----------------------------------------------------------------------===//
 // Hazard
 //===----------------------------------------------------------------------===//
@@ -167,7 +157,7 @@ bool Hazard::compare(const Hazard &other, DominanceInfo &domInfo) const {
 // AllHazard
 //===----------------------------------------------------------------------===//
 
-bool AllHazardAttr::matchInst(const InstMetadata *, ISAVersion) const {
+bool AllHazardAttr::matchInst(AMDGCNInstOpInterface, ISAVersion) const {
   return true;
 }
 
@@ -189,7 +179,7 @@ bool AllHazardAttr::isHazardTriggered(const Hazard &,
 //===----------------------------------------------------------------------===//
 // Case 1: SetRegGetRegHazard
 //===----------------------------------------------------------------------===//
-bool CDNA3SetRegGetRegHazardAttr::matchInst(const InstMetadata *,
+bool CDNA3SetRegGetRegHazardAttr::matchInst(AMDGCNInstOpInterface,
                                             ISAVersion) const {
   return false; // TODO: S_SETREG and S_GETREG not implemented.
 }
@@ -205,7 +195,7 @@ bool CDNA3SetRegGetRegHazardAttr::isHazardTriggered(
 //===----------------------------------------------------------------------===//
 // Case 2: SetRegSetRegHazard
 //===----------------------------------------------------------------------===//
-bool CDNA3SetRegSetRegHazardAttr::matchInst(const InstMetadata *,
+bool CDNA3SetRegSetRegHazardAttr::matchInst(AMDGCNInstOpInterface,
                                             ISAVersion) const {
   return false; // TODO: S_SETREG not implemented.
 }
@@ -221,7 +211,7 @@ bool CDNA3SetRegSetRegHazardAttr::isHazardTriggered(
 //===----------------------------------------------------------------------===//
 // Case 3: SetVskipGetRegHazard
 //===----------------------------------------------------------------------===//
-bool CDNA3SetVskipGetRegHazardAttr::matchInst(const InstMetadata *,
+bool CDNA3SetVskipGetRegHazardAttr::matchInst(AMDGCNInstOpInterface,
                                               ISAVersion) const {
   return false; // TODO: SET_VSKIP and S_GETREG not implemented.
 }
@@ -237,7 +227,7 @@ bool CDNA3SetVskipGetRegHazardAttr::isHazardTriggered(
 //===----------------------------------------------------------------------===//
 // Case 4: SetRegVskipVectorHazard
 //===----------------------------------------------------------------------===//
-bool CDNA3SetRegVskipVectorHazardAttr::matchInst(const InstMetadata *,
+bool CDNA3SetRegVskipVectorHazardAttr::matchInst(AMDGCNInstOpInterface,
                                                  ISAVersion) const {
   return false; // TODO: S_SETREG not implemented.
 }
@@ -253,15 +243,14 @@ bool CDNA3SetRegVskipVectorHazardAttr::isHazardTriggered(
 //===----------------------------------------------------------------------===//
 // Case 5: VccExecVcczExeczHazard
 //===----------------------------------------------------------------------===//
-bool CDNA3VccExecVcczExeczHazardAttr::matchInst(const InstMetadata *md,
+bool CDNA3VccExecVcczExeczHazardAttr::matchInst(AMDGCNInstOpInterface instOp,
                                                 ISAVersion isaVer) const {
-  return md && instSupportsIsa(md, isaVer) && md->hasProp(InstProp::IsValu);
+  return instOp.supportsISA(isaVer) && instOp.hasProp(InstProp::IsValu);
 }
 
 void CDNA3VccExecVcczExeczHazardAttr::populateHazardsFor(
     AMDGCNInstOpInterface instOp, SmallVectorImpl<Hazard> &hazards) const {
-  const InstMetadata *metadata = instOp.getInstMetadata();
-  if (!metadata || !metadata->hasProp(InstProp::IsValu))
+  if (!instOp.hasProp(InstProp::IsValu))
     return;
 
   bool writesVccOrExec = llvm::any_of(instOp.getInstOuts(), [](Value out) {
@@ -278,8 +267,7 @@ bool CDNA3VccExecVcczExeczHazardAttr::isHazardTriggered(
     const Hazard &hazard, AMDGCNInstOpInterface instOp) const {
   assert(hazard.getHazard() == *this && "Hazard mismatch");
 
-  const InstMetadata *metadata = instOp.getInstMetadata();
-  if (!metadata || !metadata->hasProp(InstProp::IsValu))
+  if (!instOp.hasProp(InstProp::IsValu))
     return false;
 
   return llvm::any_of(instOp.getInstIns(), [](Value input) {
@@ -291,7 +279,7 @@ bool CDNA3VccExecVcczExeczHazardAttr::isHazardTriggered(
 //===----------------------------------------------------------------------===//
 // Case 6: ValuSgprReadlaneHazard
 //===----------------------------------------------------------------------===//
-bool CDNA3ValuSgprReadlaneHazardAttr::matchInst(const InstMetadata *,
+bool CDNA3ValuSgprReadlaneHazardAttr::matchInst(AMDGCNInstOpInterface,
                                                 ISAVersion) const {
   return false; // TODO: V_READLANE, V_WRITELANE not implemented.
 }
@@ -307,7 +295,7 @@ bool CDNA3ValuSgprReadlaneHazardAttr::isHazardTriggered(
 //===----------------------------------------------------------------------===//
 // Case 7: VccDivFmasHazard
 //===----------------------------------------------------------------------===//
-bool CDNA3VccDivFmasHazardAttr::matchInst(const InstMetadata *,
+bool CDNA3VccDivFmasHazardAttr::matchInst(AMDGCNInstOpInterface,
                                           ISAVersion) const {
   return false; // TODO: V_DIV_FMAS not implemented.
 }
@@ -324,21 +312,20 @@ bool CDNA3VccDivFmasHazardAttr::isHazardTriggered(const Hazard &,
 // Case 8: StoreWriteDataHazard
 //===----------------------------------------------------------------------===//
 
-bool CDNA3StoreWriteDataHazardAttr::matchInst(const InstMetadata *md,
+bool CDNA3StoreWriteDataHazardAttr::matchInst(AMDGCNInstOpInterface instOp,
                                               ISAVersion isaVer) const {
-  if (!md || !instSupportsIsa(md, isaVer))
+  if (!instOp.supportsISA(isaVer))
     return false;
-  OpCode op = md->getOpCode();
-  if (md->hasProp(InstProp::Global))
+  OpCode op = instOp.getOpCode();
+  if (instOp.hasProp(InstProp::Global))
     return true;
-  if (md->hasProp(InstProp::Buffer) &&
+  if (instOp.hasProp(InstProp::Buffer) &&
       llvm::is_contained({OpCode::BUFFER_STORE_DWORDX3,
                           OpCode::BUFFER_STORE_DWORDX4,
                           OpCode::BUFFER_STORE_DWORDX3_IDXEN,
                           OpCode::BUFFER_STORE_DWORDX4_IDXEN},
-                         op)) {
+                         op))
     return true;
-  }
   return false;
 }
 
@@ -350,15 +337,14 @@ void CDNA3StoreWriteDataHazardAttr::populateHazardsFor(
   RegisterTypeInterface regTy = storeOp.getData().getType();
   if (!regTy)
     return;
-  const InstMetadata *metadata = storeOp.getInstMetadata();
-  if (!metadata)
+  if (instOp.getOpCode() == OpCode::Invalid)
     return;
 
   if (llvm::is_contained({OpCode::BUFFER_STORE_DWORDX3,
                           OpCode::BUFFER_STORE_DWORDX4,
                           OpCode::BUFFER_STORE_DWORDX3_IDXEN,
                           OpCode::BUFFER_STORE_DWORDX4_IDXEN},
-                         metadata->getOpCode())) {
+                         instOp.getOpCode())) {
     // If the dynamic offset is not set, there is no hazard.
     if (!storeOp.getDynamicOffset())
       return;
@@ -366,7 +352,7 @@ void CDNA3StoreWriteDataHazardAttr::populateHazardsFor(
                              storeOp.getDataMutable(), getInstCounts(0)));
     return;
   }
-  if (metadata->hasProp(InstProp::Global)) {
+  if (instOp.hasProp(InstProp::Global)) {
     hazards.push_back(Hazard(cast<HazardCheckerAttrInterface>(*this),
                              storeOp.getDataMutable(), getInstCounts(0)));
     return;
@@ -380,8 +366,7 @@ bool CDNA3StoreWriteDataHazardAttr::isHazardTriggered(
   assert(hazard.getHazard() == *this && "Hazard mismatch");
   // Case 8: Any instruction that writes to writedata VGPRs (non-VALU gets 1
   // wait). Case 9 (CDNA3StoreHazard) handles VALU with 2 waits.
-  const InstMetadata *metadata = instOp.getInstMetadata();
-  if (!metadata || metadata->hasProp(InstProp::IsValu))
+  if (instOp.getOpCode() == OpCode::Invalid || instOp.hasProp(InstProp::IsValu))
     return false; // VALU is handled by CDNA3StoreHazard
 
   auto storeOp = cast<StoreOp>(hazard.getOp());
@@ -398,21 +383,20 @@ bool CDNA3StoreWriteDataHazardAttr::isHazardTriggered(
 // Case 9: StoreHazard
 //===----------------------------------------------------------------------===//
 
-bool CDNA3StoreHazardAttr::matchInst(const InstMetadata *md,
+bool CDNA3StoreHazardAttr::matchInst(AMDGCNInstOpInterface instOp,
                                      ISAVersion isaVer) const {
-  if (!md || !instSupportsIsa(md, isaVer))
+  if (!instOp.supportsISA(isaVer))
     return false;
-  OpCode op = md->getOpCode();
-  if (md->hasProp(InstProp::Global))
+  OpCode op = instOp.getOpCode();
+  if (instOp.hasProp(InstProp::Global))
     return true;
-  if (md->hasProp(InstProp::Buffer) &&
+  if (instOp.hasProp(InstProp::Buffer) &&
       llvm::is_contained({OpCode::BUFFER_STORE_DWORDX3,
                           OpCode::BUFFER_STORE_DWORDX4,
                           OpCode::BUFFER_STORE_DWORDX3_IDXEN,
                           OpCode::BUFFER_STORE_DWORDX4_IDXEN},
-                         op)) {
+                         op))
     return true;
-  }
   return false;
 }
 
@@ -427,8 +411,7 @@ void CDNA3StoreHazardAttr::populateHazardsFor(
   if (!regTy || !regTy.hasAllocatedSemantics())
     return;
 
-  const InstMetadata *metadata = storeOp.getInstMetadata();
-  if (!metadata)
+  if (instOp.getOpCode() == OpCode::Invalid)
     return;
 
   // Handle buffer ops.
@@ -436,7 +419,7 @@ void CDNA3StoreHazardAttr::populateHazardsFor(
                           OpCode::BUFFER_STORE_DWORDX4,
                           OpCode::BUFFER_STORE_DWORDX3_IDXEN,
                           OpCode::BUFFER_STORE_DWORDX4_IDXEN},
-                         metadata->getOpCode())) {
+                         instOp.getOpCode())) {
 
     // If the dynamic offset is not set, there is no hazard.
     if (!storeOp.getDynamicOffset())
@@ -447,7 +430,7 @@ void CDNA3StoreHazardAttr::populateHazardsFor(
   }
 
   // Handle global ops.
-  if (metadata->hasProp(InstProp::Global)) {
+  if (instOp.hasProp(InstProp::Global)) {
     hazards.push_back(Hazard(cast<HazardCheckerAttrInterface>(*this),
                              storeOp.getDataMutable(), getInstCounts(0)));
     return;
@@ -460,8 +443,7 @@ bool CDNA3StoreHazardAttr::isHazardTriggered(
     const Hazard &hazard, AMDGCNInstOpInterface instOp) const {
   assert(hazard.getHazard() == *this && "Hazard mismatch");
 
-  const InstMetadata *metadata = instOp.getInstMetadata();
-  if (!metadata || !metadata->hasProp(InstProp::IsValu))
+  if (!instOp.hasProp(InstProp::IsValu))
     return false;
 
   auto storeOp = cast<StoreOp>(hazard.getOp());
@@ -479,15 +461,14 @@ bool CDNA3StoreHazardAttr::isHazardTriggered(
 //===----------------------------------------------------------------------===//
 // Case 10: ValuSgprVmemHazard
 //===----------------------------------------------------------------------===//
-bool CDNA3ValuSgprVmemHazardAttr::matchInst(const InstMetadata *md,
+bool CDNA3ValuSgprVmemHazardAttr::matchInst(AMDGCNInstOpInterface instOp,
                                             ISAVersion isaVer) const {
-  return md && instSupportsIsa(md, isaVer) && md->hasProp(InstProp::IsValu);
+  return instOp.supportsISA(isaVer) && instOp.hasProp(InstProp::IsValu);
 }
 
 void CDNA3ValuSgprVmemHazardAttr::populateHazardsFor(
     AMDGCNInstOpInterface instOp, SmallVectorImpl<Hazard> &hazards) const {
-  const InstMetadata *metadata = instOp.getInstMetadata();
-  if (!metadata || !metadata->hasProp(InstProp::IsValu))
+  if (!instOp.hasProp(InstProp::IsValu))
     return;
 
   for (OpOperand &operand : getOpOperands(instOp.getInstOuts())) {
@@ -504,8 +485,7 @@ bool CDNA3ValuSgprVmemHazardAttr::isHazardTriggered(
     const Hazard &hazard, AMDGCNInstOpInterface instOp) const {
   assert(hazard.getHazard() == *this && "Hazard mismatch");
 
-  const InstMetadata *metadata = instOp.getInstMetadata();
-  if (!metadata || !metadata->hasProp(InstProp::IsVmem))
+  if (!instOp.hasProp(InstProp::IsVmem))
     return false;
 
   OpOperand *sgprOperand = hazard.getOperand();
@@ -529,7 +509,7 @@ bool CDNA3ValuSgprVmemHazardAttr::isHazardTriggered(
 //===----------------------------------------------------------------------===//
 // Case 11: SaluM0GdsSendmsgHazard
 //===----------------------------------------------------------------------===//
-bool CDNA3SaluM0GdsSendmsgHazardAttr::matchInst(const InstMetadata *,
+bool CDNA3SaluM0GdsSendmsgHazardAttr::matchInst(AMDGCNInstOpInterface,
                                                 ISAVersion) const {
   return false; // TODO: GDS and S_SENDMSG not implemented.
 }
@@ -545,7 +525,7 @@ bool CDNA3SaluM0GdsSendmsgHazardAttr::isHazardTriggered(
 //===----------------------------------------------------------------------===//
 // Case 12: ValuVgprDppHazard
 //===----------------------------------------------------------------------===//
-bool CDNA3ValuVgprDppHazardAttr::matchInst(const InstMetadata *,
+bool CDNA3ValuVgprDppHazardAttr::matchInst(AMDGCNInstOpInterface,
                                            ISAVersion) const {
   return false; // TODO: DPP modifier not implemented.
 }
@@ -561,7 +541,8 @@ bool CDNA3ValuVgprDppHazardAttr::isHazardTriggered(
 //===----------------------------------------------------------------------===//
 // Case 13: ExecDppHazard
 //===----------------------------------------------------------------------===//
-bool CDNA3ExecDppHazardAttr::matchInst(const InstMetadata *, ISAVersion) const {
+bool CDNA3ExecDppHazardAttr::matchInst(AMDGCNInstOpInterface,
+                                       ISAVersion) const {
   return false; // TODO: DPP modifier not implemented.
 }
 
@@ -576,7 +557,7 @@ bool CDNA3ExecDppHazardAttr::isHazardTriggered(const Hazard &,
 //===----------------------------------------------------------------------===//
 // Case 14: MixedVccConstantHazard
 //===----------------------------------------------------------------------===//
-bool CDNA3MixedVccConstantHazardAttr::matchInst(const InstMetadata *,
+bool CDNA3MixedVccConstantHazardAttr::matchInst(AMDGCNInstOpInterface,
                                                 ISAVersion) const {
   return false; // TODO: VCC/SGPR alias tracking not implemented.
 }
@@ -592,7 +573,7 @@ bool CDNA3MixedVccConstantHazardAttr::isHazardTriggered(
 //===----------------------------------------------------------------------===//
 // Case 15: SetRegTrapstsRfeHazard
 //===----------------------------------------------------------------------===//
-bool CDNA3SetRegTrapstsRfeHazardAttr::matchInst(const InstMetadata *,
+bool CDNA3SetRegTrapstsRfeHazardAttr::matchInst(AMDGCNInstOpInterface,
                                                 ISAVersion) const {
   return false; // TODO: S_SETREG, RFE, RFE_restore not implemented.
 }
@@ -608,7 +589,7 @@ bool CDNA3SetRegTrapstsRfeHazardAttr::isHazardTriggered(
 //===----------------------------------------------------------------------===//
 // Case 16: SaluM0LdsHazard
 //===----------------------------------------------------------------------===//
-bool CDNA3SaluM0LdsHazardAttr::matchInst(const InstMetadata *,
+bool CDNA3SaluM0LdsHazardAttr::matchInst(AMDGCNInstOpInterface,
                                          ISAVersion) const {
   return false; // TODO: LDS add-TID, buffer_store_LDS not implemented.
 }
@@ -624,7 +605,7 @@ bool CDNA3SaluM0LdsHazardAttr::isHazardTriggered(const Hazard &,
 //===----------------------------------------------------------------------===//
 // Case 17: SaluM0MoverelHazard
 //===----------------------------------------------------------------------===//
-bool CDNA3SaluM0MoverelHazardAttr::matchInst(const InstMetadata *,
+bool CDNA3SaluM0MoverelHazardAttr::matchInst(AMDGCNInstOpInterface,
                                              ISAVersion) const {
   return false; // TODO: S_MOVEREL not implemented.
 }
@@ -640,7 +621,7 @@ bool CDNA3SaluM0MoverelHazardAttr::isHazardTriggered(
 //===----------------------------------------------------------------------===//
 // Case 18: ValuSgprValuReadHazard
 //===----------------------------------------------------------------------===//
-bool CDNA3ValuSgprValuReadHazardAttr::matchInst(const InstMetadata *,
+bool CDNA3ValuSgprValuReadHazardAttr::matchInst(AMDGCNInstOpInterface,
                                                 ISAVersion) const {
   return false; // TODO: SGPR/VCC dependency tracking not implemented.
 }
@@ -657,15 +638,14 @@ bool CDNA3ValuSgprValuReadHazardAttr::isHazardTriggered(
 // Case 19: ValuVgprReadlaneHazard
 // VALU writes VGPRn -> v_readfirstlane_b32 reads VGPRn (1 V_NOP)
 //===----------------------------------------------------------------------===//
-bool CDNA3ValuVgprReadlaneHazardAttr::matchInst(const InstMetadata *md,
+bool CDNA3ValuVgprReadlaneHazardAttr::matchInst(AMDGCNInstOpInterface instOp,
                                                 ISAVersion isaVer) const {
-  return md && instSupportsIsa(md, isaVer) && md->hasProp(InstProp::IsValu);
+  return instOp.supportsISA(isaVer) && instOp.hasProp(InstProp::IsValu);
 }
 
 void CDNA3ValuVgprReadlaneHazardAttr::populateHazardsFor(
     AMDGCNInstOpInterface instOp, SmallVectorImpl<Hazard> &hazards) const {
-  const InstMetadata *metadata = instOp.getInstMetadata();
-  if (!metadata || !metadata->hasProp(InstProp::IsValu))
+  if (!instOp.hasProp(InstProp::IsValu))
     return;
 
   for (OpOperand &operand : getOpOperands(instOp.getInstOuts())) {
@@ -682,8 +662,7 @@ bool CDNA3ValuVgprReadlaneHazardAttr::isHazardTriggered(
     const Hazard &hazard, AMDGCNInstOpInterface instOp) const {
   assert(hazard.getHazard() == *this && "Hazard mismatch");
 
-  const InstMetadata *metadata = instOp.getInstMetadata();
-  if (!metadata || metadata->getOpCode() != OpCode::V_READFIRSTLANE_B32)
+  if (instOp.getOpCode() != OpCode::V_READFIRSTLANE_B32)
     return false;
 
   OpOperand *vgprOperand = hazard.getOperand();
@@ -707,7 +686,7 @@ bool CDNA3ValuVgprReadlaneHazardAttr::isHazardTriggered(
 //===----------------------------------------------------------------------===//
 // Case 20: OpselSdwaHazard
 //===----------------------------------------------------------------------===//
-bool CDNA3OpselSdwaHazardAttr::matchInst(const InstMetadata *,
+bool CDNA3OpselSdwaHazardAttr::matchInst(AMDGCNInstOpInterface,
                                          ISAVersion) const {
   return false; // TODO: OPSEL and SDWA modifiers not implemented.
 }
@@ -723,7 +702,8 @@ bool CDNA3OpselSdwaHazardAttr::isHazardTriggered(const Hazard &,
 //===----------------------------------------------------------------------===//
 // Case 21: TransOpHazard
 //===----------------------------------------------------------------------===//
-bool CDNA3TransOpHazardAttr::matchInst(const InstMetadata *, ISAVersion) const {
+bool CDNA3TransOpHazardAttr::matchInst(AMDGCNInstOpInterface,
+                                       ISAVersion) const {
   return false; // TODO: Trans op detection not implemented.
 }
 
@@ -742,19 +722,17 @@ bool CDNA3TransOpHazardAttr::isHazardTriggered(const Hazard &,
 //===----------------------------------------------------------------------===//
 // Case NonDLOpsValuMfmaHazard
 //===----------------------------------------------------------------------===//
-bool CDNA3NonDLOpsValuMfmaHazardAttr::matchInst(const InstMetadata *md,
+bool CDNA3NonDLOpsValuMfmaHazardAttr::matchInst(AMDGCNInstOpInterface instOp,
                                                 ISAVersion isaVer) const {
-  if (!md || !instSupportsIsa(md, isaVer))
+  if (!instOp.supportsISA(isaVer))
     return false;
   // Non-DLops VALU = IsValu but NOT MMA (V_MFMA/V_SMFMA).
-  return md->hasProp(InstProp::IsValu) && !md->hasProp(InstProp::Mma);
+  return instOp.hasProp(InstProp::IsValu) && !instOp.hasProp(InstProp::Mma);
 }
 
 void CDNA3NonDLOpsValuMfmaHazardAttr::populateHazardsFor(
     AMDGCNInstOpInterface instOp, SmallVectorImpl<Hazard> &hazards) const {
-  const InstMetadata *metadata = instOp.getInstMetadata();
-  if (!metadata || !metadata->hasProp(InstProp::IsValu) ||
-      metadata->hasProp(InstProp::Mma))
+  if (!instOp.hasProp(InstProp::IsValu) || instOp.hasProp(InstProp::Mma))
     return;
 
   for (OpOperand &operand : getOpOperands(instOp.getInstOuts())) {
@@ -773,8 +751,7 @@ bool CDNA3NonDLOpsValuMfmaHazardAttr::isHazardTriggered(
     const Hazard &hazard, AMDGCNInstOpInterface instOp) const {
   assert(hazard.getHazard() == *this && "Hazard mismatch");
 
-  const InstMetadata *metadata = instOp.getInstMetadata();
-  if (!metadata || !metadata->hasProp(InstProp::Mma))
+  if (!instOp.hasProp(InstProp::Mma))
     return false;
 
   OpOperand *vgprOperand = hazard.getOperand();
@@ -797,7 +774,7 @@ bool CDNA3NonDLOpsValuMfmaHazardAttr::isHazardTriggered(
 // Case DLOpsWriteVgprHazard
 //===----------------------------------------------------------------------===//
 // TODO: DL ops (XDLOP dot product instructions) not implemented in AMDGCN.
-bool CDNA3DLOpsWriteVgprHazardAttr::matchInst(const InstMetadata *,
+bool CDNA3DLOpsWriteVgprHazardAttr::matchInst(AMDGCNInstOpInterface,
                                               ISAVersion) const {
   return false; // TODO: XDLOP instructions not implemented in AMDGCN.
 }
@@ -814,10 +791,10 @@ bool CDNA3DLOpsWriteVgprHazardAttr::isHazardTriggered(
 // Case XdlWriteVgprXdlReadSrcCExactHazard
 //===----------------------------------------------------------------------===//
 bool CDNA3XdlWriteVgprXdlReadSrcCExactHazardAttr::matchInst(
-    const InstMetadata *md, ISAVersion isaVer) const {
-  if (!md || !instSupportsIsa(md, isaVer))
+    AMDGCNInstOpInterface instOp, ISAVersion isaVer) const {
+  if (!instOp.supportsISA(isaVer))
     return false;
-  return md->hasProp(InstProp::Mma);
+  return instOp.hasProp(InstProp::Mma);
 }
 
 void CDNA3XdlWriteVgprXdlReadSrcCExactHazardAttr::populateHazardsFor(
@@ -830,11 +807,10 @@ void CDNA3XdlWriteVgprXdlReadSrcCExactHazardAttr::populateHazardsFor(
   assert(vdstRegTy && vdstRegTy.hasAllocatedSemantics() &&
          "vdst must have allocated register semantics");
 
-  const InstMetadata *metadata = instOp.getInstMetadata();
-  if (!metadata)
+  if (instOp.getOpCode() == OpCode::Invalid)
     return;
 
-  int16_t caseNum = getMfmaPassCase(metadata->getOpCode());
+  int16_t caseNum = getMfmaPassCase(instOp.getOpCode());
   if (caseNum < 0)
     return; // 8/16-pass MFMA not implemented
 
@@ -877,10 +853,9 @@ bool CDNA3XdlWriteVgprXdlReadSrcCExactHazardAttr::isHazardTriggered(
   if (!raiserInstOp)
     return false;
 
-  const InstMetadata *raiserMetadata = raiserInstOp.getInstMetadata();
-  assert(raiserMetadata && "Raiser metadata cannot be nullptr");
-
-  int16_t raiserPassCase = getMfmaPassCase(raiserMetadata->getOpCode());
+  assert(raiserInstOp.getOpCode() != OpCode::Invalid &&
+         "raiser must have a valid opcode");
+  int16_t raiserPassCase = getMfmaPassCase(raiserInstOp.getOpCode());
   return raiserPassCase >= 0 && raiserPassCase == caseNum;
 }
 
@@ -888,7 +863,7 @@ bool CDNA3XdlWriteVgprXdlReadSrcCExactHazardAttr::isHazardTriggered(
 // Case XdlWriteVgprXdlReadSrcCOverlapHazard
 //===----------------------------------------------------------------------===//
 bool CDNA3XdlWriteVgprXdlReadSrcCOverlapHazardAttr::matchInst(
-    const InstMetadata *, ISAVersion) const {
+    AMDGCNInstOpInterface, ISAVersion) const {
   return false; // TODO: XDL/V_SMFMA* write VGPR detection.
 }
 
@@ -903,7 +878,7 @@ bool CDNA3XdlWriteVgprXdlReadSrcCOverlapHazardAttr::isHazardTriggered(
 //===----------------------------------------------------------------------===//
 // Case XdlWriteVgprSdgemmReadSrcCHazard
 //===----------------------------------------------------------------------===//
-bool CDNA3XdlWriteVgprSdgemmReadSrcCHazardAttr::matchInst(const InstMetadata *,
+bool CDNA3XdlWriteVgprSdgemmReadSrcCHazardAttr::matchInst(AMDGCNInstOpInterface,
                                                           ISAVersion) const {
   return false; // TODO: XDL/V_SMFMA* write VGPR detection.
 }
@@ -920,10 +895,10 @@ bool CDNA3XdlWriteVgprSdgemmReadSrcCHazardAttr::isHazardTriggered(
 // Case XdlWriteVgprMfmaReadSrcABHazard
 //===----------------------------------------------------------------------===//
 bool CDNA3XdlWriteVgprMfmaReadSrcABHazardAttr::matchInst(
-    const InstMetadata *md, ISAVersion isaVer) const {
-  if (!md || !instSupportsIsa(md, isaVer))
+    AMDGCNInstOpInterface instOp, ISAVersion isaVer) const {
+  if (!instOp.supportsISA(isaVer))
     return false;
-  return md->hasProp(InstProp::Mma);
+  return instOp.hasProp(InstProp::Mma);
 }
 
 void CDNA3XdlWriteVgprMfmaReadSrcABHazardAttr::populateHazardsFor(
@@ -939,11 +914,10 @@ void CDNA3XdlWriteVgprMfmaReadSrcABHazardAttr::populateHazardsFor(
   assert(vdstRegTy && vdstRegTy.hasAllocatedSemantics() &&
          "vdst must have allocated register semantics");
 
-  const InstMetadata *metadata = instOp.getInstMetadata();
-  if (!metadata)
+  if (instOp.getOpCode() == OpCode::Invalid)
     return;
 
-  int16_t caseNum = getMfmaPassCase(metadata->getOpCode());
+  int16_t caseNum = getMfmaPassCase(instOp.getOpCode());
   if (caseNum < 0)
     return; // 8/16-pass MFMA not implemented
 
@@ -997,11 +971,9 @@ bool CDNA3XdlWriteVgprMfmaReadSrcABHazardAttr::isHazardTriggered(
   if (!raiserInstOp)
     return false;
 
-  const InstMetadata *raiserMetadata = raiserInstOp.getInstMetadata();
-  if (!raiserMetadata)
-    return false;
-
-  int16_t raiserPassCase = getMfmaPassCase(raiserMetadata->getOpCode());
+  assert(raiserInstOp.getOpCode() != OpCode::Invalid &&
+         "raiser must have a valid opcode");
+  int16_t raiserPassCase = getMfmaPassCase(raiserInstOp.getOpCode());
   return raiserPassCase >= 0 && raiserPassCase == caseNum;
 }
 
@@ -1009,10 +981,10 @@ bool CDNA3XdlWriteVgprMfmaReadSrcABHazardAttr::isHazardTriggered(
 // Case CDNA4 XdlWriteVgprMfmaReadSrcABHazard
 //===----------------------------------------------------------------------===//
 bool CDNA4XdlWriteVgprMfmaReadSrcABHazardAttr::matchInst(
-    const InstMetadata *md, ISAVersion isaVer) const {
-  if (!md || !instSupportsIsa(md, isaVer))
+    AMDGCNInstOpInterface instOp, ISAVersion isaVer) const {
+  if (!instOp.supportsISA(isaVer))
     return false;
-  return md->hasProp(InstProp::Mma);
+  return instOp.hasProp(InstProp::Mma);
 }
 
 void CDNA4XdlWriteVgprMfmaReadSrcABHazardAttr::populateHazardsFor(
@@ -1028,11 +1000,10 @@ void CDNA4XdlWriteVgprMfmaReadSrcABHazardAttr::populateHazardsFor(
   assert(vdstRegTy && vdstRegTy.hasAllocatedSemantics() &&
          "vdst must have allocated register semantics");
 
-  const InstMetadata *metadata = instOp.getInstMetadata();
-  if (!metadata)
+  if (instOp.getOpCode() == OpCode::Invalid)
     return;
 
-  int16_t caseNum = getMfmaPassCase(metadata->getOpCode());
+  int16_t caseNum = getMfmaPassCase(instOp.getOpCode());
   if (caseNum < 0)
     return;
 
@@ -1082,21 +1053,20 @@ bool CDNA4XdlWriteVgprMfmaReadSrcABHazardAttr::isHazardTriggered(
   if (!raiserInstOp)
     return false;
 
-  const InstMetadata *raiserMetadata = raiserInstOp.getInstMetadata();
-  assert(raiserMetadata && "Raiser metadata cannot be nullptr");
-
-  int16_t raiserPassCase = getMfmaPassCase(raiserMetadata->getOpCode());
+  assert(raiserInstOp.getOpCode() != OpCode::Invalid &&
+         "raiser must have a valid opcode");
+  int16_t raiserPassCase = getMfmaPassCase(raiserInstOp.getOpCode());
   return raiserPassCase >= 0 && raiserPassCase == caseNum;
 }
 
 //===----------------------------------------------------------------------===//
 // Case XdlWriteVgprVmemValuHazard
 //===----------------------------------------------------------------------===//
-bool CDNA3XdlWriteVgprVmemValuHazardAttr::matchInst(const InstMetadata *md,
-                                                    ISAVersion isaVer) const {
-  if (!md || !instSupportsIsa(md, isaVer))
+bool CDNA3XdlWriteVgprVmemValuHazardAttr::matchInst(
+    AMDGCNInstOpInterface instOp, ISAVersion isaVer) const {
+  if (!instOp.supportsISA(isaVer))
     return false;
-  return md->hasProp(InstProp::Mma);
+  return instOp.hasProp(InstProp::Mma);
 }
 
 void CDNA3XdlWriteVgprVmemValuHazardAttr::populateHazardsFor(
@@ -1112,11 +1082,10 @@ void CDNA3XdlWriteVgprVmemValuHazardAttr::populateHazardsFor(
   assert(vdstRegTy && vdstRegTy.hasAllocatedSemantics() &&
          "vdst must have allocated register semantics");
 
-  const InstMetadata *metadata = instOp.getInstMetadata();
-  if (!metadata)
+  if (instOp.getOpCode() == OpCode::Invalid)
     return;
 
-  int16_t caseNum = getMfmaPassCase(metadata->getOpCode());
+  int16_t caseNum = getMfmaPassCase(instOp.getOpCode());
   if (caseNum < 0)
     return; // 8/16-pass MFMA not implemented
 
@@ -1133,12 +1102,10 @@ bool CDNA3XdlWriteVgprVmemValuHazardAttr::isHazardTriggered(
     return false;
 
   // instOp must be VMEM, L/GDS, FLAT, Export, or VALU.
-  const InstMetadata *metadata = instOp.getInstMetadata();
-  if (!metadata ||
-      !metadata->hasAnyProps({InstProp::IsValu, InstProp::IsVmem,
-                              InstProp::Dsmem, InstProp::Flat, InstProp::Global,
-                              InstProp::Buffer}) ||
-      metadata->hasProp(InstProp::Mma))
+  if (!instOp.hasAnyProps({InstProp::IsValu, InstProp::IsVmem, InstProp::Dsmem,
+                           InstProp::Flat, InstProp::Global,
+                           InstProp::Buffer}) ||
+      instOp.hasProp(InstProp::Mma))
     return false;
 
   int16_t caseNum = hazardAttr.getCaseNum();
@@ -1185,22 +1152,20 @@ bool CDNA3XdlWriteVgprVmemValuHazardAttr::isHazardTriggered(
   if (!raiserInstOp)
     return false;
 
-  const InstMetadata *raiserMetadata = raiserInstOp.getInstMetadata();
-  if (!raiserMetadata)
-    return false;
-
-  int16_t raiserPassCase = getMfmaPassCase(raiserMetadata->getOpCode());
+  assert(raiserInstOp.getOpCode() != OpCode::Invalid &&
+         "raiser must have a valid opcode");
+  int16_t raiserPassCase = getMfmaPassCase(raiserInstOp.getOpCode());
   return raiserPassCase >= 0 && raiserPassCase == caseNum;
 }
 
 //===----------------------------------------------------------------------===//
 // Case CDNA4 XdlWriteVgprVmemValuHazard
 //===----------------------------------------------------------------------===//
-bool CDNA4XdlWriteVgprVmemValuHazardAttr::matchInst(const InstMetadata *md,
-                                                    ISAVersion isaVer) const {
-  if (!md || !instSupportsIsa(md, isaVer))
+bool CDNA4XdlWriteVgprVmemValuHazardAttr::matchInst(
+    AMDGCNInstOpInterface instOp, ISAVersion isaVer) const {
+  if (!instOp.supportsISA(isaVer))
     return false;
-  return md->hasProp(InstProp::Mma);
+  return instOp.hasProp(InstProp::Mma);
 }
 
 void CDNA4XdlWriteVgprVmemValuHazardAttr::populateHazardsFor(
@@ -1216,11 +1181,10 @@ void CDNA4XdlWriteVgprVmemValuHazardAttr::populateHazardsFor(
   assert(vdstRegTy && vdstRegTy.hasAllocatedSemantics() &&
          "vdst must have allocated register semantics");
 
-  const InstMetadata *metadata = instOp.getInstMetadata();
-  if (!metadata)
+  if (instOp.getOpCode() == OpCode::Invalid)
     return;
 
-  int16_t caseNum = getMfmaPassCase(metadata->getOpCode());
+  int16_t caseNum = getMfmaPassCase(instOp.getOpCode());
   if (caseNum < 0)
     return;
 
@@ -1236,12 +1200,10 @@ bool CDNA4XdlWriteVgprVmemValuHazardAttr::isHazardTriggered(
   if (!hazardAttr)
     return false;
 
-  const InstMetadata *metadata = instOp.getInstMetadata();
-  if (!metadata ||
-      !metadata->hasAnyProps({InstProp::IsValu, InstProp::IsVmem,
-                              InstProp::Dsmem, InstProp::Flat, InstProp::Global,
-                              InstProp::Buffer}) ||
-      metadata->hasProp(InstProp::Mma))
+  if (!instOp.hasAnyProps({InstProp::IsValu, InstProp::IsVmem, InstProp::Dsmem,
+                           InstProp::Flat, InstProp::Global,
+                           InstProp::Buffer}) ||
+      instOp.hasProp(InstProp::Mma))
     return false;
 
   int16_t caseNum = hazardAttr.getCaseNum();
@@ -1285,11 +1247,9 @@ bool CDNA4XdlWriteVgprVmemValuHazardAttr::isHazardTriggered(
   if (!raiserInstOp)
     return false;
 
-  const InstMetadata *raiserMetadata = raiserInstOp.getInstMetadata();
-  if (!raiserMetadata)
-    return false;
-
-  int16_t raiserPassCase = getMfmaPassCase(raiserMetadata->getOpCode());
+  assert(raiserInstOp.getOpCode() != OpCode::Invalid &&
+         "raiser must have a valid opcode");
+  int16_t raiserPassCase = getMfmaPassCase(raiserInstOp.getOpCode());
   return raiserPassCase >= 0 && raiserPassCase == caseNum;
 }
 
@@ -1297,7 +1257,7 @@ bool CDNA4XdlWriteVgprVmemValuHazardAttr::isHazardTriggered(
 // Case SgemmWriteVgprXdlReadSrcCExactHazard
 //===----------------------------------------------------------------------===//
 bool CDNA3SgemmWriteVgprXdlReadSrcCExactHazardAttr::matchInst(
-    const InstMetadata *, ISAVersion) const {
+    AMDGCNInstOpInterface, ISAVersion) const {
   return false; // TODO: SGEMM write VGPR detection.
 }
 
@@ -1313,7 +1273,7 @@ bool CDNA3SgemmWriteVgprXdlReadSrcCExactHazardAttr::isHazardTriggered(
 // Case SgemmWriteVgprXdlReadSrcCOverlapHazard
 //===----------------------------------------------------------------------===//
 bool CDNA3SgemmWriteVgprXdlReadSrcCOverlapHazardAttr::matchInst(
-    const InstMetadata *, ISAVersion) const {
+    AMDGCNInstOpInterface, ISAVersion) const {
   return false; // TODO: SGEMM write VGPR detection.
 }
 
@@ -1329,7 +1289,7 @@ bool CDNA3SgemmWriteVgprXdlReadSrcCOverlapHazardAttr::isHazardTriggered(
 // Case SgemmWriteVgprSdgemmReadSrcCHazard
 //===----------------------------------------------------------------------===//
 bool CDNA3SgemmWriteVgprSdgemmReadSrcCHazardAttr::matchInst(
-    const InstMetadata *, ISAVersion) const {
+    AMDGCNInstOpInterface, ISAVersion) const {
   return false; // TODO: SGEMM write VGPR detection.
 }
 
@@ -1344,8 +1304,8 @@ bool CDNA3SgemmWriteVgprSdgemmReadSrcCHazardAttr::isHazardTriggered(
 //===----------------------------------------------------------------------===//
 // Case SgemmWriteVgprMfmaReadSrcABHazard
 //===----------------------------------------------------------------------===//
-bool CDNA3SgemmWriteVgprMfmaReadSrcABHazardAttr::matchInst(const InstMetadata *,
-                                                           ISAVersion) const {
+bool CDNA3SgemmWriteVgprMfmaReadSrcABHazardAttr::matchInst(
+    AMDGCNInstOpInterface, ISAVersion) const {
   return false; // TODO: SGEMM write VGPR detection.
 }
 
@@ -1360,7 +1320,7 @@ bool CDNA3SgemmWriteVgprMfmaReadSrcABHazardAttr::isHazardTriggered(
 //===----------------------------------------------------------------------===//
 // Case SgemmWriteVgprVmemValuHazard
 //===----------------------------------------------------------------------===//
-bool CDNA3SgemmWriteVgprVmemValuHazardAttr::matchInst(const InstMetadata *,
+bool CDNA3SgemmWriteVgprVmemValuHazardAttr::matchInst(AMDGCNInstOpInterface,
                                                       ISAVersion) const {
   return false; // TODO: SGEMM write VGPR detection.
 }
@@ -1376,7 +1336,7 @@ bool CDNA3SgemmWriteVgprVmemValuHazardAttr::isHazardTriggered(
 //===----------------------------------------------------------------------===//
 // Case Mfma16x16x4F64WriteVgprHazard
 //===----------------------------------------------------------------------===//
-bool CDNA3Mfma16x16x4F64WriteVgprHazardAttr::matchInst(const InstMetadata *,
+bool CDNA3Mfma16x16x4F64WriteVgprHazardAttr::matchInst(AMDGCNInstOpInterface,
                                                        ISAVersion) const {
   return false; // TODO: V_MFMA_16x16x4_F64 detection.
 }
@@ -1392,7 +1352,7 @@ bool CDNA3Mfma16x16x4F64WriteVgprHazardAttr::isHazardTriggered(
 //===----------------------------------------------------------------------===//
 // Case Mfma4x4x4F64WriteVgprHazard
 //===----------------------------------------------------------------------===//
-bool CDNA3Mfma4x4x4F64WriteVgprHazardAttr::matchInst(const InstMetadata *,
+bool CDNA3Mfma4x4x4F64WriteVgprHazardAttr::matchInst(AMDGCNInstOpInterface,
                                                      ISAVersion) const {
   return false; // TODO: V_MFMA_4x4x4_F64 detection.
 }
@@ -1408,18 +1368,17 @@ bool CDNA3Mfma4x4x4F64WriteVgprHazardAttr::isHazardTriggered(
 //===----------------------------------------------------------------------===//
 // Case VcmpxExecMfmaHazard
 //===----------------------------------------------------------------------===//
-bool CDNA3VcmpxExecMfmaHazardAttr::matchInst(const InstMetadata *md,
+bool CDNA3VcmpxExecMfmaHazardAttr::matchInst(AMDGCNInstOpInterface instOp,
                                              ISAVersion isaVer) const {
-  if (!md || !instSupportsIsa(md, isaVer))
+  if (!instOp.supportsISA(isaVer))
     return false;
   // V_CMPX* instructions write EXEC. TODO: Check for V_CMPX* opcode.
-  return md->hasProp(InstProp::IsValu);
+  return instOp.hasProp(InstProp::IsValu);
 }
 
 void CDNA3VcmpxExecMfmaHazardAttr::populateHazardsFor(
     AMDGCNInstOpInterface instOp, SmallVectorImpl<Hazard> &hazards) const {
-  const InstMetadata *metadata = instOp.getInstMetadata();
-  if (!metadata || !metadata->hasProp(InstProp::IsValu))
+  if (!instOp.hasProp(InstProp::IsValu))
     return;
   // TODO: Check if instruction is V_CMPX* that writes EXEC.
   (void)instOp;
@@ -1428,17 +1387,14 @@ void CDNA3VcmpxExecMfmaHazardAttr::populateHazardsFor(
 
 bool CDNA3VcmpxExecMfmaHazardAttr::isHazardTriggered(
     const Hazard &, AMDGCNInstOpInterface instOp) const {
-  const InstMetadata *metadata = instOp.getInstMetadata();
-  if (!metadata)
-    return false;
   // TODO: Check if instruction is V_MFMA* (Mma covers matrix ops).
-  return metadata->hasProp(InstProp::Mma);
+  return instOp.hasProp(InstProp::Mma);
 }
 
 //===----------------------------------------------------------------------===//
 // Case XdlSmfmaReadSrcCValuWriteHazard
 //===----------------------------------------------------------------------===//
-bool CDNA3XdlSmfmaReadSrcCValuWriteHazardAttr::matchInst(const InstMetadata *,
+bool CDNA3XdlSmfmaReadSrcCValuWriteHazardAttr::matchInst(AMDGCNInstOpInterface,
                                                          ISAVersion) const {
   return false; // TODO: XDL/SMFMA read VGPR SrcC detection.
 }
@@ -1502,16 +1458,15 @@ void HazardManager::populateHazardsFor(
 
   // Walk the top operation and populate the hazard raisers by opcode.
   getTopOp()->walk([&](AMDGCNInstOpInterface instOp) {
-    const InstMetadata *md = instOp.getInstMetadata();
+    OpCode opcode = instOp.getOpCode();
 
-    // Skip instructions that don't have metadata or have already been visited.
-    if (!md || !seen.insert(md->getOpCode()).second)
+    // Skip instructions that don't have an opcode or have already been visited.
+    if (opcode == OpCode::Invalid || !seen.insert(opcode).second)
       return;
 
     // Check if the instruction has a hazard raiser.
-    OpCode opcode = md->getOpCode();
     for (HazardRaiserAttrInterface hazardRaiser : hazardRaisers) {
-      if (!hazardRaiser.matchInst(md, version))
+      if (!hazardRaiser.matchInst(instOp, version))
         continue;
       hazardAttrs.push_back({opcode, hazardRaiser});
     }
@@ -1546,14 +1501,14 @@ LogicalResult HazardManager::getHazards(AMDGCNInstOpInterface instOp,
                                         SmallVectorImpl<Hazard> &hazards) {
   LDBG() << "Getting hazards for instruction: "
          << OpWithFlags(instOp, OpPrintingFlags().skipRegions());
-  const InstMetadata *md = instOp.getInstMetadata();
-  if (!md) {
-    LDBG() << "- no metadata for instruction";
+  OpCode opcode = instOp.getOpCode();
+  if (opcode == OpCode::Invalid) {
+    LDBG() << "- no opcode for instruction";
     return success();
   }
 
   // Lookup if there are any hazard raisers for the given instruction.
-  auto [start, end] = opcodeToHazardAttrs.lookup_or(md->getOpCode(), {-1, -1});
+  auto [start, end] = opcodeToHazardAttrs.lookup_or(opcode, {-1, -1});
   if (start == -1 || end == -1) {
     LDBG() << "- no hazard patterns for instruction";
     return success();

--- a/lib/Dialect/AMDGCN/IR/SchedAttrs.cpp
+++ b/lib/Dialect/AMDGCN/IR/SchedAttrs.cpp
@@ -238,18 +238,16 @@ void GraphBuilder::handleBarrier(SchedGraph &graph, int64_t pos,
       continue;
 
     auto instOp = dyn_cast<AMDGCNInstOpInterface>(op);
-    const InstMetadata *metadata = instOp ? instOp.getInstMetadata() : nullptr;
 
-    // If there's no metadata, add an edge from the barrier to the operation.
-    if (!metadata) {
+    // If there's no interface, add an edge from the barrier to the operation.
+    if (!instOp || instOp.getOpCode() == OpCode::Invalid) {
       if (!isPure(op))
         addEdge(op, i);
       continue;
     }
 
     // If the operation has any SALU or SMEM properties, add an edge.
-    if (metadata->hasAnyProps(
-            {InstProp::Salu, InstProp::Smem, InstProp::Dsmem})) {
+    if (instOp.hasAnyProps({InstProp::Salu, InstProp::Smem, InstProp::Dsmem})) {
       addEdge(op, i);
       continue;
     }
@@ -319,13 +317,12 @@ ValueSchedulerAttr::createGraph(Block *block,
 int32_t InstPropLabelerAttr::getLabel(Operation *op, int32_t,
                                       const SchedGraph &) const {
   auto instOp = dyn_cast<AMDGCNInstOpInterface>(op);
-  const InstMetadata *metadata = instOp ? instOp.getInstMetadata() : nullptr;
-  if (!metadata)
+  if (!instOp || instOp.getOpCode() == OpCode::Invalid)
     return -1;
   ArrayRef<InstProp> matcher = getInstMatcher();
   if (matcher.empty())
     return getStage();
-  if (!metadata->hasAnyProps(matcher))
+  if (!instOp.hasAnyProps(matcher))
     return -1;
   return getStage();
 }
@@ -337,13 +334,12 @@ int32_t InstPropLabelerAttr::getLabel(Operation *op, int32_t,
 int32_t OpCodeLabelerAttr::getLabel(Operation *op, int32_t,
                                     const SchedGraph &) const {
   auto instOp = dyn_cast<AMDGCNInstOpInterface>(op);
-  const InstMetadata *metadata = instOp ? instOp.getInstMetadata() : nullptr;
-  if (!metadata)
+  if (!instOp || instOp.getOpCode() == OpCode::Invalid)
     return -1;
   ArrayRef<OpCode> matcher = getOpCodeMatcher();
   if (matcher.empty())
     return getStage();
-  OpCode opcode = metadata->getOpCode();
+  OpCode opcode = instOp.getOpCode();
   if (!llvm::is_contained(matcher, opcode))
     return -1;
   return getStage();
@@ -460,27 +456,24 @@ static QueueType classifyOp(Operation *op) {
     return *qt;
 
   auto instOp = dyn_cast<AMDGCNInstOpInterface>(op);
-  if (!instOp)
-    return QueueType::Unknown;
-  const InstMetadata *md = instOp.getInstMetadata();
-  if (!md)
+  if (!instOp || instOp.getOpCode() == OpCode::Invalid)
     return QueueType::Unknown;
 
   // SOPP (s_waitcnt, s_barrier, branches) must be scheduling barriers.
-  if (md->hasProp(InstProp::Sopp))
+  if (instOp.hasProp(InstProp::Sopp))
     return QueueType::Unknown;
-  if (md->hasProp(InstProp::Dsmem))
+  if (instOp.hasProp(InstProp::Dsmem))
     return QueueType::LGKM;
-  if (md->hasProp(InstProp::Smem))
+  if (instOp.hasProp(InstProp::Smem))
     return QueueType::LGKM;
-  if (md->hasProp(InstProp::IsVmem))
+  if (instOp.hasProp(InstProp::IsVmem))
     return QueueType::VMEM;
   // Check before VALU: MFMA ops carry both Mma and IsValu props.
-  if (md->hasAnyProps({InstProp::Mma, InstProp::ScaledMma}))
+  if (instOp.hasAnyProps({InstProp::Mma, InstProp::ScaledMma}))
     return QueueType::XDL;
-  if (md->hasProp(InstProp::Salu))
+  if (instOp.hasProp(InstProp::Salu))
     return QueueType::SALU;
-  if (md->hasProp(InstProp::IsValu))
+  if (instOp.hasProp(InstProp::IsValu))
     return QueueType::VALU;
 
   return QueueType::Unknown;

--- a/lib/Dialect/AMDGCN/IR/Utils.cpp
+++ b/lib/Dialect/AMDGCN/IR/Utils.cpp
@@ -166,22 +166,6 @@ bool mlir::aster::amdgcn::hasPackedTID(ISAVersion isa) {
   llvm_unreachable("unknown ISA version");
 }
 
-bool mlir::aster::amdgcn::isOpcodeValidForAllIsas(OpCode opcode,
-                                                  ArrayRef<ISAVersion> isas,
-                                                  MLIRContext *ctx) {
-  ArrayRef<ISAVersion> instISAVersions =
-      InstAttr::get(ctx, opcode).getMetadata()->getISAVersions();
-  if (instISAVersions.empty()) {
-    // Available on all targets.
-    return true;
-  }
-  for (ISAVersion isa : isas) {
-    if (!llvm::is_contained(instISAVersions, isa))
-      return false;
-  }
-  return true;
-}
-
 //===----------------------------------------------------------------------===//
 // KernelArgSegmentInfo
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/AMDGCN/Transforms/LegalizeOperands.cpp
+++ b/lib/Dialect/AMDGCN/Transforms/LegalizeOperands.cpp
@@ -79,10 +79,10 @@ void LegalizeOperands::runOnOperation() {
     // s_mov_b32.
     Type sgprTy = SGPRType::get(rewriter.getContext(), Register());
     Value out = AllocaOp::create(rewriter, loc, sgprTy);
-    auto instAttr = InstAttr::get(rewriter.getContext(), OpCode::S_MOV_B32);
-    Value movResult = inst::SOP1Op::create(rewriter, loc, sgprTy, instAttr, out,
-                                           selectOp.getTrueValue())
-                          .getSdstRes();
+    Value movResult =
+        inst::SOP1Op::create(rewriter, loc, sgprTy, OpCode::S_MOV_B32, out,
+                             selectOp.getTrueValue())
+            .getSdstRes();
 
     // Replace the true_value operand with the register value.
     selectOp.getTrueValueMutable().assign(movResult);

--- a/lib/Dialect/AMDGCN/Transforms/OptimizeAMDGCN.cpp
+++ b/lib/Dialect/AMDGCN/Transforms/OptimizeAMDGCN.cpp
@@ -87,10 +87,10 @@ constexpr int64_t kMaxDSConstOffset = (1 << 16) - 1;
 constexpr int64_t kMaxBufferConstOffset = (1 << 12) - 1;
 
 /// Return the maximum constant offset for the given instruction type.
-static int64_t getMaxConstOffset(const InstMetadata *md) {
-  if (md->hasProp(InstProp::Dsmem))
+static int64_t getMaxConstOffset(AMDGCNInstOpInterface instOp) {
+  if (instOp.hasProp(InstProp::Dsmem))
     return kMaxDSConstOffset;
-  if (md->hasProp(InstProp::Buffer))
+  if (instOp.hasProp(InstProp::Buffer))
     return kMaxBufferConstOffset;
   return kMaxGlobalConstOffset;
 }
@@ -109,13 +109,11 @@ static Value getI32Constant(OpBuilder &builder, Location loc, int32_t value) {
 /// modifying a mutable operand range invalidates the ranges for the other
 /// operands.
 using GetOperandsFn = llvm::function_ref<MutableOperandRange()>;
-static LogicalResult optimizeMemOpOffsets(Operation *op, const InstMetadata *md,
-                                          Value addr, Value constantOffset,
-                                          Value dynamicOffset,
-                                          GetOperandsFn addrMutable,
-                                          GetOperandsFn constantOffsetMutable,
-                                          GetOperandsFn dynamicOffsetMutable,
-                                          PatternRewriter &rewriter) {
+static LogicalResult optimizeMemOpOffsets(
+    Operation *op, AMDGCNInstOpInterface instOp, Value addr,
+    Value constantOffset, Value dynamicOffset, GetOperandsFn addrMutable,
+    GetOperandsFn constantOffsetMutable, GetOperandsFn dynamicOffsetMutable,
+    PatternRewriter &rewriter) {
 
   // Get if the address is produced by a ptr_add operation.
   auto ptrAdd = addr.getDefiningOp<amdgcn::PtrAddOp>();
@@ -126,7 +124,7 @@ static LogicalResult optimizeMemOpOffsets(Operation *op, const InstMetadata *md,
 
   // Bail if the operation is not a DS or global memory operation.
   // Buffer ops use optimizeAddiOffsets instead (no ptr_add addressing).
-  if (!md->hasAnyProps({InstProp::Dsmem, InstProp::Global}))
+  if (!instOp.hasAnyProps({InstProp::Dsmem, InstProp::Global}))
     return rewriter.notifyMatchFailure(
         op, "expected DS or global memory operation");
 
@@ -161,7 +159,7 @@ static LogicalResult optimizeMemOpOffsets(Operation *op, const InstMetadata *md,
   });
 
   // Use the correct max offset for the instruction type.
-  int64_t maxConstOff = getMaxConstOffset(md);
+  int64_t maxConstOff = getMaxConstOffset(instOp);
 
   // When possible, merge the constant offset from the ptr_add operation and the
   // mem op.
@@ -174,7 +172,7 @@ static LogicalResult optimizeMemOpOffsets(Operation *op, const InstMetadata *md,
   }
 
   // For DSMem we can only update the constant offset.
-  if (md->hasProp(InstProp::Dsmem))
+  if (instOp.hasProp(InstProp::Dsmem))
     return success(changed);
 
   // For global memory we can only update the dynamic offset if the address is
@@ -254,14 +252,14 @@ struct FoldableOperand {
   std::function<MutableOperandRange()> getMutable;
 };
 static std::optional<FoldableOperand>
-getFoldableOperand(Operation *op, const InstMetadata *md, Value addr,
+getFoldableOperand(Operation *op, AMDGCNInstOpInterface instOp, Value addr,
                    GetOperandsFn addrMutable) {
   // DS ops: fold from the addr operand (32-bit LDS address).
-  if (md->hasProp(InstProp::Dsmem))
+  if (instOp.hasProp(InstProp::Dsmem))
     return FoldableOperand{addr, addrMutable};
 
   // Buffer ops: fold from the dynamic_offset (voffset), not addr (rsrc).
-  if (md->hasProp(InstProp::Buffer)) {
+  if (instOp.hasProp(InstProp::Buffer)) {
     if (auto loadOp = dyn_cast<amdgcn::LoadOp>(op)) {
       Value dynOff = loadOp.getDynamicOffset();
       if (!dynOff)
@@ -282,7 +280,8 @@ getFoldableOperand(Operation *op, const InstMetadata *md, Value addr,
   return std::nullopt;
 }
 
-static LogicalResult optimizeAddiOffsets(Operation *op, const InstMetadata *md,
+static LogicalResult optimizeAddiOffsets(Operation *op,
+                                         AMDGCNInstOpInterface instOp,
                                          Value addr, Value constantOffset,
                                          GetOperandsFn addrMutable,
                                          GetOperandsFn constantOffsetMutable,
@@ -290,10 +289,10 @@ static LogicalResult optimizeAddiOffsets(Operation *op, const InstMetadata *md,
   // Apply to DS or buffer memory operations.
   // Global ops use 64-bit addresses via ptr_add, handled by
   // optimizeMemOpOffsets.
-  if (!md || !md->hasAnyProps({InstProp::Dsmem, InstProp::Buffer}))
+  if (!instOp.hasAnyProps({InstProp::Dsmem, InstProp::Buffer}))
     return rewriter.notifyMatchFailure(op, "not a DS or buffer memory op");
 
-  auto foldable = getFoldableOperand(op, md, addr, addrMutable);
+  auto foldable = getFoldableOperand(op, instOp, addr, addrMutable);
   if (!foldable)
     return rewriter.notifyMatchFailure(op, "no foldable operand");
 
@@ -335,7 +334,7 @@ static LogicalResult optimizeAddiOffsets(Operation *op, const InstMetadata *md,
   }
 
   // Compute merged offset with instruction-type-specific limit.
-  int64_t maxOff = getMaxConstOffset(md);
+  int64_t maxOff = getMaxConstOffset(instOp);
   int64_t mergedOff = addiConst + memOpOff;
   if (mergedOff < 0 || mergedOff > maxOff)
     return rewriter.notifyMatchFailure(op, "merged offset out of range");
@@ -355,8 +354,8 @@ static LogicalResult optimizeAddiOffsets(Operation *op, const InstMetadata *md,
 
 LogicalResult LoadOpPattern::matchAndRewrite(amdgcn::LoadOp op,
                                              PatternRewriter &rewriter) const {
-  const InstMetadata *md = op.getInstMetadata();
-  assert(md && "expected inst metadata");
+  AMDGCNInstOpInterface instOp = cast<AMDGCNInstOpInterface>(op.getOperation());
+  assert(instOp.getOpcodeAttr() && "expected opcode attribute");
   auto getAddr = [&]() -> MutableOperandRange { return op.getAddrMutable(); };
   auto getConstantOffset = [&]() -> MutableOperandRange {
     return op.getConstantOffsetMutable();
@@ -366,11 +365,11 @@ LogicalResult LoadOpPattern::matchAndRewrite(amdgcn::LoadOp op,
   };
   // Try ptr_add pattern first, then lsir.addi pattern for DS/buffer ops.
   if (succeeded(optimizeMemOpOffsets(
-          op.getOperation(), md, op.getAddr(), op.getConstantOffset(),
+          op.getOperation(), instOp, op.getAddr(), op.getConstantOffset(),
           op.getDynamicOffset(), getAddr, getConstantOffset, getDynamicOffset,
           rewriter)))
     return success();
-  return optimizeAddiOffsets(op.getOperation(), md, op.getAddr(),
+  return optimizeAddiOffsets(op.getOperation(), instOp, op.getAddr(),
                              op.getConstantOffset(), getAddr, getConstantOffset,
                              rewriter);
 }
@@ -381,8 +380,8 @@ LogicalResult LoadOpPattern::matchAndRewrite(amdgcn::LoadOp op,
 
 LogicalResult StoreOpPattern::matchAndRewrite(amdgcn::StoreOp op,
                                               PatternRewriter &rewriter) const {
-  const InstMetadata *md = op.getInstMetadata();
-  assert(md && "expected inst metadata");
+  AMDGCNInstOpInterface instOp = cast<AMDGCNInstOpInterface>(op.getOperation());
+  assert(instOp.getOpcodeAttr() && "expected opcode attribute");
   auto getAddr = [&]() -> MutableOperandRange { return op.getAddrMutable(); };
   auto getConstantOffset = [&]() -> MutableOperandRange {
     return op.getConstantOffsetMutable();
@@ -392,11 +391,11 @@ LogicalResult StoreOpPattern::matchAndRewrite(amdgcn::StoreOp op,
   };
   // Try ptr_add pattern first, then lsir.addi pattern for DS/buffer ops.
   if (succeeded(optimizeMemOpOffsets(
-          op.getOperation(), md, op.getAddr(), op.getConstantOffset(),
+          op.getOperation(), instOp, op.getAddr(), op.getConstantOffset(),
           op.getDynamicOffset(), getAddr, getConstantOffset, getDynamicOffset,
           rewriter)))
     return success();
-  return optimizeAddiOffsets(op.getOperation(), md, op.getAddr(),
+  return optimizeAddiOffsets(op.getOperation(), instOp, op.getAddr(),
                              op.getConstantOffset(), getAddr, getConstantOffset,
                              rewriter);
 }

--- a/lib/Dialect/AMDGCN/Transforms/SetMFMAPriority.cpp
+++ b/lib/Dialect/AMDGCN/Transforms/SetMFMAPriority.cpp
@@ -23,28 +23,19 @@ using namespace mlir::aster::amdgcn;
 
 namespace {
 
-/// Get instruction metadata, returning nullptr for ops that don't have an
-/// opcode attribute (e.g., TestInstOp).
-static const InstMetadata *getMetadataSafe(Operation *op) {
-  auto instOp = dyn_cast<AMDGCNInstOpInterface>(op);
-  if (!instOp)
-    return nullptr;
-  // Guard against ops like TestInstOp that implement the interface but
-  // assert in getOpcodeAttr(). Check for the attribute directly.
-  if (!op->getAttrOfType<InstAttr>("opcode"))
-    return nullptr;
-  return instOp.getInstMetadata();
-}
-
 static bool isMFMA(Operation *op) {
-  const InstMetadata *md = getMetadataSafe(op);
-  return md && (md->hasProp(InstProp::Mma) || md->hasProp(InstProp::ScaledMma));
+  auto instOp = dyn_cast<AMDGCNInstOpInterface>(op);
+  if (!instOp || instOp.getOpCode() == OpCode::Invalid)
+    return false;
+  return instOp.hasAnyProps({InstProp::Mma, InstProp::ScaledMma});
 }
 
 static bool isMemoryOp(Operation *op) {
-  const InstMetadata *md = getMetadataSafe(op);
-  return md &&
-         md->hasAnyProps({InstProp::IsVmem, InstProp::Dsmem, InstProp::Smem});
+  auto instOp = dyn_cast<AMDGCNInstOpInterface>(op);
+  if (!instOp || instOp.getOpCode() == OpCode::Invalid)
+    return false;
+  return instOp.hasAnyProps(
+      {InstProp::IsVmem, InstProp::Dsmem, InstProp::Smem});
 }
 
 static bool blockHasSetprio(Block &block) {


### PR DESCRIPTION
Use hasProp, hasAnyProps, getOpCode, and the new supportsISA method from AMDGCNInstOpInterface instead of accessing InstMetadata directly. HazardRaiserAttrInterface::matchInst now takes AMDGCNInstOpInterface.

This is in preparation for instruction revamp.

Made-with: Cursor