### PR TITLE
[amdgcn] Add LoadOpInterface and StoreOpInterface, migrate uses

### DIFF
--- a/include/aster/Dialect/AMDGCN/IR/AMDGCNOps.h
+++ b/include/aster/Dialect/AMDGCN/IR/AMDGCNOps.h
@@ -21,6 +21,7 @@
 #include "aster/Dialect/AMDGCN/IR/AMDGCNVerifiers.h"
 #include "aster/Dialect/AMDGCN/IR/InstructionProps.h"
 #include "aster/Dialect/AMDGCN/IR/Interfaces/AMDGCNInterfaces.h"
+#include "aster/Dialect/AMDGCN/IR/Interfaces/MemoryOpInterfaces.h"
 #include "aster/IR/InstImpl.h"
 #include "aster/Interfaces/AllocaOpInterface.h"
 #include "aster/Interfaces/DependentOpInterface.h"

--- a/include/aster/Dialect/AMDGCN/IR/Instructions/Memory.td
+++ b/include/aster/Dialect/AMDGCN/IR/Instructions/Memory.td
@@ -17,6 +17,7 @@
 
 include "aster/Dialect/AMDGCN/IR/AMDGCN.td"
 include "aster/Interfaces/DependentOpInterface.td"
+include "aster/Dialect/AMDGCN/IR/Interfaces/MemoryOpInterfaces.td"
 
 //===----------------------------------------------------------------------===//
 // Memory address operand type
@@ -46,7 +47,8 @@ def DataOperand : AnyRegOf<[
 def AMDGCN_LoadOp : AMDGCN_InstOp<"load", [
     ConditionallySpeculatable, MemoryEffectsOpInterface,
     DeclareOpInterfaceMethods<DependentOpInterface>,
-    DeclareOpInterfaceMethods<InferTypeOpInterface>
+    DeclareOpInterfaceMethods<InferTypeOpInterface>,
+    LoadOpInterface
   ]> {
   let cppNamespace = "::mlir::aster::amdgcn";
   let summary = "AMDGCN memory load operation";
@@ -124,7 +126,8 @@ def AMDGCN_LoadOp : AMDGCN_InstOp<"load", [
 def AMDGCN_StoreOp : AMDGCN_InstOp<"store", [
     ConditionallySpeculatable, MemoryEffectsOpInterface,
     DeclareOpInterfaceMethods<DependentOpInterface>,
-    DeclareOpInterfaceMethods<InferTypeOpInterface>
+    DeclareOpInterfaceMethods<InferTypeOpInterface>,
+    StoreOpInterface
   ]> {
   let cppNamespace = "::mlir::aster::amdgcn";
   let summary = "AMDGCN memory store operation";

--- a/include/aster/Dialect/AMDGCN/IR/Interfaces/CMakeLists.txt
+++ b/include/aster/Dialect/AMDGCN/IR/Interfaces/CMakeLists.txt
@@ -17,3 +17,8 @@ set(LLVM_TARGET_DEFINITIONS AMDGCNInstOpInterface.td)
 mlir_tablegen(AMDGCNInstOpInterface.h.inc -gen-op-interface-decls)
 mlir_tablegen(AMDGCNInstOpInterface.cpp.inc -gen-op-interface-defs)
 add_public_tablegen_target(AMDGCNInstOpInterfaceIncGen)
+
+set(LLVM_TARGET_DEFINITIONS MemoryOpInterfaces.td)
+mlir_tablegen(MemoryOpInterfaces.h.inc -gen-op-interface-decls)
+mlir_tablegen(MemoryOpInterfaces.cpp.inc -gen-op-interface-defs)
+add_public_tablegen_target(MemoryOpInterfacesIncGen)

--- a/include/aster/Dialect/AMDGCN/IR/Interfaces/MemoryOpInterfaces.h
+++ b/include/aster/Dialect/AMDGCN/IR/Interfaces/MemoryOpInterfaces.h
@@ -1,0 +1,23 @@
+//===- MemoryOpInterfaces.h - Memory Op Interfaces --------------*- C++ -*-===//
+//
+// Copyright 2025 The ASTER Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the AMDGCN load and store operation interfaces.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ASTER_DIALECT_AMDGCN_IR_INTERFACES_MEMORYOPINTERFACES_H
+#define ASTER_DIALECT_AMDGCN_IR_INTERFACES_MEMORYOPINTERFACES_H
+
+#include "aster/Dialect/AMDGCN/IR/Interfaces/AMDGCNInstOpInterface.h"
+#include "aster/IR/Operand.h"
+
+#include "aster/Dialect/AMDGCN/IR/Interfaces/MemoryOpInterfaces.h.inc"
+
+#endif // ASTER_DIALECT_AMDGCN_IR_INTERFACES_MEMORYOPINTERFACES_H

--- a/include/aster/Dialect/AMDGCN/IR/Interfaces/MemoryOpInterfaces.td
+++ b/include/aster/Dialect/AMDGCN/IR/Interfaces/MemoryOpInterfaces.td
@@ -1,0 +1,75 @@
+//===- MemoryOpInterfaces.td - Memory Op Interfaces ----------*- tablegen -*-===//
+//
+// Copyright 2025 The ASTER Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the AMDGCN load and store operation interfaces.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ASTER_DIALECT_AMDGCN_IR_INTERFACES_MEMORYOPINTERFACES_TD
+#define ASTER_DIALECT_AMDGCN_IR_INTERFACES_MEMORYOPINTERFACES_TD
+
+include "mlir/IR/OpBase.td"
+include "aster/Dialect/AMDGCN/IR/Interfaces/AMDGCNInstOpInterface.td"
+include "aster/Interfaces/DependentOpInterface.td"
+
+def LoadOpInterface :
+    OpInterface<"LoadOpInterface", [AMDGCNInstOpInterface, FutureOpInterface]> {
+  let cppNamespace = "::mlir::aster::amdgcn";
+  let description = [{
+    Interface for load operations providing uniform access to operands and
+    results.
+  }];
+  let methods = [
+    InterfaceMethod<"Get the destination operand.",
+      "::mlir::aster::Operand", "getDst", (ins), [{}], [{
+        return $_op.getDestMutable();
+      }]>,
+    InterfaceMethod<"Get the address operand.",
+      "::mlir::aster::Operand", "getAddress", (ins), [{}], [{
+        return $_op.getAddrMutable();
+      }]>
+  ];
+  let extraTraitClassDeclaration = [{
+    ::mlir::aster::Future getFuture() {
+      return ::mlir::aster::Future::read($_op.getToken(), $_op.getDst().getValue());
+    }
+  }];
+}
+
+def StoreOpInterface :
+    OpInterface<"StoreOpInterface", [AMDGCNInstOpInterface, FutureOpInterface]> {
+  let cppNamespace = "::mlir::aster::amdgcn";
+  let description = [{
+    Interface for store operations providing uniform access to operands and
+    results.
+  }];
+  let methods = [
+    InterfaceMethod<"Get the data operand.",
+      "::mlir::aster::Operand", "getDataOperand", (ins), [{}], [{
+        return $_op.getDataMutable();
+      }]>,
+    InterfaceMethod<"Get the address operand.",
+      "::mlir::aster::Operand", "getAddress", (ins), [{}], [{
+        return $_op.getAddrMutable();
+      }]>,
+    InterfaceMethod<"Get the dynamic offset operand.",
+      "::mlir::aster::Operand", "getDynamicOff", (ins), [{}], [{
+        ::mlir::MutableOperandRange r = $_op.getDynamicOffsetMutable();
+        return !r.empty() ? ::mlir::aster::Operand(r[0]) : ::mlir::aster::Operand();
+      }]>
+  ];
+  let extraTraitClassDeclaration = [{
+    ::mlir::aster::Future getFuture() {
+      return ::mlir::aster::Future::write($_op.getToken(), $_op.getDataOperand().getValue());
+    }
+  }];
+}
+
+#endif // ASTER_DIALECT_AMDGCN_IR_INTERFACES_MEMORYOPINTERFACES_TD

--- a/lib/Dialect/AMDGCN/IR/AMDGCN.cpp
+++ b/lib/Dialect/AMDGCN/IR/AMDGCN.cpp
@@ -1224,6 +1224,8 @@ inferTypesImpl(MLIRContext *ctx, std::optional<Location> &loc,
 
 #include "aster/Dialect/AMDGCN/IR/Interfaces/AMDGCNInstOpInterface.cpp.inc"
 
+#include "aster/Dialect/AMDGCN/IR/Interfaces/MemoryOpInterfaces.cpp.inc"
+
 #include "aster/Dialect/AMDGCN/IR/Interfaces/AMDGCNRegisterTypeInterface.cpp.inc"
 
 #define GET_TYPEDEF_CLASSES

--- a/lib/Dialect/AMDGCN/IR/AMDGCNVerifiers.cpp
+++ b/lib/Dialect/AMDGCN/IR/AMDGCNVerifiers.cpp
@@ -218,8 +218,8 @@ static LogicalResult checkMaybeConstOperand(AMDGCNInstOpInterface op,
                .attachNote(state.getLoc())
            << "is invalid";
   }
-  if (isa<LoadOp, StoreOp>(op) || op.hasProp(InstProp::Salu) ||
-      op.hasProp(InstProp::IsValu)) {
+  if (isa<LoadOpInterface, StoreOpInterface>(op) ||
+      op.hasProp(InstProp::Salu) || op.hasProp(InstProp::IsValu)) {
     return success();
   }
   // TODO: implement actual checks for other instructions.

--- a/lib/Dialect/AMDGCN/IR/CMakeLists.txt
+++ b/lib/Dialect/AMDGCN/IR/CMakeLists.txt
@@ -12,6 +12,7 @@ add_mlir_dialect_library(AMDGCNDialect
   KernelArgInterfaceIncGen
   HazardAttrInterfaceIncGen
   AMDGCNInstOpInterfaceIncGen
+  MemoryOpInterfacesIncGen
   SchedInterfacesIncGen
   AMDGCNInstsIncGen
   AMDGCNOpsIncGen

--- a/lib/Dialect/AMDGCN/IR/Hazards.cpp
+++ b/lib/Dialect/AMDGCN/IR/Hazards.cpp
@@ -331,10 +331,11 @@ bool CDNA3StoreWriteDataHazardAttr::matchInst(AMDGCNInstOpInterface instOp,
 
 void CDNA3StoreWriteDataHazardAttr::populateHazardsFor(
     AMDGCNInstOpInterface instOp, SmallVectorImpl<Hazard> &hazards) const {
-  auto storeOp = dyn_cast<StoreOp>(instOp.getOperation());
+  auto storeOp = dyn_cast<StoreOpInterface>(instOp.getOperation());
   if (!storeOp)
     return;
-  RegisterTypeInterface regTy = storeOp.getData().getType();
+  RegisterTypeInterface regTy =
+      dyn_cast<RegisterTypeInterface>(storeOp.getDataOperand().getType());
   if (!regTy)
     return;
   if (instOp.getOpCode() == OpCode::Invalid)
@@ -346,15 +347,17 @@ void CDNA3StoreWriteDataHazardAttr::populateHazardsFor(
                           OpCode::BUFFER_STORE_DWORDX4_IDXEN},
                          instOp.getOpCode())) {
     // If the dynamic offset is not set, there is no hazard.
-    if (!storeOp.getDynamicOffset())
+    if (!storeOp.getDynamicOff())
       return;
     hazards.push_back(Hazard(cast<HazardCheckerAttrInterface>(*this),
-                             storeOp.getDataMutable(), getInstCounts(0)));
+                             *storeOp.getDataOperand().get(),
+                             getInstCounts(0)));
     return;
   }
   if (instOp.hasProp(InstProp::Global)) {
     hazards.push_back(Hazard(cast<HazardCheckerAttrInterface>(*this),
-                             storeOp.getDataMutable(), getInstCounts(0)));
+                             *storeOp.getDataOperand().get(),
+                             getInstCounts(0)));
     return;
   }
   // TODO: FLAT_ATOMIC_[F]CMPSWAP_X2, BUFFER_STORE_FORMAT_XYZ/XYZW,
@@ -369,9 +372,10 @@ bool CDNA3StoreWriteDataHazardAttr::isHazardTriggered(
   if (instOp.getOpCode() == OpCode::Invalid || instOp.hasProp(InstProp::IsValu))
     return false; // VALU is handled by CDNA3StoreHazard
 
-  auto storeOp = cast<StoreOp>(hazard.getOp());
-  AMDGCNRegisterTypeInterface writeRegTy = storeOp.getData().getType();
-  if (!writeRegTy.hasAllocatedSemantics())
+  auto storeOp = cast<StoreOpInterface>(hazard.getOp());
+  AMDGCNRegisterTypeInterface writeRegTy =
+      dyn_cast<AMDGCNRegisterTypeInterface>(storeOp.getDataOperand().getType());
+  if (!writeRegTy || !writeRegTy.hasAllocatedSemantics())
     return false;
 
   return llvm::any_of(TypeRange(instOp.getInstOuts()), [&](Type out) {
@@ -402,12 +406,13 @@ bool CDNA3StoreHazardAttr::matchInst(AMDGCNInstOpInterface instOp,
 
 void CDNA3StoreHazardAttr::populateHazardsFor(
     AMDGCNInstOpInterface instOp, SmallVectorImpl<Hazard> &hazards) const {
-  auto storeOp = dyn_cast<StoreOp>(instOp.getOperation());
+  auto storeOp = dyn_cast<StoreOpInterface>(instOp.getOperation());
   if (!storeOp)
     return;
 
   // Check if it has allocated semantics.
-  RegisterTypeInterface regTy = storeOp.getData().getType();
+  RegisterTypeInterface regTy =
+      dyn_cast<RegisterTypeInterface>(storeOp.getDataOperand().getType());
   if (!regTy || !regTy.hasAllocatedSemantics())
     return;
 
@@ -422,17 +427,19 @@ void CDNA3StoreHazardAttr::populateHazardsFor(
                          instOp.getOpCode())) {
 
     // If the dynamic offset is not set, there is no hazard.
-    if (!storeOp.getDynamicOffset())
+    if (!storeOp.getDynamicOff())
       return;
     hazards.push_back(Hazard(cast<HazardCheckerAttrInterface>(*this),
-                             storeOp.getDataMutable(), getInstCounts(0)));
+                             *storeOp.getDataOperand().get(),
+                             getInstCounts(0)));
     return;
   }
 
   // Handle global ops.
   if (instOp.hasProp(InstProp::Global)) {
     hazards.push_back(Hazard(cast<HazardCheckerAttrInterface>(*this),
-                             storeOp.getDataMutable(), getInstCounts(0)));
+                             *storeOp.getDataOperand().get(),
+                             getInstCounts(0)));
     return;
   }
   // TODO: FLAT_ATOMIC_[F]CMPSWAP_X2, BUFFER_STORE_FORMAT_XYZ/XYZW,
@@ -446,8 +453,9 @@ bool CDNA3StoreHazardAttr::isHazardTriggered(
   if (!instOp.hasProp(InstProp::IsValu))
     return false;
 
-  auto storeOp = cast<StoreOp>(hazard.getOp());
-  AMDGCNRegisterTypeInterface writeRegTy = storeOp.getData().getType();
+  auto storeOp = cast<StoreOpInterface>(hazard.getOp());
+  AMDGCNRegisterTypeInterface writeRegTy =
+      cast<AMDGCNRegisterTypeInterface>(storeOp.getDataOperand().getType());
 
   assert(writeRegTy.hasAllocatedSemantics() &&
          "Write register type must have allocated semantics");

--- a/lib/Dialect/AMDGCN/IR/SchedAttrs.cpp
+++ b/lib/Dialect/AMDGCN/IR/SchedAttrs.cpp
@@ -89,7 +89,7 @@ void GraphBuilder::buildSSADeps(SchedGraph &graph) {
     // If the operation has no side-effect we need to treat it as a possible
     // sync point. Same for non-pure operations.
     if ((!hasEffects || !mlir::isPure(op)) &&
-        !isa<LoadOp, StoreOp, AllocaOpInterface>(op)) {
+        !isa<LoadOpInterface, StoreOpInterface, AllocaOpInterface>(op)) {
       LDBG() << "Adding sync point: " << i;
       syncPoints.push_back(i);
     }

--- a/lib/Dialect/AMDGCN/Transforms/ExpandMetadataOps.cpp
+++ b/lib/Dialect/AMDGCN/Transforms/ExpandMetadataOps.cpp
@@ -66,7 +66,7 @@ public:
 
 static Value loadArgument(RewriterBase &rewriter, Value kenArgPtr, Value alloc,
                           uint32_t size, int32_t offset) {
-  llvm::function_ref<LoadOp(OpBuilder &, Location, Value, Value, Value, Value)>
+  std::function<Value(OpBuilder &, Location, Value, Value, Value, Value)>
       createOp;
   RegisterTypeInterface loadTy{};
   int32_t numWords;
@@ -75,32 +75,56 @@ static Value loadArgument(RewriterBase &rewriter, Value kenArgPtr, Value alloc,
   if (szWordsFloor % 16 == 0) {
     numWords = 16;
     loadTy = rewriter.getType<SGPRType>(RegisterRange(Register(), numWords));
-    createOp = S_LOAD_DWORDX16::create;
+    createOp = +[](OpBuilder &builder, Location loc, Value dest, Value addr,
+                   Value uniform_offset, Value constant_offset) {
+      return S_LOAD_DWORDX16::create(builder, loc, dest, addr, uniform_offset,
+                                     constant_offset)
+          .getDestRes();
+    };
   } else if (szWordsFloor % 8 == 0) {
     numWords = 8;
     loadTy = rewriter.getType<SGPRType>(RegisterRange(Register(), numWords));
-    createOp = S_LOAD_DWORDX8::create;
+    createOp = +[](OpBuilder &builder, Location loc, Value dest, Value addr,
+                   Value uniform_offset, Value constant_offset) {
+      return S_LOAD_DWORDX8::create(builder, loc, dest, addr, uniform_offset,
+                                    constant_offset)
+          .getDestRes();
+    };
   } else if (szWordsFloor % 4 == 0) {
     numWords = 4;
     loadTy = rewriter.getType<SGPRType>(RegisterRange(Register(), numWords));
-    createOp = S_LOAD_DWORDX4::create;
+    createOp = +[](OpBuilder &builder, Location loc, Value dest, Value addr,
+                   Value uniform_offset, Value constant_offset) {
+      return S_LOAD_DWORDX4::create(builder, loc, dest, addr, uniform_offset,
+                                    constant_offset)
+          .getDestRes();
+    };
   } else if (szWordsFloor % 2 == 0) {
     numWords = 2;
     loadTy = rewriter.getType<SGPRType>(RegisterRange(Register(), numWords));
-    createOp = S_LOAD_DWORDX2::create;
+    createOp = +[](OpBuilder &builder, Location loc, Value dest, Value addr,
+                   Value uniform_offset, Value constant_offset) {
+      return S_LOAD_DWORDX2::create(builder, loc, dest, addr, uniform_offset,
+                                    constant_offset)
+          .getDestRes();
+    };
   } else {
     numWords = 1;
     loadTy = rewriter.getType<SGPRType>(Register());
-    createOp = S_LOAD_DWORD::create;
+    createOp = +[](OpBuilder &builder, Location loc, Value dest, Value addr,
+                   Value uniform_offset, Value constant_offset) {
+      return S_LOAD_DWORD::create(builder, loc, dest, addr, uniform_offset,
+                                  constant_offset)
+          .getDestRes();
+    };
   }
   int32_t numLoads = ((size + 3) / 4) / numWords;
 
   // Load the easy case.
   if (numLoads == 1)
-    return createOp(rewriter, alloc.getLoc(), alloc, kenArgPtr, nullptr,
-                    arith::ConstantIntOp::create(rewriter, alloc.getLoc(),
-                                                 offset, 32))
-        .getDestRes();
+    return createOp(
+        rewriter, alloc.getLoc(), alloc, kenArgPtr, nullptr,
+        arith::ConstantIntOp::create(rewriter, alloc.getLoc(), offset, 32));
   // Load in multiple instructions.
   ValueRange splitAlloc = splitRange(rewriter, alloc.getLoc(), alloc);
   SmallVector<Value> loadedRegs;
@@ -118,8 +142,7 @@ static Value loadArgument(RewriterBase &rewriter, Value kenArgPtr, Value alloc,
     Value segment =
         createOp(rewriter, alloc.getLoc(), dest, kenArgPtr, nullptr,
                  arith::ConstantIntOp::create(rewriter, alloc.getLoc(),
-                                              offset + i * 4 * numWords, 32))
-            .getDestRes();
+                                              offset + i * 4 * numWords, 32));
 
     // Maybe partition the segment.
     if (numWords > 1) {

--- a/lib/Dialect/AMDGCN/Transforms/RegisterColoring.cpp
+++ b/lib/Dialect/AMDGCN/Transforms/RegisterColoring.cpp
@@ -677,7 +677,9 @@ LogicalResult RegisterColoring::run(FunctionOpInterface funcOp) {
   // Create the dataflow solver and load the liveness analysis.
   SymbolTableCollection symbolTable;
   DataFlowSolver solver(DataFlowConfig().setInterprocedural(false));
-  auto definitionFilter = [](Operation *op) { return isa<amdgcn::LoadOp>(op); };
+  auto definitionFilter = [](Operation *op) {
+    return isa<LoadOpInterface>(op);
+  };
   solver.load<ReachingDefinitionsAnalysis>(definitionFilter);
 
   // Create the interference graph.

--- a/lib/Dialect/AMDGCN/Transforms/RegisterDealloc.cpp
+++ b/lib/Dialect/AMDGCN/Transforms/RegisterDealloc.cpp
@@ -192,7 +192,8 @@ void RegisterDealloc::runOnOperation() {
   target.addDynamicallyLegalDialect<AMDGCNDialect>(
       [&](Operation *op) -> std::optional<bool> {
         if (isa<InstOpInterface, AMDGCNInstOpInterface, AllocaOp,
-                MakeRegisterRangeOp, SplitRegisterRangeOp, LoadOp, StoreOp>(op))
+                MakeRegisterRangeOp, SplitRegisterRangeOp, LoadOpInterface,
+                StoreOpInterface>(op))
           return converter.isLegal(op);
         return true;
       });

--- a/lib/Dialect/AMDGCN/Transforms/WaitInsertion.cpp
+++ b/lib/Dialect/AMDGCN/Transforms/WaitInsertion.cpp
@@ -96,9 +96,9 @@ struct WaitTransformImpl {
   /// The entry block of the function.
   Block *entryBlock = nullptr;
   /// A map from load operations to their corresponding alloca operations.
-  DenseMap<LoadOp, memref::AllocaOp> loadToAlloca;
+  DenseMap<FutureOpInterface, memref::AllocaOp> loadToAlloca;
   /// A set of load operations that are consumed by the current instruction.
-  DenseSet<LoadOp> definitions;
+  DenseSet<FutureOpInterface> definitions;
 };
 } // namespace
 
@@ -133,7 +133,8 @@ void WaitTransformImpl::collectDefinitions(InstOpInterface instOp) {
              "expected to find allocas for operand in reaching definitions");
       for (Value alloc : *allocasOrFailure) {
         for (Definition definition : reachingDefinitions->getRange(alloc))
-          definitions.insert(cast<LoadOp>(definition.definition->getOwner()));
+          definitions.insert(
+              cast<FutureOpInterface>(definition.definition->getOwner()));
       }
     }
   };
@@ -148,21 +149,22 @@ void WaitTransformImpl::collectDefinitions(InstOpInterface instOp) {
 void WaitTransformImpl::handleDefinitions(InstOpInterface instOp) {
   OpBuilder::InsertionGuard guard(rewriter);
   rewriter.setInsertionPoint(instOp);
-  for (LoadOp loadOp : definitions) {
+  for (FutureOpInterface loadOp : definitions) {
     memref::AllocaOp &allocaOp = loadToAlloca[loadOp];
     // Create the alloca operation if it doesn't exist.
     if (!allocaOp) {
       OpBuilder::InsertionGuard guard(rewriter);
       // Create the alloca operation at the start of the entry block.
       rewriter.setInsertionPointToStart(entryBlock);
+      Future future = loadOp.getFuture();
       allocaOp = memref::AllocaOp::create(
           rewriter, instOp.getLoc(),
-          MemRefType::get({}, loadOp.getToken().getType()));
+          MemRefType::get({}, future.getToken().getType()));
 
       // Store the token into the alloca operation.
-      rewriter.setInsertionPointAfter(loadOp);
-      memref::StoreOp::create(rewriter, loadOp.getLoc(), loadOp.getToken(),
-                              allocaOp.getResult());
+      rewriter.setInsertionPointAfter(loadOp.getOperation());
+      memref::StoreOp::create(rewriter, loadOp.getOperation()->getLoc(),
+                              future.getToken(), allocaOp.getResult());
     }
 
     // Create the load operation.
@@ -199,8 +201,10 @@ void WaitInsertion::runOnOperation() {
   // Create, configure, and run the data flow solver.
   DataFlowSolver solver(DataFlowConfig().setInterprocedural(false));
   dataflow::loadBaselineAnalyses(solver);
-  auto loadFilter =
-      +[](Operation *o) -> bool { return isa<amdgcn::LoadOp>(o); };
+  auto loadFilter = +[](Operation *o) -> bool {
+    FutureOpInterface futureOp = dyn_cast<FutureOpInterface>(o);
+    return futureOp != nullptr && futureOp.getFuture().hasReadEffect();
+  };
 
   // This callback has the effect of killing the loads if they are consumed as
   // input, the rationale being that this is equivalent to killing the token


### PR DESCRIPTION
Add LoadOpInterface and StoreOpInterface as tablegen-defined interfaces inheriting from AMDGCNInstOpInterface and FutureOpInterface. Migrate all uses of the concrete LoadOp and StoreOp types to these interfaces in hazard checking, scheduling, register coloring/dealloc, wait insertion, and metadata expansion.