### PR TITLE
[amdgcn-tblgen] Add successor operand collection in ASM printer gen

### DIFF
--- a/tools/amdgcn-tblgen/InstAsmPrinterGen.cpp
+++ b/tools/amdgcn-tblgen/InstAsmPrinterGen.cpp
@@ -113,6 +113,12 @@ ASMPrinterHandler::ASMPrinterHandler(const llvm::Record *rec) : instOp(rec) {
       arguments[arg.getName()] = {arg, ASMArgFormat(arg.getAsRecord())};
     }
   }
+  // Collect block operands from successors.
+  for (auto [i, arg] : llvm::enumerate(instOp.getSuccessors().getAsRange())) {
+    if (!ASMArgFormat::isa(arg.getAsRecord()))
+      continue;
+    arguments[arg.getName()] = {arg, ASMArgFormat(arg.getAsRecord())};
+  }
   // Set up the format context.
   ctx.addSubst("_inst", "_inst");
   ctx.addSubst("_printer", "printer");

--- a/tools/amdgcn-tblgen/InstCommon.h
+++ b/tools/amdgcn-tblgen/InstCommon.h
@@ -376,6 +376,9 @@ struct InstOp : public RecordMixin<InstOp> {
   /// Get the trailing results dag.
   Dag getTrailingResults() const { return getDag("trailingResults"); }
 
+  /// Get the successors dag.
+  Dag getSuccessors() const { return getDag("successors"); }
+
   /// Get whether this instruction wants a generated assembly format.
   bool getGenInstAssemblyFormat() const {
     return getBit("genInstAssemblyFormat");


### PR DESCRIPTION
Add getSuccessors() to InstOp and collect block operands from successors in the ASM printer handler.