### PR TITLE
[amdgcn-tblgen] Add InferrableType support and custom asm syntax

### DIFF
--- a/include/aster/Dialect/AMDGCN/IR/AMDGCNTypeConstraints.td
+++ b/include/aster/Dialect/AMDGCN/IR/AMDGCNTypeConstraints.td
@@ -69,6 +69,30 @@ def ReadTokenType : CPPType<"::mlir::aster::amdgcn::ReadTokenType",
 def WriteTokenType : CPPType<"::mlir::aster::amdgcn::WriteTokenType",
     "write token type">;
 
+def DSReadToken :
+  CPPType<"::mlir::aster::amdgcn::ReadTokenType", "read token type">,
+  InferrableType<"$_builder.getType<ReadTokenType>(MemoryInstructionKind::Shared)">;
+
+def DSWriteToken :
+  CPPType<"::mlir::aster::amdgcn::WriteTokenType", "write token type">,
+  InferrableType<"$_builder.getType<WriteTokenType>(MemoryInstructionKind::Shared)">;
+
+def ConstantReadToken :
+  CPPType<"::mlir::aster::amdgcn::ReadTokenType", "read token type">,
+  InferrableType<"$_builder.getType<ReadTokenType>(MemoryInstructionKind::Constant)">;
+
+def ConstantWriteToken :
+  CPPType<"::mlir::aster::amdgcn::WriteTokenType", "write token type">,
+  InferrableType<"$_builder.getType<WriteTokenType>(MemoryInstructionKind::Constant)">;
+
+def FlatReadToken :
+  CPPType<"::mlir::aster::amdgcn::ReadTokenType", "read token type">,
+  InferrableType<"$_builder.getType<ReadTokenType>(MemoryInstructionKind::Flat)">;
+
+def FlatWriteToken :
+  CPPType<"::mlir::aster::amdgcn::WriteTokenType", "write token type">,
+  InferrableType<"$_builder.getType<WriteTokenType>(MemoryInstructionKind::Flat)">;
+
 //===----------------------------------------------------------------------===//
 // Common type constraint classes
 //===----------------------------------------------------------------------===//
@@ -202,7 +226,7 @@ class InlineLitIntPos<list<Type> types> : ConfinedType<AnyTypeOf<types, "an inli
 
 class IntType<int bitWidth> : I<bitWidth>, ASMArgFormat, PrintOperand;
 
-class OffsetType<int bitWidth, bit _isSigned> : ConfinedType<I<32>, [
+class OffsetType<int bitWidth, bit _isSigned = false> : ConfinedType<I<32>, [
     CPred<StrSubst<[{
       true /*::mlir::aster::amdgcn::checkOffsetConst($_selfValue, $_offsetWidth, $_isSigned)*/
     }], [IntRepl<"_offsetWidth", bitWidth>, IntRepl<"_isSigned", _isSigned>]>.result>

--- a/include/aster/IR/Inst.td
+++ b/include/aster/IR/Inst.td
@@ -84,6 +84,17 @@ class Effect {
 // Operands and modifiers
 //===----------------------------------------------------------------------===//
 
+// Class to represent a type that can be inferred.
+class InferrableType<string _code> {
+  // The code to infer the type of the operand. It has access to the following
+  // variables:
+  // - `$_builder`, the builder.
+  // - `$_loc`, the location.
+  // - $_self, the adaptor.
+  // The code should produce the type as an expression.
+  code inferType = _code;
+}
+
 // A type constraint that checks if the operand is of any of the specified types.
 class AnyOperandOf<list<Type> types> : AnyTypeOf<types>, PrintOperand;
 

--- a/tools/amdgcn-tblgen/InstAsmPrinterGen.cpp
+++ b/tools/amdgcn-tblgen/InstAsmPrinterGen.cpp
@@ -66,6 +66,8 @@ private:
   void emitModifierRef(Lexer &lexer, mlir::raw_indented_ostream &os);
   /// Emit a keyword token.
   void emitKeyword(Lexer &lexer, mlir::raw_indented_ostream &os);
+  /// Emit a `@identifier(args...)` custom syntax call.
+  LogicalResult emitCustomSyntax(Lexer &lexer, mlir::raw_indented_ostream &os);
 
   //===--------------------------------------------------------------------===//
   // Higher-level emitters
@@ -200,6 +202,61 @@ void ASMPrinterHandler::emitArg(DagArg dagArg, ASMArgFormat arg,
   ctx.withSelf("_inst");
 }
 
+LogicalResult
+ASMPrinterHandler::emitCustomSyntax(Lexer &lexer,
+                                    mlir::raw_indented_ostream &os) {
+  lexer.consumeChar(); // consume '@'
+
+  FailureOr<StringRef> id = lexer.lexIdentifier();
+  if (failed(id)) {
+    emitError("failed to lex identifier in asm_syntax: " +
+              lexer.getCurrentPos());
+    return failure();
+  }
+
+  if (lexer.currentChar() != '(') {
+    emitError("expected '(' after custom syntax: " + lexer.getCurrentPos());
+    return failure();
+  }
+  lexer.consumeChar(); // consume '('
+  StringRef argStr =
+      lexer.getCurrentPos().take_until([](char c) { return c == ')'; });
+  if (lexer.getCurrentPos() == argStr) {
+    emitError("expected ')' to terminate custom syntax: " +
+              lexer.getCurrentPos());
+    return failure();
+  }
+  (void)lexer.consume(argStr);
+  lexer.consumeChar(); // consume ')'
+
+  SmallVector<StringRef, 4> args;
+  argStr.split(args, ',', -1, true);
+  for (StringRef &arg : args) {
+    arg = arg.trim(" \t\n\v\f\r");
+    // Strip `$arg` or `[modifier]` delimiters.
+    if (arg.starts_with("$"))
+      arg = arg.drop_front();
+    else if (arg.starts_with("[") && arg.ends_with("]"))
+      arg = arg.drop_front().drop_back();
+    if (arg.empty()) {
+      emitError("empty argument in custom syntax");
+      return failure();
+    }
+    if (!arguments.contains(arg)) {
+      emitError("unknown argument in custom syntax: " + arg);
+      return failure();
+    }
+  }
+  os << *id << "(" << mlir::tblgen::tgfmt("$_printer, $_self", &ctx);
+  if (!args.empty())
+    os << ", ";
+  llvm::interleaveComma(args, os, [&](StringRef arg) {
+    os << "_inst.get" + llvm::convertToCamelFromSnakeCase(arg, true) + "()";
+  });
+  os << ");\n";
+  return success();
+}
+
 void ASMPrinterHandler::emitSyntax(StringRef syntax,
                                    mlir::raw_indented_ostream &os) {
   Lexer lexer(syntax);
@@ -237,6 +294,13 @@ void ASMPrinterHandler::emitSyntax(StringRef syntax,
     // Keyword.
     if (lexer.currentChar() == '_' || std::isalpha(lexer.currentChar())) {
       emitKeyword(lexer, os);
+      continue;
+    }
+
+    // Custom syntax `@identifier(args...)`.
+    if (lexer.currentChar() == '@') {
+      if (failed(emitCustomSyntax(lexer, os)))
+        return;
       continue;
     }
 

--- a/tools/amdgcn-tblgen/InstCommon.h
+++ b/tools/amdgcn-tblgen/InstCommon.h
@@ -316,6 +316,15 @@ struct EffectRecord : public RecordMixin<EffectRecord> {
   StringRef getBody() const { return getStringRef("body"); }
 };
 
+/// Wrapper for the td `InferrableType` class.
+struct InferrableTypeRecord : public RecordMixin<InferrableTypeRecord> {
+  using Base::Base;
+  static constexpr llvm::StringRef ClassType = "InferrableType";
+
+  /// Get the type inference code fragment.
+  StringRef getInferType() const { return getStringRef("inferType"); }
+};
+
 /// Wrapper for the td `Instruction` class, providing typed accessors for
 /// encoding, effects, and assembly syntax fields.
 struct InstOp : public RecordMixin<InstOp> {

--- a/tools/amdgcn-tblgen/InstMethodsGen.cpp
+++ b/tools/amdgcn-tblgen/InstMethodsGen.cpp
@@ -92,6 +92,9 @@ parseEncodingOverrides(const InstEncRecord &enc,
                        const mlir::tblgen::Operator &op) {
   llvm::StringMap<const llvm::Record *> result;
   const llvm::DagInit *dag = enc.getConstraintsDag();
+  SmallVector<StringRef> argNames = llvm::map_to_vector(
+      Dag((op.getDef().getValueAsDag("arguments"))).getAsRange(),
+      [](const DagArg &arg) { return arg.getName(); });
   for (unsigned i = 0, e = dag->getNumArgs(); i < e; ++i) {
     StringRef name = dag->getArgNameStr(i);
     const auto *defInit = dyn_cast<llvm::DefInit>(dag->getArg(i));
@@ -99,18 +102,13 @@ parseEncodingOverrides(const InstEncRecord &enc,
       llvm::PrintFatalError(enc.getDef().getLoc(),
                             "encoding constraint argument '" + name +
                                 "' must be a Type record");
-    bool found = false;
-    for (int j = 0, je = op.getNumOperands(); j < je; ++j) {
-      if (op.getOperand(j).name != name)
-        continue;
-      found = true;
-      break;
-    }
-    if (!found)
+    bool found = llvm::is_contained(argNames, name);
+    if (!found) {
       llvm::PrintFatalError(
           enc.getDef().getLoc(),
           "encoding constraint references unknown argument '" + name +
               "' in op '" + op.getOperationName() + "'");
+    }
     result[name] = defInit->getDef();
   }
   return result;
@@ -926,33 +924,42 @@ static void genInferReturnTypes(const InstOp &instOp, StringRef className,
     }
   }
 
-  // Infer buildable trailing result types.
+  // Infer buildable or inferrable trailing result types.
   if (numTrailingResults > 0) {
     int numOutputResults = op.getNumResults() - numTrailingResults;
     mlir::tblgen::FmtContext builderCtx;
     builderCtx.withBuilder("odsBuilder");
     builderCtx.addSubst("_ctxt", "context");
+    builderCtx.addSubst("_loc", "location");
+    builderCtx.addSubst("_self", "adaptor");
 
-    // Validate that all trailing results are buildable and not optional.
+    // Validate that all trailing results are not optional and have either a
+    // buildable type or an inferrable type.
     for (int i = 0; i < numTrailingResults; ++i) {
       const mlir::tblgen::NamedTypeConstraint &result =
           op.getResult(numOutputResults + i);
       if (result.isOptional())
         llvm::PrintFatalError(op.getLoc(), "trailing result '" + result.name +
                                                "' must not be optional");
-      if (!result.constraint.getBuilderCall())
+      if (!result.constraint.getBuilderCall() &&
+          !InferrableTypeRecord::isa(&result.constraint.getDef()))
         llvm::PrintFatalError(op.getLoc(), "trailing result '" + result.name +
-                                               "' must have a buildable type");
+                                               "' must have a buildable or "
+                                               "inferrable type");
     }
 
     os << "  ::mlir::Builder odsBuilder(context);\n";
     for (int i = 0; i < numTrailingResults; ++i) {
       const mlir::tblgen::NamedTypeConstraint &result =
           op.getResult(numOutputResults + i);
+      StringRef inferCode;
+      if (std::optional<StringRef> call = result.constraint.getBuilderCall())
+        inferCode = *call;
+      else
+        inferCode =
+            InferrableTypeRecord(&result.constraint.getDef()).getInferType();
       os << "  inferredReturnTypes.push_back("
-         << mlir::tblgen::tgfmt(*result.constraint.getBuilderCall(),
-                                &builderCtx)
-         << ");\n";
+         << mlir::tblgen::tgfmt(inferCode, &builderCtx) << ");\n";
       if (hasResultSegSizes)
         os << "  _resultSegSizes[" << (numOutputs + i) << "] = 1;\n";
     }


### PR DESCRIPTION
Add InferrableType class to allow result types to be inferred from adaptor context rather than requiring a builder call. Add specific token type constraints for DS, Constant, and Flat memory kinds. Add support for @identifier(args...) custom syntax in the asm printer generator.