### PR TITLE
[amdgcn] Add memory and execution unit effect definitions

### DIFF
--- a/include/aster/Dialect/AMDGCN/IR/AMDGCNInstBase.td
+++ b/include/aster/Dialect/AMDGCN/IR/AMDGCNInstBase.td
@@ -181,10 +181,67 @@ def SC1 : UnitModifier<"sc1", "For regular load and store operations, SC0 and SC
 // Effects
 //===----------------------------------------------------------------------===//
 
+def ConstantRead : Effect {
+  let summary = "Reads from constant memory.";
+  let body = [{
+    $_effects.emplace_back(MemoryEffects::Read::get(),
+                           ConstantMemoryResource::get());
+  }];
+}
+
+def ConstantWrite : Effect {
+  let summary = "Writes to constant memory.";
+  let body = [{
+    $_effects.emplace_back(MemoryEffects::Write::get(),
+                           ConstantMemoryResource::get());
+  }];
+}
+
 def GlobalRead : Effect {
   let summary = "Reads from global memory.";
   let body = [{
-    // TODO: implement
+    $_effects.emplace_back(MemoryEffects::Read::get(),
+                           GlobalMemoryResource::get());
+  }];
+}
+
+def GlobalWrite : Effect {
+  let summary = "Writes to global memory.";
+  let body = [{
+    $_effects.emplace_back(MemoryEffects::Write::get(),
+                           GlobalMemoryResource::get());
+  }];
+}
+
+def LDSRead : Effect {
+  let summary = "Reads from LDS memory.";
+  let body = [{
+    $_effects.emplace_back(MemoryEffects::Read::get(),
+                           LDSMemoryResource::get());
+  }];
+}
+
+def LDSWrite : Effect {
+  let summary = "Writes to LDS memory.";
+  let body = [{
+    $_effects.emplace_back(MemoryEffects::Write::get(),
+                           LDSMemoryResource::get());
+  }];
+}
+
+def SALUWrite : Effect {
+  let summary = "Writes to SALU resource.";
+  let body = [{
+    $_effects.emplace_back(MemoryEffects::Write::get(),
+                           SALUResource::get());
+  }];
+}
+
+def VALUWrite : Effect {
+  let summary = "Writes to VALU resource.";
+  let body = [{
+    $_effects.emplace_back(MemoryEffects::Write::get(),
+                           VALUResource::get());
   }];
 }
 

--- a/include/aster/Dialect/AMDGCN/IR/Instructions/SOP.td
+++ b/include/aster/Dialect/AMDGCN/IR/Instructions/SOP.td
@@ -739,6 +739,7 @@ def SNop : AMDISAInstruction<"s_nop"> {
     Do nothing. Delay issue of next instruction by a small, fixed amount.
   }];
   let encodings = [InstEnc<[ENC_SOPP_CDNA3, ENC_SOPP_CDNA4], 0b0000000>];
+  let effects = [SALUWrite];
   let outputs = (ins);
   let inputs = (ins);
   let trailingArgs = (ins

--- a/include/aster/Dialect/AMDGCN/IR/Instructions/VOP.td
+++ b/include/aster/Dialect/AMDGCN/IR/Instructions/VOP.td
@@ -687,6 +687,7 @@ def VNop : AMDISAInstruction<"v_nop"> {
     InstEnc<[ENC_VOP1_CDNA3, ENC_VOP1_CDNA4], 0b00000000>,
     InstEnc<[ENC_VOP3_CDNA3, ENC_VOP3_CDNA4], 0b0110000000>
   ];
+  let effects = [VALUWrite];
   let outputs = (ins);
   let inputs = (ins);
   let asm_syntax = [

--- a/include/aster/Dialect/AMDGCN/IR/Interfaces/AMDGCNInterfaces.h
+++ b/include/aster/Dialect/AMDGCN/IR/Interfaces/AMDGCNInterfaces.h
@@ -22,6 +22,13 @@
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
 namespace mlir::aster::amdgcn {
+/// Constant memory resource (CONST - Constant Memory).
+class ConstantMemoryResource
+    : public SideEffects::Resource::Base<ConstantMemoryResource> {
+public:
+  StringRef getName() const override { return "amdgcn.constant_memory"; }
+};
+
 /// Global memory resource.
 class GlobalMemoryResource
     : public SideEffects::Resource::Base<GlobalMemoryResource> {
@@ -34,6 +41,18 @@ class LDSMemoryResource
     : public SideEffects::Resource::Base<LDSMemoryResource> {
 public:
   StringRef getName() const override { return "amdgcn.lds_memory"; }
+};
+
+/// Scalar Unit (SALU) resource.
+class SALUResource : public SideEffects::Resource::Base<SALUResource> {
+public:
+  StringRef getName() const override { return "amdgcn.salu_resource"; }
+};
+
+/// Vector Unit (VALU) resource.
+class VALUResource : public SideEffects::Resource::Base<VALUResource> {
+public:
+  StringRef getName() const override { return "amdgcn.valu_resource"; }
 };
 } // namespace mlir::aster::amdgcn
 


### PR DESCRIPTION
Add ConstantMemoryResource, SALUResource, and VALUResource side-effect resources. Add corresponding Effect definitions for Constant, Global, LDS, SALU, and VALU reads/writes, and apply SALUWrite/VALUWrite to s_nop and v_nop respectively.