### PR TITLE
[amdgcn] Add InstructionProps, cloneInstructionImpl, and inline const helpers

### DIFF
--- a/include/aster/Dialect/AMDGCN/IR/AMDGCNOps.h
+++ b/include/aster/Dialect/AMDGCN/IR/AMDGCNOps.h
@@ -19,6 +19,7 @@
 #include "aster/Dialect/AMDGCN/IR/AMDGCNDialect.h"
 #include "aster/Dialect/AMDGCN/IR/AMDGCNTypes.h"
 #include "aster/Dialect/AMDGCN/IR/AMDGCNVerifiers.h"
+#include "aster/Dialect/AMDGCN/IR/InstructionProps.h"
 #include "aster/Dialect/AMDGCN/IR/Interfaces/AMDGCNInterfaces.h"
 #include "aster/IR/InstImpl.h"
 #include "aster/Interfaces/AllocaOpInterface.h"
@@ -42,7 +43,12 @@
 
 namespace mlir {
 class PatternRewriter;
-}
+namespace aster::amdgcn {
+bool checkFloatConst(Value value, ArrayRef<float> values);
+bool checkIntConst(Value value, ArrayRef<int64_t> values);
+bool checkOffsetConst(Value value, int64_t offsetWidth, bool isSigned = false);
+} // namespace aster::amdgcn
+} // namespace mlir
 
 #define GET_OP_CLASSES
 #include "aster/Dialect/AMDGCN/IR/AMDGCNOps.h.inc"

--- a/include/aster/Dialect/AMDGCN/IR/InstructionProps.h
+++ b/include/aster/Dialect/AMDGCN/IR/InstructionProps.h
@@ -1,0 +1,54 @@
+//===- InstructionProps.h - AMDGCN instruction properties --------*- C++
+//-*-===//
+//
+// Copyright 2026 The ASTER Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the InstructionProps container for AMDGCN instruction
+// properties.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ASTER_DIALECT_AMDGCN_IR_INSTRUCTIONPROPS_H
+#define ASTER_DIALECT_AMDGCN_IR_INSTRUCTIONPROPS_H
+
+#include "aster/Dialect/AMDGCN/IR/AMDGCNEnums.h"
+#include "mlir/Support/LLVM.h"
+#include "llvm/ADT/STLExtras.h"
+#include <bitset>
+
+namespace mlir::aster::amdgcn {
+/// Container for instruction properties backed by a bitset.
+class InstructionProps {
+public:
+  InstructionProps(ArrayRef<InstProp> props) {
+    for (InstProp prop : props)
+      bits.set(static_cast<size_t>(prop), true);
+  }
+
+  /// Check if the instruction has the given property.
+  bool hasProp(InstProp prop) const {
+    return prop < InstProp::LastProp && bits[static_cast<int32_t>(prop)];
+  }
+
+  /// Check if the instruction has all of the given properties.
+  bool hasProps(ArrayRef<InstProp> props) const {
+    return llvm::all_of(props, [this](InstProp prop) { return hasProp(prop); });
+  }
+
+  /// Check if the instruction has any of the given properties.
+  bool hasAnyProps(ArrayRef<InstProp> props) const {
+    return llvm::any_of(props, [this](InstProp prop) { return hasProp(prop); });
+  }
+
+private:
+  std::bitset<static_cast<size_t>(InstProp::LastProp)> bits;
+};
+} // namespace mlir::aster::amdgcn
+
+#endif // ASTER_DIALECT_AMDGCN_IR_INSTRUCTIONPROPS_H

--- a/include/aster/IR/InstImpl.h
+++ b/include/aster/IR/InstImpl.h
@@ -119,12 +119,50 @@ OpTy cloneInstImpl(OpTy op, OpBuilder &builder, ValueRange outs,
                       attributes);
 }
 
+/// Clones the instruction operation with new operands and results.
+template <typename OpTy>
+OpTy cloneInstructionImpl(OpTy op, OpBuilder &builder, ValueRange outs,
+                          ValueRange ins) {
+
+  auto getOperandIndexAndLength = [&](unsigned index) {
+    return op.getODSOperandIndexAndLength(index);
+  };
+  auto getResultIndexAndLength = [&](unsigned index) {
+    return op.getODSResultIndexAndLength(index);
+  };
+  // Get the operation's attirbutes.
+  SmallVector<NamedAttribute> attributes =
+      llvm::to_vector(op->getDiscardableAttrs());
+  // Copy the operation's properties.
+  typename OpTy::Properties properties = op.getProperties();
+  // Get the new operands and result types.
+  SmallVector<Value> operands;
+  SmallVector<Type> resultTypes;
+  InstOpInfo info = op.getInstInfo();
+  LogicalResult result = cloneInstOperandsResultsImpl(
+      outs, ins, op->getOperands(), TypeRange(op->getResults()),
+      info.numLeadingOperands, info.numInstOuts, info.numInstIns,
+      info.numLeadingResults, getOperandIndexAndLength, getResultIndexAndLength,
+      operands, resultTypes,
+      getResultSegmentSizes<OpTy>(
+          PropertyRef(TypeID::get<typename OpTy::Properties>(), &properties)));
+  if (failed(result))
+    return nullptr;
+  return OpTy::create(builder, op.getLoc(), resultTypes, operands, properties,
+                      attributes);
+}
+
 /// Computes liveness transfer function for the instruction.
 LogicalResult livenessTransferFunctionImpl(InstOpInterface op,
                                            LivenessCallback insertCallback,
                                            LivenessCallback removeCallback,
                                            IsLiveCallback isLiveCallback);
 } // namespace detail
+
+/// Trait to provide utility methods for instruction operations.
+template <typename ConcreteType>
+struct InstructionTrait
+    : public OpTrait::TraitBase<ConcreteType, InstructionTrait> {};
 
 /// Trait to provide utility methods for instruction operations.
 template <typename ConcreteType>

--- a/include/aster/Interfaces/InstOpInterface.h
+++ b/include/aster/Interfaces/InstOpInterface.h
@@ -39,19 +39,19 @@ struct InstOpInfo {
   const int32_t numLeadingResults;
   const int32_t numInstResults;
   /// Get the leading operands.
-  ValueRange getLeadingOperands(ValueRange operands) {
+  OperandRange getLeadingOperands(OperandRange operands) {
     return operands.slice(0, numLeadingOperands);
   }
   /// Get the instruction output operands.
-  ValueRange getInstOuts(ValueRange operands) {
+  OperandRange getInstOuts(OperandRange operands) {
     return operands.slice(numLeadingOperands, numInstOuts);
   }
   /// Get the instruction input operands.
-  ValueRange getInstIns(ValueRange operands) {
+  OperandRange getInstIns(OperandRange operands) {
     return operands.slice(numLeadingOperands + numInstOuts, numInstIns);
   }
   /// Get the trailing operands.
-  ValueRange getTrailingOperands(ValueRange operands) {
+  OperandRange getTrailingOperands(OperandRange operands) {
     return operands.drop_front(numLeadingOperands + numInstOuts + numInstIns);
   }
   /// Get the leading results.

--- a/lib/Dialect/AMDGCN/IR/AMDGCN.cpp
+++ b/lib/Dialect/AMDGCN/IR/AMDGCN.cpp
@@ -14,6 +14,7 @@
 #include "aster/Dialect/AMDGCN/IR/AMDGCNOps.h"
 #include "aster/Dialect/AMDGCN/IR/AMDGCNTypes.h"
 #include "aster/Dialect/AMDGCN/IR/AMDGCNVerifiers.h"
+#include "aster/Dialect/AMDGCN/IR/InstructionProps.h"
 #include "aster/Dialect/AMDGCN/IR/Interfaces/AMDGCNInterfaces.h"
 #include "aster/Dialect/AMDGCN/IR/Utils.h"
 #include "aster/Dialect/NormalForm/IR/NormalFormInterfaces.h"
@@ -69,6 +70,20 @@ static ParseResult parseOpcode(OpAsmParser &parser, InstAttr &opcode) {
 /// Pretty printer for OpCode attribute when parsed from an operation.
 static void printOpcode(OpAsmPrinter &printer, Operation *, InstAttr opcode) {
   printer << stringifyOpCode(opcode.getValue());
+}
+
+/// Helper to get either the type of a Value or return the type itself.
+template <typename T, std::enable_if_t<std::is_base_of_v<Value, T>, int> = 0>
+static auto getTypeOrValue(T value) {
+  using Type = decltype(value.getType());
+  if (value == nullptr)
+    return Type();
+  return value.getType();
+}
+/// Helper to passthrough values that are not MLIR Values.
+template <typename T, std::enable_if_t<!std::is_base_of_v<Value, T>, int> = 0>
+static T &&getTypeOrValue(T &&value) {
+  return std::forward<T>(value);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Target/ASM/AMDGCN.td
+++ b/lib/Target/ASM/AMDGCN.td
@@ -11,6 +11,6 @@
 #ifndef AMDGCN_ASM
 #define AMDGCN_ASM
 
-include "aster/Dialect/AMDGCN/IR/AMDGCNOps.td"
+include "aster/Dialect/AMDGCN/IR/AMDGCNInsts.td"
 
 #endif // AMDGCN_ASM


### PR DESCRIPTION
Add InstructionProps, a bitset-backed container for querying InstProp flags (hasProp, hasProps, hasAnyProps), used by AMDInstTrait on new-style instruction ops.

Add cloneInstructionImpl to InstImpl.h for cloning Instruction-based ops (counterpart to the existing cloneInstImpl for old-style ops).

Add InstructionTrait CRTP stub in InstImpl.h to back the TableGen-declared NativeOpTrait.

Tighten InstOpInfo slice methods to return OperandRange instead of ValueRange so callers retain mutation capabilities.

Declare checkFloatConst, checkIntConst, and checkOffsetConst in AMDGCNOps.h for use by the inline-literal type constraint predicates.

Add getTypeOrValue helpers in AMDGCN.cpp used by generated inst-method verification code.

Update lib/Target/ASM/AMDGCN.td to include AMDGCNInsts.td instead of AMDGCNOps.td so the ASM backend sees the full opcode/property enums.

Made-with: Cursor