### PR TITLE
Relax SchedAttrs buildSSADeps to let arithmetic SALU and VALU ops

### DIFF
--- a/lib/Dialect/AMDGCN/IR/SchedAttrs.cpp
+++ b/lib/Dialect/AMDGCN/IR/SchedAttrs.cpp
@@ -88,7 +88,17 @@ void GraphBuilder::buildSSADeps(SchedGraph &graph) {
 
     // If the operation has no side-effect we need to treat it as a possible
     // sync point. Same for non-pure operations.
-    if ((!hasEffects || !mlir::isPure(op)) &&
+    //
+    // Exclude SOP2 SALU arithmetic ops (s_add_*, ...) and VALU arithmetic ops
+    // (v_add_*, ...) from sync points. The implicit read/write effects on
+    // architectural registers SCC/VCC are captured by the RAW/WAR edges
+    // added in buildNonSSADeps. Treating as fences would serialize
+    // independent arithmetic chains.
+    bool isReorderableArith = false;
+    if (auto instOp = dyn_cast<AMDGCNInstOpInterface>(op))
+      isReorderableArith =
+          instOp.hasAnyProps({InstProp::Sop2, InstProp::IsValu});
+    if ((!hasEffects || !mlir::isPure(op)) && !isReorderableArith &&
         !isa<LoadOpInterface, StoreOpInterface, AllocaOpInterface>(op)) {
       LDBG() << "Adding sync point: " << i;
       syncPoints.push_back(i);
@@ -102,6 +112,77 @@ void GraphBuilder::buildSSADeps(SchedGraph &graph) {
       if (producer && producer->getBlock() == block)
         graph.addEdge(producer, op);
     }
+  }
+}
+
+template <typename RegType>
+struct IsModeledArchReg : std::false_type {};
+template <>
+struct IsModeledArchReg<SCCType> : std::true_type {};
+template <>
+struct IsModeledArchReg<VCCType> : std::true_type {};
+
+/// Returns the read/write effects of `op` on the architectural register
+/// `RegType` (currently SCC or VCC). The register is referenced as a DPS
+/// alloca operand: an outs operand of `RegType` means the op writes the
+/// register; an ins operand of `RegType` means the op reads it. Ops without
+/// AMDGCNInstOpInterface have no architectural-register effects modeled
+/// here.
+template <typename RegType>
+static void getArchRegEffects(Operation *op, bool &reads, bool &writes) {
+  static_assert(IsModeledArchReg<RegType>::value,
+                "getArchRegEffects only supports modeled architectural "
+                "registers (SCC, VCC)");
+  reads = false;
+  writes = false;
+  auto instOp = dyn_cast<AMDGCNInstOpInterface>(op);
+  if (!instOp)
+    return;
+  for (Value v : instOp.getInstOuts()) {
+    if (isa<RegType>(v.getType())) {
+      writes = true;
+      break;
+    }
+  }
+  for (Value v : instOp.getInstIns()) {
+    if (isa<RegType>(v.getType())) {
+      reads = true;
+      break;
+    }
+  }
+}
+
+/// Add scheduling edges for the read/write effects on a single architectural
+/// register (`RegType`). The register is shared by every op that touches it
+/// but flows through DPS alloca operands rather than SSA results, so no SSA
+/// def-use chain captures the dependence.
+template <typename RegType>
+static void addArchRegEffectEdges(SchedGraph &graph, Block *block) {
+  static_assert(IsModeledArchReg<RegType>::value,
+                "addArchRegEffectEdges only supports modeled architectural "
+                "registers (SCC, VCC)");
+  SmallVector<Operation *> writers;
+  SmallVector<Operation *> readers;
+  for (Operation &op : *block) {
+    bool reads = false;
+    bool writes = false;
+    getArchRegEffects<RegType>(&op, reads, writes);
+    if (!reads && !writes)
+      continue;
+    if (reads) {
+      // RAW: pin every prior writer before this reader.
+      for (Operation *w : writers)
+        graph.addEdge(w, &op);
+    }
+    if (writes) {
+      // WAR: pin every prior reader before this writer.
+      for (Operation *r : readers)
+        graph.addEdge(r, &op);
+    }
+    if (reads)
+      readers.push_back(&op);
+    if (writes)
+      writers.push_back(&op);
   }
 }
 
@@ -126,21 +207,25 @@ void GraphBuilder::buildNonSSADeps(SchedGraph &graph) {
   // Erase all the processed sync points.
   llvm::erase(syncPoints, -1);
 
-  // If there are no sync points, return.
-  if (syncPoints.empty())
-    return;
-
-  // Add edges between all the ops before a sync point and the sync point, and
-  // between the sync point and all the ops after it.
-  for (auto [i, syncPoint] : llvm::enumerate(syncPoints)) {
-    int64_t prevSyncPoint = i > 0 ? syncPoints[i - 1] : 0;
-    int64_t nextSyncPoint =
-        i < (syncPoints.size() - 1) ? syncPoints[i + 1] + 1 : ops.size();
-    for (int64_t point = prevSyncPoint; point < syncPoint; point++)
-      graph.addEdge(point, syncPoint);
-    for (int64_t point = syncPoint + 1; point < nextSyncPoint; point++)
-      graph.addEdge(syncPoint, point);
+  // Add fence edges for the remaining sync points: every preceding op in
+  // the segment must precede the sync point, and every following op in the
+  // segment must come after.
+  if (!syncPoints.empty()) {
+    for (auto [i, syncPoint] : llvm::enumerate(syncPoints)) {
+      int64_t prevSyncPoint = i > 0 ? syncPoints[i - 1] : 0;
+      int64_t nextSyncPoint =
+          i < (syncPoints.size() - 1) ? syncPoints[i + 1] + 1 : ops.size();
+      for (int64_t point = prevSyncPoint; point < syncPoint; point++)
+        graph.addEdge(point, syncPoint);
+      for (int64_t point = syncPoint + 1; point < nextSyncPoint; point++)
+        graph.addEdge(syncPoint, point);
+    }
   }
+
+  // RAW / WAR edges for read/write effects on the architectural registers
+  // SCC and VCC.
+  addArchRegEffectEdges<SCCType>(graph, block);
+  addArchRegEffectEdges<VCCType>(graph, block);
 }
 
 void GraphBuilder::handleWaitOp(SchedGraph &graph, int64_t pos, WaitOp wait) {

--- a/test/Dialect/AMDGCN/Transforms/ll-sched-archreg-edges.mlir
+++ b/test/Dialect/AMDGCN/Transforms/ll-sched-archreg-edges.mlir
@@ -1,0 +1,122 @@
+// RUN: aster-opt %s --pass-pipeline="builtin.module(test-amdgcn-sched-graph)" 2>&1 | FileCheck %s
+
+!v   = !amdgcn.vgpr
+!s   = !amdgcn.sgpr
+
+amdgcn.module @scc_war target = #amdgcn.target<gfx942> {
+  // CHECK-LABEL: Kernel: @scc_war
+  // CHECK:       digraph SchedGraph
+  // CHECK-DAG:     label = "s_addc_u32 -> s_add_u32"
+  // CHECK-NOT:     label = "s_add_u32 -> s_addc_u32"
+  // CHECK:       }
+  amdgcn.kernel @scc_war {
+    %s_a    = amdgcn.alloca : !s
+    %s_b    = amdgcn.alloca : !s
+    %s_d1   = amdgcn.alloca : !s
+    %s_d2   = amdgcn.alloca : !s
+    %scc_in  = amdgcn.alloca : !amdgcn.scc<0>
+    %scc_out = amdgcn.alloca : !amdgcn.scc<0>
+    %addc = amdgcn.s_addc_u32 outs(%s_d1, %scc_out) ins(%s_a, %s_b, %scc_in) : outs(!s, !amdgcn.scc<0>) ins(!s, !s, !amdgcn.scc<0>)
+    %add  = amdgcn.s_add_u32  outs(%s_d2, %scc_in)  ins(%s_a, %s_b)          : outs(!s, !amdgcn.scc<0>) ins(!s, !s)
+    amdgcn.end_kernel
+  }
+}
+
+// -----
+
+amdgcn.module @vcc_raw target = #amdgcn.target<gfx942> {
+  // CHECK-LABEL: Kernel: @vcc_raw
+  // CHECK:       digraph SchedGraph
+  // CHECK-DAG:     label = "v_cmp_eq_i32 -> v_cndmask_b32"
+  // CHECK-NOT:     label = "v_cndmask_b32 -> v_cmp_eq_i32"
+  // CHECK:       }
+  amdgcn.kernel @vcc_raw {
+    %v_a = amdgcn.alloca : !v
+    %v_b = amdgcn.alloca : !v
+    %v_d = amdgcn.alloca : !v
+    %vcc = amdgcn.alloca : !amdgcn.vcc<0>
+    amdgcn.v_cmp_eq_i32 outs(%vcc) ins(%v_a, %v_b) : outs(!amdgcn.vcc<0>) ins(!v, !v)
+    %sel = amdgcn.v_cndmask_b32 outs(%v_d) ins(%v_a, %v_b, %vcc) : outs(!v) ins(!v, !v, !amdgcn.vcc<0>)
+    amdgcn.end_kernel
+  }
+}
+
+// -----
+
+amdgcn.module @scc_waw_relaxed target = #amdgcn.target<gfx942> {
+  // CHECK-LABEL: Kernel: @scc_waw_relaxed
+  // CHECK:       digraph SchedGraph
+  // CHECK-NOT:     label = "s_add_u32 -> s_and_b32"
+  // CHECK-NOT:     label = "s_and_b32 -> s_add_u32"
+  // CHECK:       }
+  amdgcn.kernel @scc_waw_relaxed {
+    %s_a   = amdgcn.alloca : !s
+    %s_b   = amdgcn.alloca : !s
+    %s_d1  = amdgcn.alloca : !s
+    %s_d2  = amdgcn.alloca : !s
+    %scc_a = amdgcn.alloca : !amdgcn.scc<0>
+    %scc_b = amdgcn.alloca : !amdgcn.scc<0>
+    %add = amdgcn.s_add_u32 outs(%s_d1, %scc_a) ins(%s_a, %s_b) : outs(!s, !amdgcn.scc<0>) ins(!s, !s)
+    %and = amdgcn.s_and_b32 outs(%s_d2, %scc_b) ins(%s_a, %s_b) : outs(!s, !amdgcn.scc<0>) ins(!s, !s)
+    amdgcn.end_kernel
+  }
+}
+
+// -----
+
+amdgcn.module @scc_war_through_writer_run target = #amdgcn.target<gfx942> {
+  // CHECK-LABEL: Kernel: @scc_war_through_writer_run
+  // CHECK:       digraph SchedGraph
+  // CHECK-DAG:     label = "s_addc_u32 -> s_add_u32"
+  // CHECK-DAG:     label = "s_addc_u32 -> s_and_b32"
+  // CHECK:       }
+  amdgcn.kernel @scc_war_through_writer_run {
+    %s_a    = amdgcn.alloca : !s
+    %s_b    = amdgcn.alloca : !s
+    %s_d1   = amdgcn.alloca : !s
+    %s_d2   = amdgcn.alloca : !s
+    %s_d3   = amdgcn.alloca : !s
+    %scc_in  = amdgcn.alloca : !amdgcn.scc<0>
+    %scc_a   = amdgcn.alloca : !amdgcn.scc<0>
+    %scc_b   = amdgcn.alloca : !amdgcn.scc<0>
+    %addc = amdgcn.s_addc_u32 outs(%s_d1, %scc_a) ins(%s_a, %s_b, %scc_in) : outs(!s, !amdgcn.scc<0>) ins(!s, !s, !amdgcn.scc<0>)
+    %add  = amdgcn.s_add_u32  outs(%s_d2, %scc_in) ins(%s_a, %s_b) : outs(!s, !amdgcn.scc<0>) ins(!s, !s)
+    %and  = amdgcn.s_and_b32  outs(%s_d3, %scc_b) ins(%s_a, %s_b) : outs(!s, !amdgcn.scc<0>) ins(!s, !s)
+    amdgcn.end_kernel
+  }
+}
+
+// -----
+
+amdgcn.module @scc_vcc_independent target = #amdgcn.target<gfx942> {
+  // CHECK-LABEL: Kernel: @scc_vcc_independent
+  // CHECK:       digraph SchedGraph
+  // CHECK-DAG:     label = "s_add_u32 -> s_addc_u32"
+  // CHECK-DAG:     label = "v_cmp_eq_i32 -> v_cndmask_b32"
+  // CHECK-NOT:     label = "s_add_u32 -> v_cmp_eq_i32"
+  // CHECK-NOT:     label = "v_cmp_eq_i32 -> s_add_u32"
+  // CHECK-NOT:     label = "s_add_u32 -> v_cndmask_b32"
+  // CHECK-NOT:     label = "v_cndmask_b32 -> s_add_u32"
+  // CHECK-NOT:     label = "s_addc_u32 -> v_cmp_eq_i32"
+  // CHECK-NOT:     label = "v_cmp_eq_i32 -> s_addc_u32"
+  // CHECK-NOT:     label = "s_addc_u32 -> v_cndmask_b32"
+  // CHECK-NOT:     label = "v_cndmask_b32 -> s_addc_u32"
+  // CHECK:       }
+  amdgcn.kernel @scc_vcc_independent {
+    %v_a = amdgcn.alloca : !v
+    %v_b = amdgcn.alloca : !v
+    %v_d = amdgcn.alloca : !v
+    %s_a = amdgcn.alloca : !s
+    %s_b = amdgcn.alloca : !s
+    %s_d1 = amdgcn.alloca : !s
+    %s_d2 = amdgcn.alloca : !s
+    %vcc   = amdgcn.alloca : !amdgcn.vcc<0>
+    %scc_w = amdgcn.alloca : !amdgcn.scc<0>
+    %scc_r = amdgcn.alloca : !amdgcn.scc<0>
+    amdgcn.v_cmp_eq_i32 outs(%vcc) ins(%v_a, %v_b) : outs(!amdgcn.vcc<0>) ins(!v, !v)
+    %add  = amdgcn.s_add_u32  outs(%s_d1, %scc_w) ins(%s_a, %s_b) : outs(!s, !amdgcn.scc<0>) ins(!s, !s)
+    %sel  = amdgcn.v_cndmask_b32 outs(%v_d) ins(%v_a, %v_b, %vcc) : outs(!v) ins(!v, !v, !amdgcn.vcc<0>)
+    %addc = amdgcn.s_addc_u32 outs(%s_d2, %scc_r) ins(%s_a, %s_b, %scc_w) : outs(!s, !amdgcn.scc<0>) ins(!s, !s, !amdgcn.scc<0>)
+    amdgcn.end_kernel
+  }
+}

--- a/test/lib/Pass/CMakeLists.txt
+++ b/test/lib/Pass/CMakeLists.txt
@@ -13,6 +13,7 @@ add_mlir_library(ASTERTestPass
   TestBufferAnalysis.cpp
   TestReachingDefinitions.cpp
   TestLDSInterferenceGraph.cpp
+  TestAMDGCNSchedGraph.cpp
   TestLDSMultibufferPrep.cpp
   TestWaitAnalysis.cpp
   TestHazardAnalysis.cpp

--- a/test/lib/Pass/Passes.td
+++ b/test/lib/Pass/Passes.td
@@ -121,6 +121,17 @@ def TestLDSInterferenceGraph
   }];
 }
 
+def TestAMDGCNSchedGraph : Pass<"test-amdgcn-sched-graph"> {
+  let summary = "Test pass that prints the AMDGCN value-scheduler SchedGraph";
+  let description = [{
+    For each amdgcn.kernel in the input, build the value-scheduler SchedGraph
+    via ValueSchedulerAttr::createGraph and print it in DOT-style form to
+    stderr. Used to verify the dependence edges added by GraphBuilder
+    (SSA, wait/barrier, sync-fence, architectural register RAW/WAR, i1
+    serialization).
+  }];
+}
+
 def TestLDSMultibufferPrep : Pass<"test-lds-multibuffer-prep"> {
   let summary = "Test pass for LDS multi-buffer prep transformation";
   let description = [{

--- a/test/lib/Pass/TestAMDGCNSchedGraph.cpp
+++ b/test/lib/Pass/TestAMDGCNSchedGraph.cpp
@@ -1,0 +1,89 @@
+//===- TestAMDGCNSchedGraph.cpp - Test SchedGraph printer -----------------===//
+//
+// Copyright 2025 The ASTER Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements a test pass that builds and prints the AMDGCN value-
+// scheduler SchedGraph for each amdgcn.kernel. Used to verify the dependence
+// edges added by GraphBuilder (SSA, wait/barrier, sync-fence, architectural
+// register RAW/WAR, i1 serialization).
+//
+//===----------------------------------------------------------------------===//
+
+#include "aster/Dialect/AMDGCN/IR/AMDGCNAttrs.h"
+#include "aster/Dialect/AMDGCN/IR/AMDGCNOps.h"
+#include "aster/Interfaces/SchedInterfaces.h"
+
+#include "mlir/Analysis/DataFlow/Utils.h"
+#include "mlir/Analysis/DataFlowFramework.h"
+#include "mlir/IR/Dominance.h"
+#include "mlir/Pass/Pass.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace mlir::aster::test {
+#define GEN_PASS_DEF_TESTAMDGCNSCHEDGRAPH
+#include "Passes.h.inc"
+} // namespace mlir::aster::test
+
+using namespace mlir;
+using namespace mlir::aster;
+using namespace mlir::aster::amdgcn;
+
+namespace {
+struct TestAMDGCNSchedGraph
+    : public mlir::aster::test::impl::TestAMDGCNSchedGraphBase<
+          TestAMDGCNSchedGraph> {
+  using TestAMDGCNSchedGraphBase::TestAMDGCNSchedGraphBase;
+
+  void runOnOperation() override {
+    Operation *root = getOperation();
+    auto &domInfo = getAnalysis<DominanceInfo>();
+
+    DataFlowSolver solver(DataFlowConfig().setInterprocedural(false));
+    dataflow::loadBaselineAnalyses(solver);
+    SchedAnalysis analysis(root, solver, domInfo, getAnalysisManager());
+
+    auto schedAttr = ValueSchedulerAttr::get(&getContext());
+    if (failed(schedAttr.initializeAnalyses(analysis))) {
+      root->emitError() << "failed to initialize sched analyses";
+      return signalPassFailure();
+    }
+    if (failed(solver.initializeAndRun(root))) {
+      root->emitError() << "failed to run dataflow analyses";
+      return signalPassFailure();
+    }
+
+    root->walk([&](amdgcn::KernelOp kernel) {
+      Block &block = kernel.getBodyRegion().front();
+      auto graph = schedAttr.createGraph(&block, analysis);
+      if (failed(graph)) {
+        kernel.emitError() << "failed to build SchedGraph";
+        signalPassFailure();
+        return;
+      }
+
+      const SchedGraph &g = *graph;
+      auto nodePrinter = [&g](raw_ostream &os, const int32_t &nodeId) {
+        Operation *op = g.getOp(nodeId);
+        os << "label = \"" << nodeId << ": " << op->getName().stripDialect()
+           << "\"";
+      };
+      auto edgePrinter = [&g](raw_ostream &os, const Graph::Edge &edge) {
+        Operation *src = g.getOp(edge.first);
+        Operation *tgt = g.getOp(edge.second);
+        os << "label = \"" << src->getName().stripDialect() << " -> "
+           << tgt->getName().stripDialect() << "\"";
+      };
+
+      llvm::errs() << "Kernel: @" << kernel.getSymName() << "\n";
+      g.print(llvm::errs(), "SchedGraph", nodePrinter, edgePrinter);
+      llvm::errs() << "\n\n";
+    });
+  }
+};
+} // namespace


### PR DESCRIPTION
We represent the implicit dependences through architectural registers via side effects.
This opens up the possibility of better schedule heuristics.