### PR TITLE
[amdgcn] Add AMDISAInstruction base class and new-style inst tblgen backends

### DIFF
--- a/include/aster/Dialect/AMDGCN/IR/AMDGCNInstBase.td
+++ b/include/aster/Dialect/AMDGCN/IR/AMDGCNInstBase.td
@@ -1,0 +1,182 @@
+//===- AMDGCNInstBase.td - AMDGCN Instruction base ---------*- tablegen -*-===//
+//
+// Copyright 2026 The ASTER Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the base file for AMDGCN instructions.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef AMDGCN_INSTBASE_TD
+#define AMDGCN_INSTBASE_TD
+
+include "aster/Dialect/AMDGCN/IR/AMDGCNDialect.td"
+include "aster/Dialect/AMDGCN/IR/AMDGCNTypeConstraints.td"
+include "aster/IR/Inst.td"
+
+//===----------------------------------------------------------------------===//
+// Base instruction class for AMDGCN instructions.
+//===----------------------------------------------------------------------===//
+
+def AMDInstTrait : InstructionTrait {
+  let extraConcreteClassDeclaration = [{
+    /// Returns whether the instruction is valid for the given target and encoding.
+    static LogicalResult isValid(TargetAttrInterface tgt, AMDGCNEncoding encoding, Adaptor adaptor);
+
+    /// Returns the encoding of the instruction.
+    FailureOr<Encoding> getEncoding(TargetAttrInterface tgt);
+
+    /// Get the defined values of the instruction.
+    ::mlir::LogicalResult livenessTransferFunction(
+        LivenessCallback insertCallback,
+        LivenessCallback removeCallback,
+        IsLiveCallback isLiveCallback) {
+      return ::mlir::aster::detail::livenessTransferFunctionImpl(
+        *this, insertCallback, removeCallback, isLiveCallback);
+    }
+    ResultRange getInstResults() {
+      return getInstInfo().getInstResults(getOperation()->getResults());
+    }
+
+    /// Returns the instruction properties.
+    static const ::mlir::aster::amdgcn::InstructionProps *getInstProps();
+
+    ::mlir::aster::amdgcn::InstAttr getOpcodeAttr() {
+      return nullptr;
+    }
+
+    bool hasInstProps(ArrayRef<InstProp> props, bool all) {
+      const InstructionProps *instProps = getInstProps();
+      return instProps ? instProps->hasProps(props) : false;
+    }
+
+    bool isNewInst() {
+      return true;
+    }
+  }];
+  let extraConcreteClassDefinition = [{
+    OperandRange $cppClass::getInstOuts() {
+      return getInstInfo().getInstOuts(getOperation()->getOperands());
+    }
+    OperandRange $cppClass::getInstIns() {
+      return getInstInfo().getInstIns(getOperation()->getOperands());
+    }
+    /// Returns the speculatability of the instruction.
+    Speculation::Speculatability $cppClass::getSpeculatability() {
+      return mlir::aster::detail::getInstSpeculatabilityImpl(*this);
+    }
+    InstOpInterface $cppClass::cloneInst(OpBuilder &builder, ValueRange outs, ValueRange ins) {
+      return ::mlir::aster::detail::cloneInstructionImpl<$cppClass>(*this, builder, outs, ins);
+    }
+  }];
+}
+
+class AMDISAInstruction<string mnemonic, list<Trait> opTraits = []>
+    : Instruction<AMDGCN_Dialect, mnemonic, opTraits # [
+        AMDInstTrait,
+        AMDGCNInstOpInterface,
+      ]>, AMDInstOpCode<"_" # mnemonic, "_" # mnemonic> {
+  list<InstProp> props = [];
+  code instExtraClassDeclaration = "";
+  code opcodeDecl = StrSubst<[{
+    ::mlir::aster::amdgcn::OpCode getOpCode() {
+      return ::mlir::aster::amdgcn::OpCode::_$mnemonic;
+    }
+  }], [VarRepl<"mnemonic", mnemonic>]>.result;
+  let extraClassDecls = [opcodeDecl, instExtraClassDeclaration];
+}
+
+//===----------------------------------------------------------------------===//
+// AMDGCN supported architectures.
+//===----------------------------------------------------------------------===//
+
+def CDNA3Isa : Arch<"CDNA3">;
+def CDNA4Isa : Arch<"CDNA4">;
+
+//===----------------------------------------------------------------------===//
+// Encoding name records
+//===----------------------------------------------------------------------===//
+
+def ENC_DS : Encoding<"ds">;
+def ENC_FLAT_GLBL : Encoding<"flat_glbl">;
+def ENC_MUBUF : Encoding<"mubuf">;
+def ENC_SMEM : Encoding<"smem">;
+def ENC_SOP1 : Encoding<"sop1">;
+def ENC_SOP2 : Encoding<"sop2">;
+def ENC_SOPC : Encoding<"sopc">;
+def ENC_SOPK : Encoding<"sopk">;
+def ENC_SOPP : Encoding<"sopp">;
+def ENC_VOP1 : Encoding<"vop1">;
+def ENC_VOP2 : Encoding<"vop2">;
+def ENC_VOP3 : Encoding<"vop3">;
+def ENC_VOP3P : Encoding<"vop3p">;
+def ENC_VOP3PX2 : Encoding<"vop3px2">;
+def ENC_VOPC : Encoding<"vopc">;
+def VOP3P_MFMA : Encoding<"vop3p_mfma">;
+
+//===----------------------------------------------------------------------===//
+// EncodedArch records
+//===----------------------------------------------------------------------===//
+
+def ENC_DS_CDNA3 : EncodedArch<ENC_DS, CDNA3Isa>;
+def ENC_DS_CDNA4 : EncodedArch<ENC_DS, CDNA4Isa>;
+def ENC_FLAT_GLBL_CDNA3 : EncodedArch<ENC_FLAT_GLBL, CDNA3Isa>;
+def ENC_FLAT_GLBL_CDNA4 : EncodedArch<ENC_FLAT_GLBL, CDNA4Isa>;
+def ENC_MUBUF_CDNA3 : EncodedArch<ENC_MUBUF, CDNA3Isa>;
+def ENC_MUBUF_CDNA4 : EncodedArch<ENC_MUBUF, CDNA4Isa>;
+def ENC_SMEM_CDNA3 : EncodedArch<ENC_SMEM, CDNA3Isa>;
+def ENC_SMEM_CDNA4 : EncodedArch<ENC_SMEM, CDNA4Isa>;
+def ENC_SOP1_CDNA3 : EncodedArch<ENC_SOP1, CDNA3Isa>;
+def ENC_SOP1_CDNA4 : EncodedArch<ENC_SOP1, CDNA4Isa>;
+def ENC_SOP2_CDNA3 : EncodedArch<ENC_SOP2, CDNA3Isa>;
+def ENC_SOP2_CDNA4 : EncodedArch<ENC_SOP2, CDNA4Isa>;
+def ENC_SOPC_CDNA3 : EncodedArch<ENC_SOPC, CDNA3Isa>;
+def ENC_SOPC_CDNA4 : EncodedArch<ENC_SOPC, CDNA4Isa>;
+def ENC_SOPK_CDNA3 : EncodedArch<ENC_SOPK, CDNA3Isa>;
+def ENC_SOPK_CDNA4 : EncodedArch<ENC_SOPK, CDNA4Isa>;
+def ENC_SOPP_CDNA3 : EncodedArch<ENC_SOPP, CDNA3Isa>;
+def ENC_SOPP_CDNA4 : EncodedArch<ENC_SOPP, CDNA4Isa>;
+def ENC_VOP1_CDNA3 : EncodedArch<ENC_VOP1, CDNA3Isa>;
+def ENC_VOP1_CDNA4 : EncodedArch<ENC_VOP1, CDNA4Isa>;
+def ENC_VOP2_CDNA3 : EncodedArch<ENC_VOP2, CDNA3Isa>;
+def ENC_VOP2_CDNA4 : EncodedArch<ENC_VOP2, CDNA4Isa>;
+def ENC_VOP3PX2_CDNA4 : EncodedArch<ENC_VOP3PX2, CDNA4Isa>;
+def ENC_VOP3P_CDNA3 : EncodedArch<ENC_VOP3P, CDNA3Isa>;
+def ENC_VOP3P_CDNA4 : EncodedArch<ENC_VOP3P, CDNA4Isa>;
+def ENC_VOP3_CDNA3 : EncodedArch<ENC_VOP3, CDNA3Isa>;
+def ENC_VOP3_CDNA4 : EncodedArch<ENC_VOP3, CDNA4Isa>;
+def ENC_VOPC_CDNA3 : EncodedArch<ENC_VOPC, CDNA3Isa>;
+def ENC_VOPC_CDNA4 : EncodedArch<ENC_VOPC, CDNA4Isa>;
+def VOP3P_MFMA_CDNA3 : EncodedArch<VOP3P_MFMA, CDNA3Isa>;
+def VOP3P_MFMA_CDNA4 : EncodedArch<VOP3P_MFMA, CDNA4Isa>;
+
+//===----------------------------------------------------------------------===//
+// Modifier attribute constraints
+//===----------------------------------------------------------------------===//
+
+def GDS : UnitModifier<"gds", "1=GDS, 0=LDS">;
+def GLC : UnitModifier<"glc", "If set, operation is globally coherent.">;
+def IDXEN : UnitModifier<"idxen", "If set, send VADDR as an index. If unset, treat the index as zero.">;
+def LDS : UnitModifier<"lds", "If set, data is written to LDS memory. If unset, data is read from/written to a VGPR.">;
+def NT : UnitModifier<"nt", "Non-Temporal: data is streamed or uncached.">;
+def OFFEN : UnitModifier<"offen", "If set, send VADDR as an offset. If unset, send the instruction offset stored in OFFSET. Only one of these offsets may be sent.">;
+def SC0 : UnitModifier<"sc0", "For regular load and store operations, SC0 and SC1 indicate memory scope such as wave, group, device and system. For atomics, SC0 means Atomic with return. 1 = Atomic with return, 0 = Atomic with no return.">;
+def SC1 : UnitModifier<"sc1", "For regular load and store operations, SC0 and SC1 indicate memory scope such as wave, group, device and system.">;
+
+//===----------------------------------------------------------------------===//
+// Effects
+//===----------------------------------------------------------------------===//
+
+def GlobalRead : Effect {
+  let summary = "Reads from global memory.";
+  let body = [{
+    // TODO: implement
+  }];
+}
+
+#endif // AMDGCN_INSTBASE_TD

--- a/include/aster/Dialect/AMDGCN/IR/AMDGCNInsts.td
+++ b/include/aster/Dialect/AMDGCN/IR/AMDGCNInsts.td
@@ -11,11 +11,21 @@
 #ifndef AMDGCN_INSTS_TD
 #define AMDGCN_INSTS_TD
 
+include "aster/Dialect/AMDGCN/IR/AMDGCNInstBase.td"
+include "aster/Dialect/AMDGCN/IR/Instructions/VMem.td"
+
 include "aster/Dialect/AMDGCN/IR/AMDGCNOps.td"
 
 //===----------------------------------------------------------------------===//
 // AMDGCN  Enums
 //===----------------------------------------------------------------------===//
+
+def EncodingEnum : AutoI32EnumCases<"AMDGCNEncoding",
+  "AMDGCN encodings", !instances<Encoding>() # [
+    PrettyEnumCaseInfo<"last_enc">
+  ]> {
+  let cppNamespace = "::mlir::aster::amdgcn";
+}
 
 def InstPropEnum : AutoI32EnumCases<"InstProp",
   "AMDGCN instruction properties", !instances<InstProp>() # [

--- a/tools/amdgcn-tblgen/CMakeLists.txt
+++ b/tools/amdgcn-tblgen/CMakeLists.txt
@@ -10,10 +10,12 @@ add_tablegen(amdgcn-tblgen Aster
   EXPORT Aster
   Dump.cpp
   InstAsmFormat.cpp
+  InstAsmPrinterGen.cpp
   InstBindings.cpp
   InstCommon.cpp
   InstCommon.h
   InstGen.cpp
+  InstMethodsGen.cpp
   Instruction.cpp
   Instruction.h
   main.cpp

--- a/tools/amdgcn-tblgen/InstAsmPrinterGen.cpp
+++ b/tools/amdgcn-tblgen/InstAsmPrinterGen.cpp
@@ -1,0 +1,438 @@
+//===- InstAsmPrinterGen.cpp ----------------------------------------------===//
+//
+// Copyright 2025 The ASTER Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file generates encoding-aware assembly printers for AMDGCN instructions.
+//
+//===----------------------------------------------------------------------===//
+
+#include "InstCommon.h"
+#include "aster/Support/Lexer.h"
+#include "mlir/Support/IndentedOstream.h"
+#include "mlir/TableGen/GenInfo.h"
+#include "mlir/TableGen/Operator.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/StringSet.h"
+#include "llvm/TableGen/Error.h"
+
+using namespace mlir;
+using namespace mlir::aster::amdgcn;
+using namespace mlir::aster::amdgcn::tblgen;
+
+//===----------------------------------------------------------------------===//
+// Generate encoding-aware asm printers for AMDISAInstruction records.
+//===----------------------------------------------------------------------===//
+
+/// A flattened (arch, encoding, syntax, predicate) entry for dispatch.
+struct ArchEncodingSyntax {
+  StringRef archId;
+  StringRef encodingId;
+  StringRef syntax;
+  mlir::tblgen::Pred pred;
+};
+
+/// An (arch, syntax, predicate) tuple within a single encoding.
+struct ArchSyntaxPred {
+  StringRef archId;
+  StringRef syntax;
+  mlir::tblgen::Pred pred;
+};
+
+namespace {
+/// Handler to generate the encoding-aware asm printer for an instruction.
+struct ASMPrinterHandler {
+  ASMPrinterHandler(const llvm::Record *rec);
+  void genPrinter(raw_ostream &os);
+
+private:
+  using ArgTy = std::optional<std::pair<DagArg, ASMArgFormat>>;
+
+  //===--------------------------------------------------------------------===//
+  // Syntax token emitters
+  //===--------------------------------------------------------------------===//
+
+  /// Emit a `${mnemonic}` interpolation token.
+  void emitMnemonicInterpolation(Lexer &lexer, mlir::raw_indented_ostream &os);
+  /// Emit a `$identifier` operand reference token.
+  void emitOperandRef(Lexer &lexer, mlir::raw_indented_ostream &os);
+  /// Emit a `[identifier]` modifier reference token.
+  void emitModifierRef(Lexer &lexer, mlir::raw_indented_ostream &os);
+  /// Emit a keyword token.
+  void emitKeyword(Lexer &lexer, mlir::raw_indented_ostream &os);
+
+  //===--------------------------------------------------------------------===//
+  // Higher-level emitters
+  //===--------------------------------------------------------------------===//
+
+  /// Emit the printer code for a complete ASMString syntax.
+  void emitSyntax(StringRef syntax, mlir::raw_indented_ostream &os);
+  /// Emit the printer code for a single argument.
+  void emitArg(DagArg dagArg, ASMArgFormat arg, mlir::raw_indented_ostream &os);
+  /// Emit encoding dispatch logic for all entries.
+  void emitEncodingDispatch(llvm::ArrayRef<ArchEncodingSyntax> entries,
+                            mlir::raw_indented_ostream &os);
+  /// Emit syntax guarded by a predicate (handles true-predicate elision).
+  void emitGuardedSyntax(StringRef syntax, const mlir::tblgen::Pred &pred,
+                         mlir::raw_indented_ostream &os);
+  /// Emit the body when all entries for an encoding share the same syntax.
+  void emitUniformEncoding(llvm::ArrayRef<ArchSyntaxPred> archEntries,
+                           mlir::raw_indented_ostream &os);
+  /// Emit the body when entries differ by arch within a single encoding.
+  void emitArchGroupedEncoding(llvm::ArrayRef<ArchSyntaxPred> archEntries,
+                               mlir::raw_indented_ostream &os);
+
+  /// Emit an error message.
+  void emitError(Twine msg) { llvm::PrintFatalError(&instOp.getDef(), msg); }
+
+  InstOp instOp;
+  mlir::tblgen::FmtContext ctx;
+  llvm::StringMap<ArgTy> arguments;
+};
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// Construction
+//===----------------------------------------------------------------------===//
+
+ASMPrinterHandler::ASMPrinterHandler(const llvm::Record *rec) : instOp(rec) {
+  // Collect arguments from outputs, inputs, and trailingArgs.
+  for (const Dag &dag :
+       {instOp.getOutputs(), instOp.getInputs(), instOp.getTrailingArgs()}) {
+    for (auto [i, arg] : llvm::enumerate(dag.getAsRange())) {
+      if (!ASMArgFormat::isa(arg.getAsRecord()))
+        continue;
+      arguments[arg.getName()] = {arg, ASMArgFormat(arg.getAsRecord())};
+    }
+  }
+  // Set up the format context.
+  ctx.addSubst("_inst", "_inst");
+  ctx.addSubst("_printer", "printer");
+}
+
+//===----------------------------------------------------------------------===//
+// Syntax token emitters
+//===----------------------------------------------------------------------===//
+
+void ASMPrinterHandler::emitMnemonicInterpolation(
+    Lexer &lexer, mlir::raw_indented_ostream &os) {
+  lexer.consumeChar(); // consume '$'
+  lexer.consumeChar(); // consume '{'
+  FailureOr<StringRef> id = lexer.lexIdentifier();
+  if (failed(id))
+    emitError("failed to lex interpolation in asm_syntax");
+  if (*id != "mnemonic")
+    emitError("unknown interpolation ${" + *id + "} in asm_syntax");
+  if (lexer.currentChar() != '}')
+    emitError("expected '}' in asm_syntax interpolation");
+  lexer.consumeChar(); // consume '}'
+
+  // Collect any trailing suffix (e.g. `_e64` in `${mnemonic}_e64`).
+  std::string suffix;
+  while (lexer.currentChar() == '_' || std::isalnum(lexer.currentChar())) {
+    suffix += lexer.currentChar();
+    lexer.consumeChar();
+  }
+  os << "auto _grd = $_printer.printMnemonic(\"" << instOp.getOpName() << suffix
+     << "\");\n";
+}
+
+void ASMPrinterHandler::emitOperandRef(Lexer &lexer,
+                                       mlir::raw_indented_ostream &os) {
+  lexer.consumeChar(); // consume '$'
+  FailureOr<StringRef> id = lexer.lexIdentifier();
+  if (failed(id))
+    emitError("failed to lex identifier in asm_syntax: " +
+              lexer.getCurrentPos());
+
+  ArgTy arg = arguments.lookup(*id);
+  if (!arg.has_value())
+    emitError("unknown operand $" + *id + " in asm_syntax");
+
+  emitArg(arg->first, arg->second, os);
+}
+
+void ASMPrinterHandler::emitModifierRef(Lexer &lexer,
+                                        mlir::raw_indented_ostream &os) {
+  lexer.consumeChar(); // consume '['
+  lexer.consumeWhiteSpace();
+  FailureOr<StringRef> id = lexer.lexIdentifier();
+  if (failed(id))
+    emitError("failed to lex modifier name in asm_syntax: " +
+              lexer.getCurrentPos());
+  lexer.consumeWhiteSpace();
+  if (lexer.currentChar() != ']')
+    emitError("expected ']' after modifier name in asm_syntax");
+  lexer.consumeChar(); // consume ']'
+
+  ArgTy arg = arguments.lookup(*id);
+  if (!arg.has_value())
+    emitError("unknown modifier [" + *id + "] in asm_syntax");
+
+  emitArg(arg->first, arg->second, os);
+}
+
+void ASMPrinterHandler::emitKeyword(Lexer &lexer,
+                                    mlir::raw_indented_ostream &os) {
+  FailureOr<StringRef> id = lexer.lexIdentifier();
+  if (failed(id))
+    emitError("failed to lex keyword in asm_syntax: " + lexer.getCurrentPos());
+  os << llvm::formatv("$_printer.printKeyword(\"{0}\");\n", *id);
+}
+
+//===----------------------------------------------------------------------===//
+// Higher-level emitters
+//===----------------------------------------------------------------------===//
+
+void ASMPrinterHandler::emitArg(DagArg dagArg, ASMArgFormat arg,
+                                mlir::raw_indented_ostream &os) {
+  ctx.withSelf("_inst.get" +
+               llvm::convertToCamelFromSnakeCase(dagArg.getName(), true) +
+               "()");
+  os.printReindented(mlir::tblgen::tgfmt(arg.getPrinter(), &ctx).str());
+  os << "\n";
+  ctx.withSelf("_inst");
+}
+
+void ASMPrinterHandler::emitSyntax(StringRef syntax,
+                                   mlir::raw_indented_ostream &os) {
+  Lexer lexer(syntax);
+  while (lexer.currentChar() != '\0') {
+    lexer.consumeWhiteSpace();
+    if (lexer.currentChar() == '\0')
+      break;
+
+    // `${mnemonic}` interpolation.
+    if (lexer.currentChar() == '$' && lexer.getCurrentPos().size() > 1 &&
+        lexer.getCurrentPos()[1] == '{') {
+      emitMnemonicInterpolation(lexer, os);
+      continue;
+    }
+
+    // `$identifier` operand reference.
+    if (lexer.currentChar() == '$') {
+      emitOperandRef(lexer, os);
+      continue;
+    }
+
+    // `[identifier]` modifier reference.
+    if (lexer.currentChar() == '[') {
+      emitModifierRef(lexer, os);
+      continue;
+    }
+
+    // Comma.
+    if (lexer.currentChar() == ',') {
+      lexer.consumeChar();
+      os << "$_printer.printComma();\n";
+      continue;
+    }
+
+    // Keyword.
+    if (lexer.currentChar() == '_' || std::isalpha(lexer.currentChar())) {
+      emitKeyword(lexer, os);
+      continue;
+    }
+
+    emitError("unexpected character in asm_syntax: " + lexer.getCurrentPos());
+  }
+  os << "return success();\n";
+}
+
+//===----------------------------------------------------------------------===//
+// Encoding dispatch
+//===----------------------------------------------------------------------===//
+
+void ASMPrinterHandler::emitGuardedSyntax(StringRef syntax,
+                                          const mlir::tblgen::Pred &pred,
+                                          mlir::raw_indented_ostream &os) {
+  std::string predStr = mlir::tblgen::tgfmt(pred.getCondition(), &ctx, "_inst");
+  bool isTruePred = (predStr == "true");
+  if (!isTruePred) {
+    os << "if ((" << predStr << ")) {\n";
+    os.indent();
+  }
+  emitSyntax(syntax, os);
+  if (!isTruePred) {
+    os.unindent();
+    os << "}\n";
+  }
+}
+
+void ASMPrinterHandler::emitUniformEncoding(
+    llvm::ArrayRef<ArchSyntaxPred> archEntries,
+    mlir::raw_indented_ostream &os) {
+  emitGuardedSyntax(archEntries.front().syntax, archEntries.front().pred, os);
+}
+
+void ASMPrinterHandler::emitArchGroupedEncoding(
+    llvm::ArrayRef<ArchSyntaxPred> archEntries,
+    mlir::raw_indented_ostream &os) {
+  // Collect arch order preserving encounter order.
+  llvm::SmallVector<StringRef> archOrder;
+  llvm::StringSet<> seenArchs;
+  for (const ArchSyntaxPred &asp : archEntries) {
+    if (seenArchs.insert(asp.archId).second)
+      archOrder.push_back(asp.archId);
+  }
+
+  for (StringRef archId : archOrder) {
+    llvm::SmallVector<const ArchSyntaxPred *> archGroup;
+    for (const ArchSyntaxPred &asp : archEntries) {
+      if (asp.archId == archId)
+        archGroup.push_back(&asp);
+    }
+
+    os << "if (tgt.getTargetFamily() == "
+          "::mlir::aster::amdgcn::ISAVersion::"
+       << archId << ") {\n";
+    os.indent();
+    for (const ArchSyntaxPred *asp : archGroup)
+      emitGuardedSyntax(asp->syntax, asp->pred, os);
+    os.unindent();
+    os << "}\n";
+  }
+}
+
+void ASMPrinterHandler::emitEncodingDispatch(
+    llvm::ArrayRef<ArchEncodingSyntax> entries,
+    mlir::raw_indented_ostream &os) {
+  // Collect encoding order.
+  llvm::SmallVector<StringRef> encOrder;
+  llvm::StringSet<> seenEncs;
+  for (const ArchEncodingSyntax &e : entries) {
+    if (seenEncs.insert(e.encodingId).second)
+      encOrder.push_back(e.encodingId);
+  }
+
+  for (StringRef encId : encOrder) {
+    // Collect all (arch, syntax, pred) tuples for this encoding.
+    llvm::SmallVector<ArchSyntaxPred> archEntries;
+    for (const ArchEncodingSyntax &e : entries) {
+      if (e.encodingId != encId)
+        continue;
+      archEntries.push_back({e.archId, e.syntax, e.pred});
+    }
+
+    os << "if (_enc == ::mlir::aster::amdgcn::AMDGCNEncoding::" << encId
+       << ") {\n";
+    os.indent();
+
+    // Check if all entries share the same syntax and predicate.
+    bool allSame = llvm::all_of(archEntries, [&](const ArchSyntaxPred &asp) {
+      return asp.syntax == archEntries.front().syntax &&
+             asp.pred.getCondition() == archEntries.front().pred.getCondition();
+    });
+
+    if (allSame)
+      emitUniformEncoding(archEntries, os);
+    else
+      emitArchGroupedEncoding(archEntries, os);
+
+    os.unindent();
+    os << "}\n";
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Printer function generation
+//===----------------------------------------------------------------------===//
+
+void ASMPrinterHandler::genPrinter(raw_ostream &osOut) {
+  StrStream strStream;
+  mlir::raw_indented_ostream os(strStream.os);
+  std::string qualClass = instOp.getQualCppClassName();
+
+  // Read the asm_syntax list.
+  llvm::SmallVector<ASMStringRecord> asmStrings = instOp.getAsmSyntax();
+  if (asmStrings.empty())
+    return;
+
+  // Build a flat list of (arch, encoding, syntax, predicate) entries.
+  llvm::SmallVector<ArchEncodingSyntax> entries;
+  for (const ASMStringRecord &asmStr : asmStrings) {
+    mlir::tblgen::Pred pred = asmStr.getPred();
+    for (const EncodedArchRecord &ea : asmStr.getArchs())
+      entries.push_back({ea.getArch().getIdentifier(),
+                         ea.getEncoding().getIdentifier(), asmStr.getSyntax(),
+                         pred});
+  }
+
+  // Generate the printer function.
+  ctx.withSelf("_inst");
+  os << "static ::mlir::LogicalResult print" << instOp.getCppClassName()
+     << "(\n";
+  os << "    ::mlir::aster::amdgcn::AsmPrinter &printer,\n";
+  os << "    ::mlir::aster::TargetAttrInterface tgt,\n";
+  os << "    ::mlir::Operation *op) {\n";
+  os.indent();
+  os << "auto _inst = ::llvm::cast<" << qualClass << ">(op);\n";
+  os << "(void)_inst;\n";
+  os << "auto _encOrFailure = _inst.getEncoding(tgt);\n";
+  os << "if (::mlir::failed(_encOrFailure))\n";
+  os << "  return op->emitError(\"failed to get encoding\");\n";
+  os << "auto _enc = *_encOrFailure;\n";
+
+  emitEncodingDispatch(entries, os);
+
+  os << "return ::mlir::failure();\n";
+  os.unindent();
+  os << "}\n";
+  osOut << mlir::tblgen::tgfmt(strStream.str, &ctx);
+}
+
+//===----------------------------------------------------------------------===//
+// Top-level generator
+//===----------------------------------------------------------------------===//
+
+static bool generateInstAsmPrinters(const llvm::RecordKeeper &records,
+                                    raw_ostream &os) {
+  llvm::SmallVector<const llvm::Record *> instRecs =
+      llvm::to_vector(records.getAllDerivedDefinitions("AMDISAInstruction"));
+  llvm::sort(instRecs, llvm::LessRecord());
+
+  llvm::interleave(
+      instRecs, os,
+      [&](const llvm::Record *instRec) {
+        ASMPrinterHandler handler(instRec);
+        handler.genPrinter(os);
+      },
+      "\n");
+
+  // Generate the TypeSwitch-based dispatch function.
+  os << R"(
+static ::mlir::LogicalResult printISAInstruction(
+    ::mlir::aster::amdgcn::AsmPrinter &printer,
+    ::mlir::aster::TargetAttrInterface tgt,
+    ::mlir::Operation *op) {
+  return ::llvm::TypeSwitch<::mlir::Operation *, ::mlir::LogicalResult>(op)
+)";
+  for (const llvm::Record *instRec : instRecs) {
+    InstOp inst(instRec);
+    os << "    .Case<" << inst.getQualCppClassName() << ">([&](auto) {\n";
+    os << "      return print" << inst.getCppClassName()
+       << "(printer, tgt, op);\n";
+    os << "    })\n";
+  }
+  os << R"(    .Default([](::mlir::Operation *op) {
+      return op->emitError("no ISA printer for instruction");
+    });
+}
+)";
+  return false;
+}
+
+//===----------------------------------------------------------------------===//
+// TableGen Registration
+//===----------------------------------------------------------------------===//
+
+static GenRegistration
+    generateInstAsmPrintersReg("gen-inst-asm-printers",
+                               "Generate encoding-aware inst asm printers",
+                               generateInstAsmPrinters);

--- a/tools/amdgcn-tblgen/InstCommon.cpp
+++ b/tools/amdgcn-tblgen/InstCommon.cpp
@@ -21,6 +21,15 @@ using namespace mlir;
 using namespace mlir::aster::amdgcn;
 using namespace mlir::aster::amdgcn::tblgen;
 
+llvm::SmallVector<const llvm::Record *>
+mlir::aster::amdgcn::tblgen::getSortedDerivedDefinitions(
+    const llvm::RecordKeeper &records, llvm::StringRef classType) {
+  llvm::SmallVector<const llvm::Record *> recs =
+      llvm::to_vector(records.getAllDerivedDefinitions(classType));
+  llvm::sort(recs, llvm::LessRecordByID());
+  return recs;
+}
+
 std::string mlir::aster::amdgcn::tblgen::getQualName(StringRef cppNamespace,
                                                      StringRef className) {
   if (cppNamespace.empty())
@@ -118,6 +127,49 @@ std::string mlir::aster::amdgcn::tblgen::getInstPropList(const AMDInst &inst) {
                   flag.getAsEnumCase().getIdentifier();
   });
   return str.str;
+}
+
+int InstOp::getNumOutputs() const {
+  return static_cast<int>(def->getValueAsDag("outputs")->getNumArgs());
+}
+
+int InstOp::getNumInputs() const {
+  return static_cast<int>(def->getValueAsDag("inputs")->getNumArgs());
+}
+
+int InstOp::getNumTrailingArgOperands() const {
+  Dag dag = getTrailingArgs();
+  int count = 0;
+  int odsStart = getNumOutputs() + getNumInputs();
+  for (int i = 0, e = static_cast<int>(dag.getNumArgs()); i < e; ++i) {
+    mlir::tblgen::Argument arg = op.getArg(odsStart + i);
+    if (llvm::isa<mlir::tblgen::NamedTypeConstraint *>(arg))
+      ++count;
+  }
+  return count;
+}
+
+InstSegmentInfo mlir::aster::amdgcn::tblgen::collectSegmentInfo(
+    const mlir::tblgen::Operator &op, const Dag &dag, int odsStart) {
+  InstSegmentInfo info;
+  int odsOperandIdx = 0;
+  // Compute the starting operand index by counting operands before odsStart.
+  for (int i = 0; i < odsStart; ++i) {
+    mlir::tblgen::Argument arg = op.getArg(i);
+    if (llvm::isa<mlir::tblgen::NamedTypeConstraint *>(arg))
+      ++odsOperandIdx;
+  }
+  for (int i = 0, e = static_cast<int>(dag.getNumArgs()); i < e; ++i) {
+    mlir::tblgen::Argument arg = op.getArg(odsStart + i);
+    auto *operand = llvm::dyn_cast<mlir::tblgen::NamedTypeConstraint *>(arg);
+    if (!operand)
+      continue;
+    info.names.push_back(operand->name);
+    info.kinds.push_back(getODSOperandKind(*operand));
+    info.odsIndices.push_back(odsOperandIdx);
+    ++odsOperandIdx;
+  }
+  return info;
 }
 
 /// Populate the format context with common substitutions.

--- a/tools/amdgcn-tblgen/InstCommon.h
+++ b/tools/amdgcn-tblgen/InstCommon.h
@@ -203,6 +203,45 @@ struct ISAVersion : public RecordMixin<ISAVersion> {
   EnumCaseInfo getAsEnumCase() const { return EnumCaseInfo(def); }
 };
 
+/// A concrete encoding of an instruction for a specific architecture.
+struct EncodedArchRecord : public RecordMixin<EncodedArchRecord> {
+  using Base::Base;
+  static constexpr llvm::StringRef ClassType = "EncodedArch";
+  /// Get the architecture enum case.
+  EnumCaseInfo getArch() const { return getDefAs<EnumCaseInfo>("arch"); }
+  /// Get the encoding enum case.
+  EnumCaseInfo getEncoding() const {
+    return getDefAs<EnumCaseInfo>("encoding");
+  }
+};
+
+/// A concrete instruction encoding with opcode.
+struct InstEncRecord : public RecordMixin<InstEncRecord> {
+  using Base::Base;
+  static constexpr llvm::StringRef ClassType = "InstEnc";
+  /// Get the encoded archs (encoding + architecture pairs) this encoding
+  /// applies to.
+  SmallVector<EncodedArchRecord> getEncodedArchs() const {
+    return getRecordList<EncodedArchRecord>("archs");
+  }
+  /// Get the opcode for this encoding.
+  int64_t getOpcode() const { return def->getValueAsInt("opcode"); }
+  /// Get the per-encoding type-constraint dag (head is the `pred` marker).
+  const llvm::DagInit *getConstraintsDag() const {
+    return def->getValueAsDag("constraints");
+  }
+};
+
+/// Get the encodings from an AMDISAInstruction record.
+inline SmallVector<InstEncRecord>
+getEncodingsFromRecord(const llvm::Record &rec) {
+  return llvm::map_to_vector(rec.getValueAsListInit("encodings")->getElements(),
+                             [](const llvm::Init *init) {
+                               return InstEncRecord(
+                                   cast<llvm::DefInit>(init)->getDef());
+                             });
+}
+
 /// AMDGCN instruction property definition.
 struct InstProp : public RecordMixin<InstProp> {
   using Base::Base;
@@ -246,6 +285,105 @@ struct AsmVariant : public RecordMixin<AsmVariant> {
   StringRef getAsmFormat() const { return getStringRef("asmFormat"); }
 };
 
+/// AMDGCN instruction assembly syntax string.
+struct ASMStringRecord : public RecordMixin<ASMStringRecord> {
+  using Base::Base;
+  static constexpr llvm::StringRef ClassType = "ASMString";
+
+  /// Get the list of encoded archs this syntax applies to.
+  SmallVector<EncodedArchRecord> getArchs() const {
+    return getRecordList<EncodedArchRecord>("archs");
+  }
+
+  /// Get the assembly syntax format string.
+  StringRef getSyntax() const { return getStringRef("syntax"); }
+
+  /// Get the predicate guarding this syntax.
+  mlir::tblgen::Pred getPred() const {
+    return mlir::tblgen::Pred(def->getValueInit("pred"));
+  }
+};
+
+/// Wrapper for the td `Effect` class.
+struct EffectRecord : public RecordMixin<EffectRecord> {
+  using Base::Base;
+  static constexpr llvm::StringRef ClassType = "Effect";
+
+  /// Get the summary string.
+  StringRef getSummary() const { return getStringRef("summary"); }
+
+  /// Get the code body for this effect.
+  StringRef getBody() const { return getStringRef("body"); }
+};
+
+/// Wrapper for the td `Instruction` class, providing typed accessors for
+/// encoding, effects, and assembly syntax fields.
+struct InstOp : public RecordMixin<InstOp> {
+  InstOp(const llvm::Record *def) : Base(def), op(*def) {}
+  static constexpr llvm::StringRef ClassType = "Instruction";
+
+  /// Get the associated MLIR operator.
+  const Operator &getOperator() const { return op; }
+
+  /// Get the qualified C++ class name.
+  std::string getQualCppClassName() const { return op.getQualCppClassName(); }
+
+  /// Get the unqualified C++ class name.
+  StringRef getCppClassName() const { return op.getCppClassName(); }
+
+  /// Get the operation name (mnemonic).
+  StringRef getOpName() const { return getStringRef("opName"); }
+
+  /// Get the number of output operands.
+  int getNumOutputs() const;
+
+  /// Get the number of input operands.
+  int getNumInputs() const;
+
+  /// Get the list of encodings.
+  SmallVector<InstEncRecord> getEncodings() const {
+    return getEncodingsFromRecord(*def);
+  }
+
+  /// Get the list of effects.
+  SmallVector<EffectRecord> getEffects() const {
+    return getRecordList<EffectRecord>("effects");
+  }
+
+  /// Get the list of ASMString records (encoding-aware asm syntax).
+  SmallVector<ASMStringRecord> getAsmSyntax() const {
+    return getRecordList<ASMStringRecord>("asm_syntax");
+  }
+
+  /// Get the outputs dag.
+  Dag getOutputs() const { return getDag("outputs"); }
+
+  /// Get the inputs dag.
+  Dag getInputs() const { return getDag("inputs"); }
+
+  /// Get the trailing arguments dag.
+  Dag getTrailingArgs() const { return getDag("trailingArgs"); }
+
+  /// Get the trailing results dag.
+  Dag getTrailingResults() const { return getDag("trailingResults"); }
+
+  /// Get whether this instruction wants a generated assembly format.
+  bool getGenInstAssemblyFormat() const {
+    return getBit("genInstAssemblyFormat");
+  }
+
+  /// Get the number of trailing argument SSA operands (excludes attrs).
+  int getNumTrailingArgOperands() const;
+
+  /// Get the list of instruction properties.
+  SmallVector<InstProp> getInstProps() const {
+    return getRecordList<InstProp>("props");
+  }
+
+private:
+  Operator op;
+};
+
 /// AMDGCN instruction definition.
 struct AMDInst : public RecordMixin<AMDInst> {
   AMDInst(llvm::Record const *def)
@@ -275,6 +413,11 @@ struct AMDInst : public RecordMixin<AMDInst> {
   /// Get the list of ISA versions this instruction is available on.
   SmallVector<ISAVersion> getISAVersions() const {
     return getRecordList<ISAVersion>("isa");
+  }
+
+  /// Get the list of encodings for this instruction.
+  SmallVector<InstEncRecord> getEncodings() const {
+    return getEncodingsFromRecord(instOp.getDef());
   }
 
   /// Get the list of instruction properties.
@@ -324,6 +467,56 @@ private:
 };
 
 //===----------------------------------------------------------------------===//
+// Assembly format helpers
+//===----------------------------------------------------------------------===//
+
+/// Describes the kind of an SSA operand in an instruction segment.
+/// Must match the runtime ODSOperandKind in ParsePrintUtils.h.
+enum class ODSOperandKind : int8_t {
+  Plain = 0,
+  Optional,
+  Variadic,
+};
+
+/// Returns the C++ enumerator string for an ODSOperandKind value.
+inline StringRef getODSOperandKindEnumerator(ODSOperandKind kind) {
+  switch (kind) {
+  case ODSOperandKind::Plain:
+    return "::mlir::aster::ODSOperandKind::Plain";
+  case ODSOperandKind::Optional:
+    return "::mlir::aster::ODSOperandKind::Optional";
+  case ODSOperandKind::Variadic:
+    return "::mlir::aster::ODSOperandKind::Variadic";
+  }
+  llvm_unreachable("unhandled ODSOperandKind");
+}
+
+/// Returns the ODSOperandKind for a given named type constraint.
+inline ODSOperandKind
+getODSOperandKind(const mlir::tblgen::NamedTypeConstraint &operand) {
+  if (operand.isVariadic())
+    return ODSOperandKind::Variadic;
+  if (operand.isOptional())
+    return ODSOperandKind::Optional;
+  return ODSOperandKind::Plain;
+}
+
+/// Information about one operand segment (outs, ins, or args) of an
+/// instruction, collecting the SSA operand names, kinds, and ODS indices.
+struct InstSegmentInfo {
+  llvm::SmallVector<StringRef> names;
+  llvm::SmallVector<ODSOperandKind> kinds;
+  /// ODS operand indices for each SSA operand in this segment.
+  llvm::SmallVector<int> odsIndices;
+};
+
+/// Collects InstSegmentInfo for a dag segment starting at ODS operand index
+/// \p odsStart. Only SSA operands are included (attributes are skipped).
+/// The \p Operator is used to look up the operand metadata.
+InstSegmentInfo collectSegmentInfo(const mlir::tblgen::Operator &op,
+                                   const Dag &dag, int odsStart);
+
+//===----------------------------------------------------------------------===//
 // Utility functions and classes
 //===----------------------------------------------------------------------===//
 
@@ -344,6 +537,11 @@ struct StrStream {
   std::string str;
   llvm::raw_string_ostream os;
 };
+
+/// Returns records derived from classType, sorted by ID for determinism.
+llvm::SmallVector<const llvm::Record *>
+getSortedDerivedDefinitions(const llvm::RecordKeeper &records,
+                            llvm::StringRef classType);
 
 /// Get the qualified C++ name.
 std::string getQualName(StringRef cppNamespace, StringRef className);

--- a/tools/amdgcn-tblgen/InstMethodsGen.cpp
+++ b/tools/amdgcn-tblgen/InstMethodsGen.cpp
@@ -1,0 +1,1087 @@
+//===- InstMethodsGen.cpp -------------------------------------------------===//
+//
+// Copyright 2026 The ASTER Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file generates the AMDGCN instruction method definitions.
+//
+//===----------------------------------------------------------------------===//
+
+#include "InstCommon.h"
+#include "mlir/TableGen/GenInfo.h"
+#include "mlir/TableGen/Operator.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/StringSet.h"
+#include "llvm/TableGen/CodeGenHelpers.h"
+#include "llvm/TableGen/Error.h"
+
+using namespace mlir;
+using namespace mlir::aster::amdgcn;
+using namespace mlir::aster::amdgcn::tblgen;
+
+//===----------------------------------------------------------------------===//
+// Helpers
+//===----------------------------------------------------------------------===//
+
+/// TableGen class for ISA-level instruction ops (different from AMDInst which
+/// is the instruction metadata class).
+static constexpr StringRef AMDISAInstClassType = "AMDISAInstruction";
+
+/// Returns the raw adaptor accessor expression for an operand.
+static std::string getAdaptorAccessor(StringRef name) {
+  if (name.empty())
+    return "adaptor";
+  return "adaptor.get" +
+         llvm::convertToCamelFromSnakeCase(name, /*capitalizeFirst=*/true) +
+         "()";
+}
+
+/// Returns the constraint for an operand, unwrapping Optional<...>.
+/// Returns std::nullopt when an Optional operand has no resolvable baseType.
+static std::optional<std::pair<mlir::tblgen::Constraint, bool>>
+resolveConstraint(const mlir::tblgen::NamedTypeConstraint &operand) {
+  const mlir::tblgen::TypeConstraint &tc = operand.constraint;
+  const llvm::Record *rec = &tc.getDef();
+  bool isOptional = false;
+  if (tc.isOptional()) {
+    rec = rec->getValueAsOptionalDef("baseType");
+    if (!rec)
+      return std::nullopt;
+    isOptional = true;
+  }
+  return std::pair{mlir::tblgen::TypeConstraint(rec), isOptional};
+}
+
+/// Emits a single constraint check block. `selfValue` is the raw adaptor
+/// accessor expression (e.g. `adaptor.getFoo()`). The block declares
+/// `_selfValue` (raw) and `_self` (type-or-value wrapped) locals, then checks
+/// the condition template.
+static void emitConstraintCheck(raw_ostream &os, mlir::tblgen::FmtContext &ctx,
+                                StringRef selfValue,
+                                const mlir::tblgen::Constraint &constraint,
+                                bool isOptional, StringRef failureExpr) {
+  const std::string_view body = R"(  {
+    auto &&_selfValue = $0;
+    auto &&_self = getTypeOrValue($0);
+    (void)_self;
+    (void)_selfValue;
+    if ($1!($2))
+      return $3;
+  })";
+  ctx.withSelf("_self");
+  ctx.addSubst("_selfValue", "_selfValue");
+  StringRef optionalStr = isOptional ? "_self && " : "";
+  StrStream stream;
+  stream.os << mlir::tblgen::tgfmt(body.data(), &ctx,
+                                   /*0=*/selfValue,
+                                   /*1=*/optionalStr,
+                                   /*2=*/constraint.getConditionTemplate(),
+                                   /*3=*/failureExpr);
+  os << mlir::tblgen::tgfmt(stream.str.data(), &ctx);
+}
+
+/// Parses the `constraints` dag of an encoding into a name -> Type record map.
+/// Emits a fatal error if a name does not match any operand of `op`.
+static llvm::StringMap<const llvm::Record *>
+parseEncodingOverrides(const InstEncRecord &enc,
+                       const mlir::tblgen::Operator &op) {
+  llvm::StringMap<const llvm::Record *> result;
+  const llvm::DagInit *dag = enc.getConstraintsDag();
+  for (unsigned i = 0, e = dag->getNumArgs(); i < e; ++i) {
+    StringRef name = dag->getArgNameStr(i);
+    const auto *defInit = dyn_cast<llvm::DefInit>(dag->getArg(i));
+    if (!defInit)
+      llvm::PrintFatalError(enc.getDef().getLoc(),
+                            "encoding constraint argument '" + name +
+                                "' must be a Type record");
+    bool found = false;
+    for (int j = 0, je = op.getNumOperands(); j < je; ++j) {
+      if (op.getOperand(j).name != name)
+        continue;
+      found = true;
+      break;
+    }
+    if (!found)
+      llvm::PrintFatalError(
+          enc.getDef().getLoc(),
+          "encoding constraint references unknown argument '" + name +
+              "' in op '" + op.getOperationName() + "'");
+    result[name] = defInit->getDef();
+  }
+  return result;
+}
+
+/// Collects the set of operand names that have per-encoding overrides in any
+/// encoding.
+static llvm::StringSet<>
+collectOverriddenNames(llvm::ArrayRef<InstEncRecord> encodings) {
+  llvm::StringSet<> overriddenNames;
+  for (const InstEncRecord &enc : encodings) {
+    const llvm::DagInit *dag = enc.getConstraintsDag();
+    for (unsigned i = 0, e = dag->getNumArgs(); i < e; ++i)
+      overriddenNames.insert(dag->getArgNameStr(i));
+  }
+  return overriddenNames;
+}
+
+//===----------------------------------------------------------------------===//
+// Encoding dispatch helpers
+//===----------------------------------------------------------------------===//
+
+/// A flattened (arch, encoding) pair used for dispatch iteration.
+struct ArchEncPair {
+  StringRef archId;
+  StringRef encodingId;
+  InstEncRecord enc;
+};
+
+/// Builds a flat list of (arch, encoding) pairs from the encoding list,
+/// grouped by arch in encounter order.
+static llvm::SmallVector<ArchEncPair>
+flattenEncodings(llvm::ArrayRef<InstEncRecord> encodings) {
+  llvm::SmallVector<ArchEncPair> pairs;
+  for (const InstEncRecord &enc : encodings)
+    for (const EncodedArchRecord &ea : enc.getEncodedArchs())
+      pairs.push_back({ea.getArch().getIdentifier(),
+                       ea.getEncoding().getIdentifier(), enc});
+  return pairs;
+}
+
+/// Returns the distinct arch IDs in encounter order.
+static llvm::SmallVector<StringRef>
+getArchOrder(llvm::ArrayRef<ArchEncPair> pairs) {
+  llvm::SmallVector<StringRef> order;
+  llvm::StringSet<> seen;
+  for (const ArchEncPair &p : pairs) {
+    if (seen.insert(p.archId).second)
+      order.push_back(p.archId);
+  }
+  return order;
+}
+
+//===----------------------------------------------------------------------===//
+// isValid generation (split into sub-emitters)
+//===----------------------------------------------------------------------===//
+
+/// Emits the `isValidPair` lambda that checks whether the (arch, encoding)
+/// combination is valid for this instruction.
+static void emitArchEncodingCheck(llvm::ArrayRef<ArchEncPair> pairs,
+                                  llvm::ArrayRef<StringRef> archOrder,
+                                  mlir::tblgen::FmtContext &ctx,
+                                  raw_ostream &os) {
+  os << "  auto isValidPair = [&]() -> bool {\n";
+  for (StringRef archId : archOrder) {
+    ctx.addSubst("_archId", archId);
+    os << mlir::tblgen::tgfmt(
+        R"(    if (tgt.getTargetFamily() == ::mlir::aster::amdgcn::ISAVersion::$_archId)
+      return )",
+        &ctx);
+    llvm::interleave(
+        llvm::make_filter_range(
+            pairs, [&](const ArchEncPair &p) { return p.archId == archId; }),
+        os,
+        [&](const ArchEncPair &p) {
+          ctx.addSubst("_encodingId", p.encodingId);
+          os << mlir::tblgen::tgfmt(
+              "encoding == ::mlir::aster::amdgcn::AMDGCNEncoding::$_encodingId",
+              &ctx);
+        },
+        " || ");
+    os << ";\n";
+  }
+  os << R"(    return false;
+  };
+  if (!isValidPair())
+    return ::mlir::failure();
+)";
+}
+
+/// Emits constraint checks for operands that are NOT overridden by any
+/// encoding (i.e. they have a single constraint across all encodings).
+static void emitCommonConstraints(const mlir::tblgen::Operator &op,
+                                  const llvm::StringSet<> &overriddenNames,
+                                  mlir::tblgen::FmtContext &ctx,
+                                  raw_ostream &os) {
+  for (int i = 0, e = op.getNumOperands(); i < e; ++i) {
+    const mlir::tblgen::NamedTypeConstraint &operand = op.getOperand(i);
+    if (overriddenNames.contains(operand.name))
+      continue;
+    std::optional<std::pair<mlir::tblgen::Constraint, bool>> resolved =
+        resolveConstraint(operand);
+    if (!resolved)
+      continue;
+    auto [constraint, isOptional] = *resolved;
+    emitConstraintCheck(os, ctx, getAdaptorAccessor(operand.name), constraint,
+                        isOptional, "::mlir::failure()");
+    os << "\n";
+  }
+}
+
+/// Emits the constraint checks for a single encoding's `checkEnc` lambda body.
+/// For each operand, either the encoding provides an override constraint, or
+/// the operand's default constraint is used (only for overridden operands).
+static void emitEncodingConstraintBody(
+    const mlir::tblgen::Operator &op,
+    const llvm::StringMap<const llvm::Record *> &overrides,
+    const llvm::StringSet<> &overriddenNames, mlir::tblgen::FmtContext &ctx,
+    raw_ostream &os) {
+  for (int i = 0, e = op.getNumOperands(); i < e; ++i) {
+    const mlir::tblgen::NamedTypeConstraint &operand = op.getOperand(i);
+    auto it = overrides.find(operand.name);
+    if (it != overrides.end()) {
+      emitConstraintCheck(os, ctx, getAdaptorAccessor(operand.name),
+                          mlir::tblgen::TypeConstraint(it->second),
+                          /*isOptional=*/false, "false");
+      os << "\n";
+      continue;
+    }
+    if (!overriddenNames.contains(operand.name))
+      continue;
+    std::optional<std::pair<mlir::tblgen::Constraint, bool>> resolved =
+        resolveConstraint(operand);
+    if (!resolved)
+      continue;
+    auto [constraint, isOptional] = *resolved;
+    emitConstraintCheck(os, ctx, getAdaptorAccessor(operand.name), constraint,
+                        isOptional, "false");
+    os << "\n";
+  }
+}
+
+/// Emits the encoding check block for a single (arch, encoding) pair within
+/// an arch-level `if` body.
+static void emitSingleEncodingCheck(const mlir::tblgen::Operator &op,
+                                    const ArchEncPair &p,
+                                    const llvm::StringSet<> &overriddenNames,
+                                    mlir::tblgen::FmtContext &ctx,
+                                    raw_ostream &os) {
+  llvm::StringMap<const llvm::Record *> overrides =
+      parseEncodingOverrides(p.enc, op);
+  ctx.addSubst("_encodingId", p.encodingId);
+  os << mlir::tblgen::tgfmt(
+      "    if (encoding == "
+      "::mlir::aster::amdgcn::AMDGCNEncoding::$_encodingId) "
+      "{\n",
+      &ctx);
+  os << "      auto checkEnc = [&] {\n";
+  emitEncodingConstraintBody(op, overrides, overriddenNames, ctx, os);
+  os << R"(        return true;
+      };
+      if (checkEnc()) return ::mlir::success();
+    }
+)";
+}
+
+/// Emits the per-arch, per-encoding dispatch that checks encoding-specific
+/// operand constraints.
+static void emitPerEncodingDispatch(const mlir::tblgen::Operator &op,
+                                    llvm::ArrayRef<ArchEncPair> pairs,
+                                    llvm::ArrayRef<StringRef> archOrder,
+                                    const llvm::StringSet<> &overriddenNames,
+                                    mlir::tblgen::FmtContext &ctx,
+                                    raw_ostream &os) {
+  for (StringRef archId : archOrder) {
+    ctx.addSubst("_archId", archId);
+    os << mlir::tblgen::tgfmt(
+        R"(  if (tgt.getTargetFamily() == ::mlir::aster::amdgcn::ISAVersion::$_archId) {
+)",
+        &ctx);
+    for (const ArchEncPair &p : pairs) {
+      if (p.archId != archId)
+        continue;
+      emitSingleEncodingCheck(op, p, overriddenNames, ctx, os);
+    }
+    os << R"(    return ::mlir::failure();
+  }
+)";
+  }
+  os << "  return ::mlir::failure();\n}\n\n";
+}
+
+/// Generates the static `isValid<OpName>` function for the given instruction.
+static void genIsValidFunc(const InstOp &instOp,
+                           llvm::ArrayRef<InstEncRecord> encodings,
+                           raw_ostream &os) {
+  const mlir::tblgen::Operator &op = instOp.getOperator();
+  mlir::tblgen::FmtContext ctx;
+  std::string qualClass = instOp.getQualCppClassName();
+  std::string funcName = "isValid" + instOp.getCppClassName().str();
+  llvm::StringSet<> overriddenNames = collectOverriddenNames(encodings);
+  llvm::SmallVector<ArchEncPair> pairs = flattenEncodings(encodings);
+  llvm::SmallVector<StringRef> archOrder = getArchOrder(pairs);
+
+  // Function signature.
+  ctx.addSubst("_funcName", funcName);
+  ctx.addSubst("_qualClass", qualClass);
+  const std::string_view sigBody =
+      R"(static ::mlir::LogicalResult $_funcName(
+    ::mlir::aster::TargetAttrInterface tgt,
+    ::mlir::aster::amdgcn::AMDGCNEncoding encoding,
+    $_qualClass::Adaptor adaptor) {
+)";
+  os << mlir::tblgen::tgfmt(sigBody.data(), &ctx);
+
+  emitArchEncodingCheck(pairs, archOrder, ctx, os);
+  emitCommonConstraints(op, overriddenNames, ctx, os);
+  emitPerEncodingDispatch(op, pairs, archOrder, overriddenNames, ctx, os);
+}
+
+//===----------------------------------------------------------------------===//
+// Assembly format generation helpers
+//===----------------------------------------------------------------------===//
+
+/// Emits a static constexpr C++ array of StringRef arg names.
+static void emitNameArray(raw_ostream &os, StringRef indent, StringRef varName,
+                          const InstSegmentInfo &seg) {
+  if (seg.names.empty()) {
+    os << indent << "::llvm::ArrayRef<::llvm::StringRef> " << varName
+       << "Names;\n";
+    return;
+  }
+  os << indent << "static constexpr ::llvm::StringRef " << varName
+     << "Names[] = {";
+  llvm::interleaveComma(seg.names, os,
+                        [&](StringRef n) { os << '"' << n << '"'; });
+  os << "};\n";
+}
+
+/// Emits a static constexpr C++ array of ODSOperandKind values.
+static void emitKindArray(raw_ostream &os, StringRef indent, StringRef varName,
+                          const InstSegmentInfo &seg) {
+  if (seg.kinds.empty()) {
+    os << indent << "::llvm::ArrayRef<::mlir::aster::ODSOperandKind> "
+       << varName << "Kinds;\n";
+    return;
+  }
+  os << indent << "static constexpr ::mlir::aster::ODSOperandKind " << varName
+     << "Kinds[] = {";
+  llvm::interleaveComma(seg.kinds, os, [&](ODSOperandKind k) {
+    os << getODSOperandKindEnumerator(k);
+  });
+  os << "};\n";
+}
+
+/// Collects the three instruction segments (outs, ins, args).
+struct InstSegments {
+  InstSegmentInfo outs;
+  InstSegmentInfo ins;
+  InstSegmentInfo args;
+  int numTrailingResults;
+};
+
+static InstSegments collectInstSegments(const InstOp &instOp) {
+  const mlir::tblgen::Operator &op = instOp.getOperator();
+  int numOuts = instOp.getNumOutputs();
+  int numIns = instOp.getNumInputs();
+  InstSegments segs;
+  segs.outs = collectSegmentInfo(op, instOp.getOutputs(), /*odsStart=*/0);
+  segs.ins = collectSegmentInfo(op, instOp.getInputs(), /*odsStart=*/numOuts);
+  segs.args = collectSegmentInfo(op, instOp.getTrailingArgs(),
+                                 /*odsStart=*/numOuts + numIns);
+  Dag trailingResults = instOp.getTrailingResults();
+  segs.numTrailingResults = static_cast<int>(trailingResults.getNumArgs());
+  return segs;
+}
+
+/// Returns true if the operator uses the AttrSizedOperandSegments trait.
+static bool hasAttrSizedOperandSegments(const mlir::tblgen::Operator &op) {
+  return op.getTrait("::mlir::OpTrait::AttrSizedOperandSegments") != nullptr;
+}
+
+/// Returns true if the operator uses the AttrSizedResultSegments trait.
+static bool hasAttrSizedResultSegments(const mlir::tblgen::Operator &op) {
+  return op.getTrait("::mlir::OpTrait::AttrSizedResultSegments") != nullptr;
+}
+
+//===----------------------------------------------------------------------===//
+// parse() generation
+//===----------------------------------------------------------------------===//
+
+/// Emits the segment size assignment for AttrSizedOperandSegments properties.
+static void emitSetSegmentSizes(raw_ostream &os, StringRef className,
+                                int totalODSOperands) {
+  os << "  // Set operand segment sizes.\n";
+  os << "  auto &_props = "
+        "result.getOrAddProperties<"
+     << className << "::Properties>();\n";
+  for (int i = 0; i < totalODSOperands; ++i)
+    os << "  _props.operandSegmentSizes[" << i << "] = segmentSizes[" << i
+       << "];\n";
+}
+
+/// Emits a parseInstOperands call for a segment.
+static void emitParseSegmentCall(raw_ostream &os, StringRef varName,
+                                 const InstSegmentInfo &seg) {
+  if (seg.names.empty())
+    return;
+  os << "  if (failed(::mlir::aster::parseInstOperands(\n"
+     << "          parser, \"" << varName << "\", " << varName << "Operands, "
+     << varName << "Names, " << varName << "Kinds, " << varName
+     << "SegSizes)))\n"
+     << "    return ::mlir::failure();\n";
+}
+
+/// Emits a parseInstOperandTypes call for a segment.
+static void emitParseTypeSegmentCall(raw_ostream &os, StringRef varName,
+                                     const InstSegmentInfo &seg) {
+  if (seg.names.empty())
+    return;
+  os << "  if (failed(::mlir::aster::parseInstOperandTypes(\n"
+     << "          parser, \"" << varName << "\", " << varName << "Types, "
+     << varName << "Names, " << varName << "Kinds, " << varName
+     << "SegSizes)))\n"
+     << "    return ::mlir::failure();\n";
+}
+
+/// Emits the parse() method body for one instruction.
+static void genParseMethod(const InstOp &instOp, StringRef className,
+                           const InstSegments &segs, raw_ostream &os) {
+  const mlir::tblgen::Operator &op = instOp.getOperator();
+  bool hasSegSizes = hasAttrSizedOperandSegments(op);
+  mlir::tblgen::FmtContext ctx;
+  ctx.addSubst("_className", className);
+
+  int numOutsODS = static_cast<int>(segs.outs.names.size());
+  int numInsODS = static_cast<int>(segs.ins.names.size());
+  int numArgsODS = static_cast<int>(segs.args.names.size());
+  int totalODS = numOutsODS + numInsODS + numArgsODS;
+  bool hasOuts = numOutsODS > 0;
+  bool hasIns = numInsODS > 0;
+  bool hasArgs = numArgsODS > 0;
+
+  // Signature.
+  os << mlir::tblgen::tgfmt(
+      R"(::mlir::ParseResult
+$_className::parse(::mlir::OpAsmParser &parser,
+                   ::mlir::OperationState &result) {
+)",
+      &ctx);
+
+  // Declare per-segment operand and type vectors only for segments that exist.
+  if (hasOuts)
+    os << "  ::llvm::SmallVector<::mlir::OpAsmParser::UnresolvedOperand> "
+          "outsOperands;\n"
+       << "  ::llvm::SmallVector<::mlir::Type> outsTypes;\n";
+  if (hasIns)
+    os << "  ::llvm::SmallVector<::mlir::OpAsmParser::UnresolvedOperand> "
+          "insOperands;\n"
+       << "  ::llvm::SmallVector<::mlir::Type> insTypes;\n";
+  if (hasArgs)
+    os << "  ::llvm::SmallVector<::mlir::OpAsmParser::UnresolvedOperand> "
+          "argsOperands;\n"
+       << "  ::llvm::SmallVector<::mlir::Type> argsTypes;\n";
+
+  if (totalODS > 0) {
+    // Statically allocate segment sizes in one chunk.
+    os << "  std::array<int32_t, " << totalODS << "> segmentSizes{};\n";
+    if (hasOuts)
+      os << "  ::llvm::MutableArrayRef<int32_t> "
+            "outsSegSizes(segmentSizes.data(), "
+         << "static_cast<size_t>(" << numOutsODS << "));\n";
+    if (hasIns)
+      os << "  ::llvm::MutableArrayRef<int32_t> "
+            "insSegSizes(segmentSizes.data() + "
+         << numOutsODS << ", static_cast<size_t>(" << numInsODS << "));\n";
+    if (hasArgs)
+      os << "  ::llvm::MutableArrayRef<int32_t> "
+            "argsSegSizes(segmentSizes.data() + "
+         << (numOutsODS + numInsODS) << ", static_cast<size_t>(" << numArgsODS
+         << "));\n";
+
+    // Emit name/kind arrays once for each segment that has operands.
+    if (hasOuts) {
+      emitNameArray(os, "  ", "outs", segs.outs);
+      emitKindArray(os, "  ", "outs", segs.outs);
+    }
+    if (hasIns) {
+      emitNameArray(os, "  ", "ins", segs.ins);
+      emitKindArray(os, "  ", "ins", segs.ins);
+    }
+    if (hasArgs) {
+      emitNameArray(os, "  ", "args", segs.args);
+      emitKindArray(os, "  ", "args", segs.args);
+    }
+
+    // Parse operand segments.
+    emitParseSegmentCall(os, "outs", segs.outs);
+    emitParseSegmentCall(os, "ins", segs.ins);
+    emitParseSegmentCall(os, "args", segs.args);
+  }
+
+  // Parse attr-dict.
+  os << R"(  {
+    auto loc = parser.getCurrentLocation();
+    (void)loc;
+    if (parser.parseOptionalAttrDict(result.attributes))
+      return ::mlir::failure();
+    if (failed(verifyInherentAttrs(result.name, result.attributes, [&]() {
+        return parser.emitError(loc) << "'" << result.name.getStringRef()
+                                     << "' op ";
+      })))
+      return ::mlir::failure();
+  }
+)";
+
+  if (totalODS > 0) {
+    // Parse colon.
+    os << "  if (parser.parseColon())\n"
+          "    return ::mlir::failure();\n";
+
+    // Parse type segments.
+    emitParseTypeSegmentCall(os, "outs", segs.outs);
+    emitParseTypeSegmentCall(os, "ins", segs.ins);
+    emitParseTypeSegmentCall(os, "args", segs.args);
+  }
+
+  // Parse trailing result types.
+  if (segs.numTrailingResults > 0) {
+    os << R"(  ::llvm::SmallVector<::mlir::Type> trailingResultTypes;
+  if (parser.parseArrow() || parser.parseTypeList(trailingResultTypes))
+    return ::mlir::failure();
+)";
+  }
+
+  if (totalODS > 0) {
+    // Resolve operands.
+    os << "  // Resolve operands in ODS order: outs, ins, args.\n";
+    os << "  ::llvm::SMLoc allOperandLoc = parser.getCurrentLocation();\n";
+    os << "  ::llvm::SmallVector<::mlir::OpAsmParser::UnresolvedOperand> "
+          "allOperands;\n";
+    os << "  ::llvm::SmallVector<::mlir::Type> allOperandTypes;\n";
+    if (hasOuts) {
+      os << "  llvm::append_range(allOperands, outsOperands);\n";
+      os << "  llvm::append_range(allOperandTypes, outsTypes);\n";
+    }
+    if (hasIns) {
+      os << "  llvm::append_range(allOperands, insOperands);\n";
+      os << "  llvm::append_range(allOperandTypes, insTypes);\n";
+    }
+    if (hasArgs) {
+      os << "  llvm::append_range(allOperands, argsOperands);\n";
+      os << "  llvm::append_range(allOperandTypes, argsTypes);\n";
+    }
+    os << "  if (parser.resolveOperands(allOperands, allOperandTypes, "
+          "allOperandLoc,\n"
+       << "                             result.operands))\n"
+       << "    return ::mlir::failure();\n";
+
+    // Set segment sizes if needed.
+    if (hasSegSizes)
+      emitSetSegmentSizes(os, className, totalODS);
+  }
+
+  // Ensure properties are allocated so inferReturnTypes can populate them.
+  bool hasResultSegSizes = hasAttrSizedResultSegments(op);
+  if (hasResultSegSizes && !hasSegSizes) {
+    os << "  // Allocate properties for result segment sizes.\n";
+    os << "  result.getOrAddProperties<" << className << "::Properties>();\n";
+  }
+
+  // Infer return types.
+  os << mlir::tblgen::tgfmt(
+      R"(  ::llvm::SmallVector<::mlir::Type> inferredReturnTypes;
+  if (::mlir::failed($_className::inferReturnTypes(
+          parser.getContext(), result.location, result.operands,
+          result.attributes.getDictionary(parser.getContext()),
+          result.getRawProperties(), result.regions, inferredReturnTypes)))
+    return ::mlir::failure();
+  result.addTypes(inferredReturnTypes);
+)",
+      &ctx);
+
+  // Verify parsed trailing result types match inferred ones.
+  if (segs.numTrailingResults > 0) {
+    os << "  {\n";
+    os << "    ::mlir::ArrayRef<::mlir::Type> inferredTrailing =\n";
+    os << "        ::mlir::ArrayRef(inferredReturnTypes).take_back("
+       << segs.numTrailingResults << ");\n";
+    os << "    if (!trailingResultTypes.empty() &&\n";
+    os << "        ::mlir::TypeRange(trailingResultTypes) != "
+          "::mlir::TypeRange(inferredTrailing))\n";
+    os << "      return parser.emitError(parser.getCurrentLocation(),\n";
+    os << "          \"trailing result types do not match inferred types\");\n";
+    os << "  }\n";
+  }
+
+  os << "  return ::mlir::success();\n}\n\n";
+}
+
+//===----------------------------------------------------------------------===//
+// print() generation
+//===----------------------------------------------------------------------===//
+
+/// Emits the list of attribute names to elide from attr-dict printing.
+static void emitElidedAttrs(raw_ostream &os, const InstOp &instOp,
+                            bool hasSegSizes) {
+  const mlir::tblgen::Operator &op = instOp.getOperator();
+  os << "  ::llvm::SmallVector<::llvm::StringRef, 2> elidedAttrs;\n";
+  if (hasSegSizes)
+    os << "  elidedAttrs.push_back(\"operandSegmentSizes\");\n";
+  if (op.getTrait("::mlir::OpTrait::AttrSizedResultSegments"))
+    os << "  elidedAttrs.push_back(\"resultSegmentSizes\");\n";
+}
+
+/// Emits operand range + printInstOperands call for a segment.
+static void emitPrintSegmentCall(raw_ostream &os, StringRef varName,
+                                 const InstSegmentInfo &seg) {
+  if (seg.names.empty())
+    return;
+  os << "  {\n";
+  os << "    auto [_start, _size] = getODSOperandIndexAndLength("
+     << seg.odsIndices.front() << ");\n";
+  if (seg.odsIndices.size() > 1) {
+    int lastIdx = seg.odsIndices.back();
+    os << "    auto [_lastStart, _lastSize] = getODSOperandIndexAndLength("
+       << lastIdx << ");\n";
+    os << "    int64_t _totalSize = (_lastStart + _lastSize) - _start;\n";
+  } else {
+    os << "    int64_t _totalSize = _size;\n";
+  }
+  os << "    ::mlir::OperandRange " << varName
+     << "Operands = getOperation()->getOperands().slice(_start, "
+        "_totalSize);\n";
+  os << "    ::mlir::aster::printInstOperands(_odsPrinter, \"" << varName
+     << "\", " << varName << "Operands, " << varName << "Names, " << varName
+     << "Kinds, " << varName << "SegSizes);\n";
+  os << "  }\n";
+}
+
+/// Emits type range + printInstOperandTypes call for a segment.
+static void emitPrintTypeSegmentCall(raw_ostream &os, StringRef varName,
+                                     const InstSegmentInfo &seg) {
+  if (seg.names.empty())
+    return;
+  os << "  {\n";
+  os << "    auto [_start, _size] = getODSOperandIndexAndLength("
+     << seg.odsIndices.front() << ");\n";
+  if (seg.odsIndices.size() > 1) {
+    int lastIdx = seg.odsIndices.back();
+    os << "    auto [_lastStart, _lastSize] = getODSOperandIndexAndLength("
+       << lastIdx << ");\n";
+    os << "    int64_t _totalSize = (_lastStart + _lastSize) - _start;\n";
+  } else {
+    os << "    int64_t _totalSize = _size;\n";
+  }
+  os << "    ::mlir::OperandRange " << varName
+     << "TypeOps = getOperation()->getOperands().slice(_start, "
+        "_totalSize);\n";
+  os << "    ::mlir::aster::printInstOperandTypes(_odsPrinter, \"" << varName
+     << "\", " << varName << "TypeOps.getTypes(), " << varName << "Names, "
+     << varName << "Kinds, " << varName << "SegSizes);\n";
+  os << "  }\n";
+}
+
+/// Emits the print() method body for one instruction.
+static void genPrintMethod(const InstOp &instOp, StringRef className,
+                           const InstSegments &segs, raw_ostream &os) {
+  const mlir::tblgen::Operator &op = instOp.getOperator();
+  bool hasSegSizes = hasAttrSizedOperandSegments(op);
+  mlir::tblgen::FmtContext ctx;
+  ctx.addSubst("_className", className);
+
+  int numOutsODS = static_cast<int>(segs.outs.names.size());
+  int numInsODS = static_cast<int>(segs.ins.names.size());
+  int numArgsODS = static_cast<int>(segs.args.names.size());
+  int totalODS = numOutsODS + numInsODS + numArgsODS;
+  bool hasOuts = numOutsODS > 0;
+  bool hasIns = numInsODS > 0;
+  bool hasArgs = numArgsODS > 0;
+
+  // Signature.
+  os << mlir::tblgen::tgfmt(
+      R"(void $_className::print(::mlir::OpAsmPrinter &_odsPrinter) {
+)",
+      &ctx);
+
+  if (totalODS > 0) {
+    // Allocate segment sizes in one chunk and fill from ODS metadata.
+    os << "  std::array<int32_t, " << totalODS << "> segmentSizes{};\n";
+    {
+      int flatIdx = 0;
+      auto emitSegSizeFill = [&](const InstSegmentInfo &seg) {
+        for (int odsIdx : seg.odsIndices) {
+          os << "  segmentSizes[" << flatIdx
+             << "] = std::get<1>(getODSOperandIndexAndLength(" << odsIdx
+             << "));\n";
+          ++flatIdx;
+        }
+      };
+      if (hasOuts)
+        emitSegSizeFill(segs.outs);
+      if (hasIns)
+        emitSegSizeFill(segs.ins);
+      if (hasArgs)
+        emitSegSizeFill(segs.args);
+    }
+    if (hasOuts)
+      os << "  ::llvm::ArrayRef<int32_t> outsSegSizes(segmentSizes.data(), "
+         << "static_cast<size_t>(" << numOutsODS << "));\n";
+    if (hasIns)
+      os << "  ::llvm::ArrayRef<int32_t> insSegSizes(segmentSizes.data() + "
+         << numOutsODS << ", static_cast<size_t>(" << numInsODS << "));\n";
+    if (hasArgs)
+      os << "  ::llvm::ArrayRef<int32_t> argsSegSizes(segmentSizes.data() + "
+         << (numOutsODS + numInsODS) << ", static_cast<size_t>(" << numArgsODS
+         << "));\n";
+
+    // Emit name/kind arrays once for each segment that has operands.
+    if (hasOuts) {
+      emitNameArray(os, "  ", "outs", segs.outs);
+      emitKindArray(os, "  ", "outs", segs.outs);
+    }
+    if (hasIns) {
+      emitNameArray(os, "  ", "ins", segs.ins);
+      emitKindArray(os, "  ", "ins", segs.ins);
+    }
+    if (hasArgs) {
+      emitNameArray(os, "  ", "args", segs.args);
+      emitKindArray(os, "  ", "args", segs.args);
+    }
+
+    // Print operand segments.
+    emitPrintSegmentCall(os, "outs", segs.outs);
+    emitPrintSegmentCall(os, "ins", segs.ins);
+    emitPrintSegmentCall(os, "args", segs.args);
+  }
+
+  // Print attr-dict.
+  emitElidedAttrs(os, instOp, hasSegSizes);
+  os << "  _odsPrinter.printOptionalAttrDict((*this)->getAttrs(), "
+        "elidedAttrs);\n";
+
+  if (totalODS > 0) {
+    // Print colon and type segments.
+    os << "  _odsPrinter << \" :\";\n";
+
+    emitPrintTypeSegmentCall(os, "outs", segs.outs);
+    emitPrintTypeSegmentCall(os, "ins", segs.ins);
+    emitPrintTypeSegmentCall(os, "args", segs.args);
+  }
+
+  // Print trailing result types.
+  if (segs.numTrailingResults > 0) {
+    os << "  _odsPrinter << \" -> \";\n";
+    os << "  llvm::interleaveComma(getOperation()->getResults().take_back("
+       << segs.numTrailingResults << ").getTypes(), _odsPrinter);\n";
+  }
+
+  os << "}\n\n";
+}
+
+//===----------------------------------------------------------------------===//
+// Other method generators
+//===----------------------------------------------------------------------===//
+
+static void genIsValidMethod(const InstOp &instOp, StringRef className,
+                             raw_ostream &os) {
+  std::string funcName = "isValid" + instOp.getCppClassName().str();
+  mlir::tblgen::FmtContext ctx;
+  ctx.addSubst("_className", className);
+  ctx.addSubst("_funcName", funcName);
+  const std::string_view body =
+      R"(::mlir::LogicalResult
+$_className::isValid(::mlir::aster::TargetAttrInterface tgt,
+    ::mlir::aster::amdgcn::AMDGCNEncoding encoding,
+    $_className::Adaptor adaptor) {
+  return $_funcName(tgt, encoding, adaptor);
+}
+
+)";
+  os << mlir::tblgen::tgfmt(body.data(), &ctx);
+}
+
+static void genGetEncoding(const InstOp &instOp, StringRef className,
+                           llvm::ArrayRef<InstEncRecord> encodings,
+                           raw_ostream &os) {
+  mlir::tblgen::FmtContext ctx;
+  ctx.addSubst("_className", className);
+  llvm::SmallVector<ArchEncPair> pairs = flattenEncodings(encodings);
+  llvm::SmallVector<StringRef> archOrder = getArchOrder(pairs);
+
+  os << "// Instruction: " << instOp.getOperator().getOperationName() << "\n";
+  const std::string_view sigBody =
+      R"(mlir::FailureOr<::mlir::aster::Encoding>
+$_className::getEncoding(::mlir::aster::TargetAttrInterface tgt) {
+  Adaptor _adaptor(*this);
+)";
+  os << mlir::tblgen::tgfmt(sigBody.data(), &ctx);
+
+  for (StringRef archId : archOrder) {
+    ctx.addSubst("_archId", archId);
+    os << mlir::tblgen::tgfmt(
+        R"(  if (tgt.getTargetFamily() == ::mlir::aster::amdgcn::ISAVersion::$_archId) {
+)",
+        &ctx);
+    for (const ArchEncPair &p : pairs) {
+      if (p.archId != archId)
+        continue;
+      ctx.addSubst("_encodingId", p.encodingId);
+      os << mlir::tblgen::tgfmt(
+          R"(    if (::mlir::succeeded(isValid(tgt, ::mlir::aster::amdgcn::AMDGCNEncoding::$_encodingId, _adaptor)))
+      return mlir::aster::Encoding::get(::mlir::aster::amdgcn::AMDGCNEncoding::$_encodingId);
+)",
+          &ctx);
+    }
+    os << R"(    return ::mlir::failure();
+  }
+)";
+  }
+  os << "  return ::mlir::failure();\n}\n\n";
+}
+
+static void genGetEffects(const InstOp &instOp, StringRef className,
+                          raw_ostream &os) {
+  mlir::tblgen::FmtContext ctx;
+  ctx.withSelf("(*this)");
+  ctx.addSubst("_className", className);
+  ctx.addSubst("_op", "(*this)");
+  ctx.addSubst("_effects", "effects");
+  const std::string_view sigBody =
+      R"(void $_className::getEffects(
+    ::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects) {
+)";
+  os << mlir::tblgen::tgfmt(sigBody.data(), &ctx);
+  for (const EffectRecord &effect : instOp.getEffects()) {
+    StringRef body = effect.getBody();
+    if (body.empty())
+      continue;
+    os << "  " << mlir::tblgen::tgfmt(body, &ctx) << "\n";
+  }
+  os << R"(  ::mlir::aster::detail::getInstEffectsImpl(*this, effects);
+}
+
+)";
+}
+
+static void genInferReturnTypes(const InstOp &instOp, StringRef className,
+                                raw_ostream &os) {
+  const mlir::tblgen::Operator &op = instOp.getOperator();
+  int numOutputs = instOp.getNumOutputs();
+  Dag trailingResults = instOp.getTrailingResults();
+  int numTrailingResults = static_cast<int>(trailingResults.getNumArgs());
+  bool hasResultSegSizes = hasAttrSizedResultSegments(op);
+  bool hasResults = numOutputs > 0 || numTrailingResults > 0;
+
+  mlir::tblgen::FmtContext ctx;
+  ctx.addSubst("_className", className);
+
+  const std::string_view sigBody =
+      R"(::llvm::LogicalResult $_className::inferReturnTypes(
+    ::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location,
+    ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes,
+    ::mlir::PropertyRef properties, ::mlir::RegionRange regions,
+    ::llvm::SmallVectorImpl<::mlir::Type> &inferredReturnTypes) {
+)";
+  os << mlir::tblgen::tgfmt(sigBody.data(), &ctx);
+
+  if (!hasResults) {
+    os << "  return ::mlir::success();\n}\n\n";
+    return;
+  }
+
+  os << mlir::tblgen::tgfmt(
+      "  $_className::Adaptor adaptor(operands, attributes, properties, "
+      "regions);\n",
+      &ctx);
+
+  // Declare per-output result counters when result segment sizes are needed.
+  int numResultSegments = numOutputs + numTrailingResults;
+  if (hasResultSegSizes)
+    os << "  std::array<int32_t, " << numResultSegments
+       << "> _resultSegSizes{};\n";
+
+  // Infer result types from output operands.
+  for (int i = 0; i < numOutputs; ++i) {
+    if (hasResultSegSizes) {
+      os << mlir::tblgen::tgfmt(
+          R"(  {
+    auto [_start, _size] = adaptor.getODSOperandIndexAndLength($0);
+    for (::mlir::Type _ty : ::mlir::TypeRange(operands.slice(_start, _size))) {
+      auto _regTy = ::llvm::dyn_cast<::mlir::aster::RegisterTypeInterface>(_ty);
+      if (_regTy && _regTy.hasValueSemantics()) {
+        inferredReturnTypes.push_back(_ty);
+        ++_resultSegSizes[$0];
+      }
+    }
+  }
+)",
+          &ctx, /*0=*/std::to_string(i));
+    } else {
+      os << mlir::tblgen::tgfmt(
+          R"(  {
+    auto [_start, _size] = adaptor.getODSOperandIndexAndLength($0);
+    for (::mlir::Type _ty : ::mlir::TypeRange(operands.slice(_start, _size))) {
+      auto _regTy = ::llvm::dyn_cast<::mlir::aster::RegisterTypeInterface>(_ty);
+      if (_regTy && _regTy.hasValueSemantics())
+        inferredReturnTypes.push_back(_ty);
+    }
+  }
+)",
+          &ctx, /*0=*/std::to_string(i));
+    }
+  }
+
+  // Infer buildable trailing result types.
+  if (numTrailingResults > 0) {
+    int numOutputResults = op.getNumResults() - numTrailingResults;
+    mlir::tblgen::FmtContext builderCtx;
+    builderCtx.withBuilder("odsBuilder");
+    builderCtx.addSubst("_ctxt", "context");
+
+    // Validate that all trailing results are buildable and not optional.
+    for (int i = 0; i < numTrailingResults; ++i) {
+      const mlir::tblgen::NamedTypeConstraint &result =
+          op.getResult(numOutputResults + i);
+      if (result.isOptional())
+        llvm::PrintFatalError(op.getLoc(), "trailing result '" + result.name +
+                                               "' must not be optional");
+      if (!result.constraint.getBuilderCall())
+        llvm::PrintFatalError(op.getLoc(), "trailing result '" + result.name +
+                                               "' must have a buildable type");
+    }
+
+    os << "  ::mlir::Builder odsBuilder(context);\n";
+    for (int i = 0; i < numTrailingResults; ++i) {
+      const mlir::tblgen::NamedTypeConstraint &result =
+          op.getResult(numOutputResults + i);
+      os << "  inferredReturnTypes.push_back("
+         << mlir::tblgen::tgfmt(*result.constraint.getBuilderCall(),
+                                &builderCtx)
+         << ");\n";
+      if (hasResultSegSizes)
+        os << "  _resultSegSizes[" << (numOutputs + i) << "] = 1;\n";
+    }
+  }
+
+  // Write the result segment sizes into the properties.
+  if (hasResultSegSizes) {
+    os << mlir::tblgen::tgfmt(
+        R"(  if (properties) {
+    auto *_props = properties.as<$_className::Properties *>();
+    _props->setResultSegmentSizes(_resultSegSizes);
+  }
+)",
+        &ctx);
+  }
+
+  os << "  return ::mlir::success();\n}\n\n";
+}
+
+static void genGetInstInfo(const InstOp &instOp, StringRef className,
+                           raw_ostream &os) {
+  int numOutputs = instOp.getNumOutputs();
+  int numInputs = instOp.getNumInputs();
+  mlir::tblgen::FmtContext ctx;
+  ctx.addSubst("_className", className);
+
+  const std::string_view sigBody =
+      R"(::mlir::aster::InstOpInfo $_className::getInstInfo() {
+  int32_t numInstOuts = 0;
+)";
+  os << mlir::tblgen::tgfmt(sigBody.data(), &ctx);
+  for (int i = 0; i < numOutputs; ++i)
+    os << mlir::tblgen::tgfmt(
+        "  numInstOuts += std::get<1>(getODSOperandIndexAndLength($0));\n",
+        &ctx, /*0=*/std::to_string(i));
+  os << "  int32_t numInstIns = 0;\n";
+  for (int i = 0; i < numInputs; ++i)
+    os << mlir::tblgen::tgfmt(
+        "  numInstIns += std::get<1>(getODSOperandIndexAndLength($0));\n", &ctx,
+        /*0=*/std::to_string(numOutputs + i));
+  os << "  int32_t numInstResults = 0;\n";
+  for (int i = 0; i < numOutputs; ++i)
+    os << mlir::tblgen::tgfmt(
+        "  numInstResults += std::get<1>(getODSResultIndexAndLength($0));\n",
+        &ctx, /*0=*/std::to_string(i));
+  os << R"(  return ::mlir::aster::InstOpInfo(
+      /*numLeadingOperands=*/0, numInstOuts, numInstIns,
+      /*numLeadingResults=*/0, numInstResults);
+}
+
+)";
+}
+
+static void genGetInstProps(const InstOp &instOp, StringRef className,
+                            raw_ostream &os) {
+  mlir::tblgen::FmtContext ctx;
+  ctx.addSubst("_className", className);
+  llvm::SmallVector<InstProp> props = instOp.getInstProps();
+  if (props.empty()) {
+    os << mlir::tblgen::tgfmt(
+        R"(const ::mlir::aster::amdgcn::InstructionProps *
+$_className::getInstProps() {
+  return nullptr;
+}
+
+)",
+        &ctx);
+  } else {
+    os << mlir::tblgen::tgfmt(
+        R"(const ::mlir::aster::amdgcn::InstructionProps *
+$_className::getInstProps() {
+  static const ::mlir::aster::amdgcn::InstProp _props[] = {)",
+        &ctx);
+    llvm::interleaveComma(props, os, [&](const InstProp &prop) {
+      os << "::mlir::aster::amdgcn::InstProp::"
+         << prop.getAsEnumCase().getIdentifier();
+    });
+    os << R"(};
+  static ::mlir::aster::amdgcn::InstructionProps props(_props);
+  return &props;
+}
+
+)";
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Top-level generators
+//===----------------------------------------------------------------------===//
+
+static void genInstMethods(const llvm::Record *rec, raw_ostream &os) {
+  InstOp instOp(rec);
+  std::string qualClass = instOp.getQualCppClassName();
+  StringRef className = StringRef(qualClass).ltrim("::");
+
+  llvm::SmallVector<InstEncRecord> encodings = instOp.getEncodings();
+  if (!encodings.empty()) {
+    genIsValidFunc(instOp, encodings, os);
+    genIsValidMethod(instOp, className, os);
+    genGetEncoding(instOp, className, encodings, os);
+  }
+
+  genGetEffects(instOp, className, os);
+  genInferReturnTypes(instOp, className, os);
+  genGetInstInfo(instOp, className, os);
+  genGetInstProps(instOp, className, os);
+
+  if (instOp.getGenInstAssemblyFormat()) {
+    InstSegments segs = collectInstSegments(instOp);
+    genParseMethod(instOp, className, segs, os);
+    genPrintMethod(instOp, className, segs, os);
+  }
+}
+
+static bool generateInstMethods(const llvm::RecordKeeper &records,
+                                raw_ostream &os) {
+  llvm::IfDefEmitter ifdefEmitter(os, "AMDGCN_GEN_INST_METHODS");
+  for (const llvm::Record *rec :
+       getSortedDerivedDefinitions(records, AMDISAInstClassType))
+    genInstMethods(rec, os);
+  return false;
+}
+
+//===----------------------------------------------------------------------===//
+// TableGen Registration
+//===----------------------------------------------------------------------===//
+
+static GenRegistration generateInstMethodsReg(
+    "gen-inst-methods", "Generate inst method definitions",
+    [](const llvm::RecordKeeper &records, raw_ostream &os) {
+      return generateInstMethods(records, os);
+    });


### PR DESCRIPTION
Introduce AMDGCNInstBase.td with AMDISAInstruction, which binds the generic Instruction base to the AMDGCN dialect (AMDInstTrait, AMDGCNInstOpInterface) and registers each instruction as an AMDInstOpCode so it appears in OpCodeEnum. Add arch records (CDNA3Isa, CDNA4Isa) and encoding records (ENC_SOP1, ENC_VOP1, etc.) used by instruction encodings.

Add two new amdgcn-tblgen backends:
- InstMethodsGen: generates C++ method bodies for new-style instruction ops (type verification, isValid, getEncoding, getInstMetadata, etc.).
- InstAsmPrinterGen: generates the custom assembly parser/printer for new-style instruction ops, consuming the ASMArgFormat/PrintOperand metadata from operand type constraints.

Add InstCommon.cpp with shared implementation used by both backends.

Made-with: Cursor