### PR TITLE
QoL - Tighten PipelineConfig with a protocol and dump the full options

### DIFF
--- a/contrib/kittens/gemm_config.py
+++ b/contrib/kittens/gemm_config.py
@@ -24,6 +24,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING
 
+from aster.pass_pipelines import PipelineConfigProtocol
+
 if TYPE_CHECKING:
     from aster.layout import Layout
 
@@ -209,7 +211,7 @@ class GemmSpec:
 
 
 @dataclass
-class GemmMappingSpec:
+class GemmMappingSpec(PipelineConfigProtocol):
     """Transform-dialect style mapping specification for a Linalg-like GemmSpec.
 
     Analogous to transform.structured.tile_using_forall + pipeline schedule
@@ -280,6 +282,13 @@ class GemmMappingSpec:
         from kittens_helpers import PIPELINE_STRATEGIES
 
         return PIPELINE_STRATEGIES[self.pipeline_strategy]
+
+    @property
+    def rotate_stage(self) -> int | None:
+        """Compute stage for rotation, or None if rotation is disabled."""
+        if not self.rotate_compute_stage:
+            return None
+        return self._pipeline_stage_dict()["COMPUTE"]
 
     @property
     def isa(self) -> str:

--- a/contrib/kittens/test/bench/bench_harness.py
+++ b/contrib/kittens/test/bench/bench_harness.py
@@ -5,6 +5,7 @@ Phase 2: Parallel GPU execution (per-config subprocess, crash-isolated).
 Phase 3: Correctness verification (per-config subprocess, crash-isolated).
 """
 
+import dataclasses
 import fcntl
 import json
 import os
@@ -27,7 +28,7 @@ MI300X_PEAK_TFLOPS_F16 = 1307.0
 NUM_ITERATIONS = 100
 WARMUP_ITERATIONS = 20
 DEFAULT_COMPILE_WORKERS = 8
-DEFAULT_COMPILE_TIMEOUT = 180  # seconds per kernel
+DEFAULT_COMPILE_TIMEOUT = 30  # seconds per kernel compilation
 DEFAULT_EXEC_TIMEOUT = 10  # seconds per kernel execution
 
 
@@ -1472,6 +1473,33 @@ def print_config(cfg, resources=None, iterations=None):
         print(f"  sched:      {', '.join(sched)}")
     iters = iterations if iterations is not None else NUM_ITERATIONS
     print(f"  iterations: {iters} (warmup={WARMUP_ITERATIONS})")
+    # Exhaustive dump of every dataclass field on spec / mapping plus a few
+    # computed properties on cfg, so the printed config is a full repro.
+    print("  --- spec ---")
+    for f in dataclasses.fields(cfg.spec):
+        print(f"    {f.name}: {getattr(cfg.spec, f.name)}")
+    print("  --- mapping ---")
+    for f in dataclasses.fields(cfg.mapping):
+        print(f"    {f.name}: {getattr(cfg.mapping, f.name)}")
+    print("  --- derived ---")
+    for name in (
+        "gemm_size",
+        "load_type",
+        "b_path",
+        "lds_bytes",
+        "estimated_vgprs",
+        "estimated_agprs",
+        "simd_occupancy",
+        "kernel_name",
+        "k_scaling_factor",
+        "num_threads",
+    ):
+        if hasattr(cfg, name):
+            try:
+                print(f"    {name}: {getattr(cfg, name)}")
+            except Exception as e:
+                print(f"    {name}: <error: {e}>")
+    print("  --- resources ---")
     if resources:
         print(f"  resources:  {resources}")
         # Warn on large estimate-vs-actual discrepancies.
@@ -1551,8 +1579,6 @@ def run_single(cfg, compile_fn, args, execute_fn):
                 print(f"  OCCUPANCY ERROR: {v}")
             if violations and not getattr(args, "force", False):
                 raise SystemExit(1)
-    else:
-        print_config(cfg, iterations=iterations)
 
     if not has_gpu:
         print("No GPUs detected -- skipping execution.")

--- a/contrib/kittens/test/bench/bench_sweep_heuristic.py
+++ b/contrib/kittens/test/bench/bench_sweep_heuristic.py
@@ -134,7 +134,7 @@ def add_heuristic_cli_args(parser) -> None:
     parser.add_argument(
         "--weak-scale-boost",
         type=float,
-        default=10.0,
+        default=0.0,
         help="Priority boost for weak-scaled best-known configs (0 = disable seeding)",
     )
 

--- a/contrib/kittens/test/bench/sweep_harness.py
+++ b/contrib/kittens/test/bench/sweep_harness.py
@@ -151,12 +151,31 @@ class SweepGrid:
 
         if extra_eligible:
             # Dedup against enumerated pool via a frozen fingerprint of dict items.
+            # Also apply pins and the full filter set:
+            #   weak-scale seeded configs must pass the same eligibility checks
+            #   as enumerated configs, otherwise they bypass `passes_resource_check`
+            #   and pin constraints and produce too many compile-time register/LDS
+            #   allocation failures.
+            all_filters = [f for level in level_filters for f in level]
             seen = {tuple(sorted(c.items())) for c in eligible}
+            n_dropped_pin = 0
+            n_dropped_filter = 0
             for extra in extra_eligible:
                 key = tuple(sorted(extra.items()))
-                if key not in seen:
-                    eligible.append(extra)
-                    seen.add(key)
+                if key in seen:
+                    continue
+                # Pin check: every pin must match.
+                if any(k in extra and extra[k] != v for k, v in pins.items()):
+                    n_dropped_pin += 1
+                    continue
+                # Filter check: each filter is a SweepFilter with deps + check.
+                if any(not f.check(extra) for f in all_filters if all(d in extra for d in f.deps)):
+                    n_dropped_filter += 1
+                    continue
+                eligible.append(extra)
+                seen.add(key)
+            if n_dropped_pin or n_dropped_filter:
+                print(f"  weak-scale: dropped {n_dropped_pin} (pin mismatch), {n_dropped_filter} (filter rejected)")
 
         total = len(eligible)
 

--- a/contrib/kittens/test/test_101_gemm_python_pipelined.py
+++ b/contrib/kittens/test/test_101_gemm_python_pipelined.py
@@ -22,7 +22,7 @@ from aster.compiler.core import compile_mlir_module_to_asm, assemble_to_hsaco
 from aster.execution.core import execute_hsaco, InputArray, OutputArray
 from aster.execution.helpers import hsaco_file
 from aster.execution.utils import system_has_mcpu
-from aster.pass_pipelines import make_default_pass_pipeline
+from aster.pass_pipelines import make_default_pass_pipeline, PipelineConfig
 
 from aster.layout import Layout, Swizzle
 
@@ -139,7 +139,7 @@ class TestPythonGEMMPipelined:
         ctx.allow_unregistered_dialects = True
         with ctx:
             module = _build_gemm_pipelined(k, stride_ab)
-            asm = compile_mlir_module_to_asm(module, pass_pipeline=make_default_pass_pipeline())
+            asm = compile_mlir_module_to_asm(module, pass_pipeline=make_default_pass_pipeline(PipelineConfig()))
 
         path = assemble_to_hsaco(asm, target=MCPU, wavefront_size=64)
         if path is None:
@@ -181,7 +181,7 @@ if __name__ == "__main__":
         module = _build_gemm_pipelined(args.k, args.k * 2, 2)
         asm = compile_mlir_module_to_asm(
             module,
-            pass_pipeline=make_default_pass_pipeline(),
+            pass_pipeline=make_default_pass_pipeline(PipelineConfig()),
             print_opts=PrintOptions.from_flags(
                 print_ir_after_all=args.print_ir_after_all,
                 print_asm=args.print_asm,

--- a/contrib/kittens/test/test_102_gemm_python_multitile.py
+++ b/contrib/kittens/test/test_102_gemm_python_multitile.py
@@ -641,24 +641,16 @@ class MultitileGemmInstance(WeakScaledMappedGemmInstance):
 def compile_multitile_gemm(cfg, output_hsaco_path, **kw):
     """Compile a multi-tile GEMM config to HSACO."""
     from aster.compiler.core import PrintOptions
-    from kittens_helpers import PIPELINE_STRATEGIES
 
     lds_at_write = kw.pop("lds_at_write", getattr(cfg.mapping, "lds_at_write", False))
-    rotate_stage = None
-    if getattr(cfg.mapping, "rotate_compute_stage", False):
-        rotate_stage = PIPELINE_STRATEGIES[cfg.mapping.pipeline_strategy]["COMPUTE"]
     ctx = ir.Context()
     ctx.allow_unregistered_dialects = True
     with ctx:
         module = _build_multitile_gemm(cfg, lds_at_write=lds_at_write)
         pipeline = make_default_pass_pipeline(
+            cfg.mapping,
             num_vgprs=kw.get("num_vgprs", 256),
             num_agprs=kw.get("num_agprs", 256),
-            unroll_factor_multiplier=getattr(cfg.mapping, "unroll_factor_multiplier", 1),
-            epilogue_peeling=getattr(cfg.mapping, "epilogue_peeling", True),
-            ll_sched=getattr(cfg.mapping, "ll_sched", False),
-            hoist_iter_arg_waits=getattr(cfg.mapping, "hoist_wait", False),
-            rotate_stage=rotate_stage,
         )
         asm = compile_mlir_module_to_asm(
             module,

--- a/contrib/kittens/test/test_102_gemm_python_multitile_cdna4.py
+++ b/contrib/kittens/test/test_102_gemm_python_multitile_cdna4.py
@@ -544,23 +544,15 @@ def _make_instance(
 def compile_cdna4_gemm(cfg, output_hsaco_path, **kw):
     """Compile a CDNA4 GEMM config to HSACO."""
     from aster.compiler.core import PrintOptions
-    from kittens_helpers import PIPELINE_STRATEGIES
 
-    rotate_stage = None
-    if getattr(cfg.mapping, "rotate_compute_stage", False):
-        rotate_stage = PIPELINE_STRATEGIES[cfg.mapping.pipeline_strategy]["COMPUTE"]
     ctx = ir.Context()
     ctx.allow_unregistered_dialects = True
     with ctx:
         module = _build_cdna4_gemm(cfg)
         pipeline = make_default_pass_pipeline(
+            cfg.mapping,
             num_vgprs=kw.get("num_vgprs", 256),
             num_agprs=kw.get("num_agprs", 256),
-            unroll_factor_multiplier=getattr(cfg.mapping, "unroll_factor_multiplier", 1),
-            epilogue_peeling=getattr(cfg.mapping, "epilogue_peeling", True),
-            ll_sched=getattr(cfg.mapping, "ll_sched", False),
-            hoist_iter_arg_waits=getattr(cfg.mapping, "hoist_wait", False),
-            rotate_stage=rotate_stage,
         )
         asm = compile_mlir_module_to_asm(
             module,

--- a/contrib/kittens/test/test_103_gemm_python_multitile_ping_pong.py
+++ b/contrib/kittens/test/test_103_gemm_python_multitile_ping_pong.py
@@ -51,24 +51,16 @@ class PingPongGemmInstance(MultitileGemmInstance):
 def compile_ping_pong_gemm(cfg, output_hsaco_path, **kw):
     """Compile a ping-pong GEMM config to HSACO."""
     from aster.compiler.core import PrintOptions
-    from kittens_helpers import PIPELINE_STRATEGIES
 
-    rotate_stage = None
-    if getattr(cfg.mapping, "rotate_compute_stage", False):
-        rotate_stage = PIPELINE_STRATEGIES[cfg.mapping.pipeline_strategy]["COMPUTE"]
+    lds_at_write = kw.pop("lds_at_write", getattr(cfg.mapping, "lds_at_write", False))
     ctx = ir.Context()
     ctx.allow_unregistered_dialects = True
     with ctx:
-        module = _build_multitile_gemm(cfg, ping_pong_staggered=True)
+        module = _build_multitile_gemm(cfg, ping_pong_staggered=True, lds_at_write=lds_at_write)
         pipeline = make_default_pass_pipeline(
+            cfg.mapping,
             num_vgprs=kw.get("num_vgprs", 256),
             num_agprs=kw.get("num_agprs", 256),
-            unroll_factor_multiplier=getattr(cfg.mapping, "unroll_factor_multiplier", 1),
-            epilogue_peeling=getattr(cfg.mapping, "epilogue_peeling", True),
-            ll_sched=getattr(cfg.mapping, "ll_sched", False),
-            hoist_iter_arg_waits=getattr(cfg.mapping, "hoist_wait", False),
-            set_mfma_priority=getattr(cfg.mapping, "set_mfma_priority", True),
-            rotate_stage=rotate_stage,
         )
         asm = compile_mlir_module_to_asm(
             module,
@@ -140,7 +132,7 @@ def _run_ping_pong(cfg):
     ctx.allow_unregistered_dialects = True
     with ctx:
         module = _build_multitile_gemm(cfg, ping_pong_staggered=True)
-        asm = compile_mlir_module_to_asm(module, pass_pipeline=make_default_pass_pipeline())
+        asm = compile_mlir_module_to_asm(module, pass_pipeline=make_default_pass_pipeline(cfg.mapping))
 
     mcpu = cfg.mapping.mcpu
     path = assemble_to_hsaco(asm, target=mcpu, wavefront_size=64)

--- a/contrib/kittens/test/test_perf_001_gemm_fp16_weak_scaled.py
+++ b/contrib/kittens/test/test_perf_001_gemm_fp16_weak_scaled.py
@@ -33,7 +33,6 @@ from kittens_helpers import (
     get_mlir_file,
     get_kittens_16x16_lds_library_paths,
     constexpr_substitutions_16x32,
-    PIPELINE_STRATEGIES,
     shuffle_weight,
 )
 
@@ -179,22 +178,16 @@ def _make_substitutions(cfg):
     return subs
 
 
-def compile_gemm(
-    cfg,
-    output_hsaco_path,
-    print_ir_after_all=False,
-    print_asm=False,
-    num_vgprs=256,
-    num_agprs=256,
-):
+def compile_gemm(cfg, output_hsaco_path, **kw):
     """Compile a GEMM config to HSACO.
 
     Returns (hsaco_path, asm_str). Handles b_path (lds/direct) and
     load_type (flat/buffer) via cfg fields. All compilation options
-    (unroll, peeling, ll_sched, hoist_wait) are read from cfg.
+    (lcm_unroll, unroll, peeling, ll_sched, hoist_wait,
+    set_mfma_priority) are read from cfg.mapping.
     """
     from aster import ir
-    from aster.compiler.core import compile_mlir_file_to_asm, assemble_to_hsaco
+    from aster.compiler.core import PrintOptions, compile_mlir_file_to_asm, assemble_to_hsaco
 
     subs = _make_substitutions(cfg)
 
@@ -207,25 +200,15 @@ def compile_gemm(
     mlir_file = MLIR_FILES[mlir_key]
     lib_paths = get_kittens_16x16_lds_library_paths(use_buffer=cfg.use_buffer)
 
-    rotate_stage = None
-    if getattr(cfg, "rotate_compute_stage", False):
-        rotate_stage = PIPELINE_STRATEGIES[cfg.pipeline_strategy]["COMPUTE"]
-
     pipeline = make_default_pass_pipeline(
-        num_vgprs=num_vgprs,
-        num_agprs=num_agprs,
-        unroll_factor_multiplier=getattr(cfg, "unroll_factor_multiplier", 1),
-        epilogue_peeling=getattr(cfg, "epilogue_peeling", True),
-        ll_sched=getattr(cfg, "ll_sched", False),
-        hoist_iter_arg_waits=getattr(cfg, "hoist_wait", False),
-        rotate_stage=rotate_stage,
+        cfg.mapping,
+        num_vgprs=kw.get("num_vgprs", 256),
+        num_agprs=kw.get("num_agprs", 256),
     )
 
     ctx = ir.Context()
-    ctx.__enter__()
-    try:
-        from aster.compiler.core import PrintOptions
-
+    ctx.allow_unregistered_dialects = True
+    with ctx:
         asm, _ = compile_mlir_file_to_asm(
             get_mlir_file(mlir_file),
             cfg.kernel_name,
@@ -234,8 +217,8 @@ def compile_gemm(
             library_paths=lib_paths,
             preprocess=preprocess,
             print_opts=PrintOptions.from_flags(
-                print_ir_after_all=print_ir_after_all,
-                print_asm=print_asm,
+                print_ir_after_all=kw.get("print_ir_after_all", False),
+                print_asm=kw.get("print_asm", False),
             ),
         )
         path = assemble_to_hsaco(
@@ -246,8 +229,6 @@ def compile_gemm(
         )
         assert path is not None, "assemble_to_hsaco returned None"
         return path, asm
-    finally:
-        ctx.__exit__(None, None, None)
 
 
 def execute_gemm_hsaco(cfg, hsaco_path, num_iterations, A, B, skip_gpu_check=False):

--- a/python/aster/pass_pipelines.py
+++ b/python/aster/pass_pipelines.py
@@ -1,5 +1,34 @@
 """Common pass pipelines used across the codebase."""
 
+from dataclasses import dataclass
+from typing import Protocol
+
+
+class PipelineConfigProtocol(Protocol):
+    """Structural protocol for objects carrying pipeline compilation flags."""
+
+    lcm_unroll: bool
+    unroll_factor_multiplier: int
+    epilogue_peeling: bool
+    ll_sched: bool
+    hoist_wait: bool
+    set_mfma_priority: bool
+    rotate_stage: int | None
+
+
+@dataclass(frozen=True)
+class PipelineConfig(PipelineConfigProtocol):
+    """Default pipeline flags for callers that have no GemmMappingSpec."""
+
+    lcm_unroll: bool = False
+    unroll_factor_multiplier: int = 1
+    epilogue_peeling: bool = True
+    ll_sched: bool = False
+    hoist_wait: bool = False
+    set_mfma_priority: bool = True
+    rotate_stage: int | None = None
+
+
 # --------------------------------------------------------------------------- #
 # Helpers for compositional pass pipelines.
 # --------------------------------------------------------------------------- #
@@ -269,27 +298,26 @@ PHASE_CONSTEXPR_EXPANSION = (
 # --------------------------------------------------------------------------- #
 
 def make_default_pass_pipeline(
-    lcm_unroll=False,
-    num_vgprs=256,
-    num_agprs=256,
-    unroll_factor_multiplier=1,
-    epilogue_peeling=True,
-    ll_sched=False,
-    hoist_iter_arg_waits=False,
-    set_mfma_priority=True,
-    rotate_stage=None,
+    mapping: PipelineConfigProtocol,
+    *,
+    num_vgprs: int = 256,
+    num_agprs: int = 256,
 ) -> str:
-    """Build the production pass pipeline with configurable pipelining options."""
-    # Rotation is implemented in aster-scf-pipeline and activated only when
-    # rotate_stage is explicitly provided.
+    """Build the production pass pipeline driven by a PipelineConfigProtocol.
+
+    Args:
+        mapping: Object carrying pipeline flags (GemmMappingSpec or PipelineConfig).
+        num_vgprs: Max VGPRs for backend (default: 256).
+        num_agprs: Max AGPRs for backend (default: 256).
+    """
     return builtin_module(
         PHASE_PRE_SCHEDULING_CLEANUP,
         PHASE_CONSTEXPR_EXPANSION,
         phase_scf_pipelining(
-            lcm_unroll=lcm_unroll,
-            unroll_factor_multiplier=unroll_factor_multiplier,
-            epilogue_peeling=epilogue_peeling,
-            rotate_stage=rotate_stage,
+            lcm_unroll=mapping.lcm_unroll,
+            unroll_factor_multiplier=mapping.unroll_factor_multiplier,
+            epilogue_peeling=mapping.epilogue_peeling,
+            rotate_stage=mapping.rotate_stage,
         ),
         "aster-destructure-struct-iter-args",
         "canonicalize",
@@ -305,10 +333,11 @@ def make_default_pass_pipeline(
         # PHASE_LOWER_TO_AMDGCN,
         amdgcn_module(amdgcn_kernel("aster-hoist-ops")),
         phase_amdgcn_backend(
-            num_vgprs=num_vgprs, num_agprs=num_agprs,
-            ll_sched=ll_sched,
-            hoist_iter_arg_waits=hoist_iter_arg_waits,
-            set_mfma_priority=set_mfma_priority,
+            num_vgprs=num_vgprs,
+            num_agprs=num_agprs,
+            ll_sched=mapping.ll_sched,
+            hoist_iter_arg_waits=mapping.hoist_wait,
+            set_mfma_priority=mapping.set_mfma_priority,
         ),
         phase_nop_insertion(delays=0),
     )
@@ -332,7 +361,7 @@ def _build_registry():
         TEST_SYNCHRONOUS_PASS_PIPELINE,
     )
     return {
-        "default": make_default_pass_pipeline(),
+        "default": make_default_pass_pipeline(PipelineConfig()),
         "test-empty": TEST_EMPTY_PASS_PIPELINE,
         "test-loop": TEST_LOOP_PASS_PIPELINE,
         "test-minimal": TEST_MINIMAL_PASS_PIPELINE,


### PR DESCRIPTION
This refactoring incleases code cleanliness and also fixes lcm-unroll / set-mfma-priority / weak_scale consistently.