### PR TITLE
[amdgcn] Materialize GP register type definitions with GPRegTrait

### DIFF
--- a/include/aster/Dialect/AMDGCN/IR/AMDGCNTypes.h
+++ b/include/aster/Dialect/AMDGCN/IR/AMDGCNTypes.h
@@ -36,6 +36,12 @@ template <typename ConcreteType>
 struct SpecialRegTrait
     : public ::mlir::TypeTrait::TraitBase<ConcreteType, SpecialRegTrait> {};
 
+/// Trait providing common method implementations for AMDGCN general-purpose
+/// register types. Each concrete type defines kRegisterKind.
+template <typename ConcreteType>
+struct GPRegTrait
+    : public ::mlir::TypeTrait::TraitBase<ConcreteType, GPRegTrait> {};
+
 /// Returns true if it's a register type with size 1.
 bool isRegisterLike(Type type);
 } // namespace mlir::aster::amdgcn

--- a/include/aster/Dialect/AMDGCN/IR/AMDGCNTypes.td
+++ b/include/aster/Dialect/AMDGCN/IR/AMDGCNTypes.td
@@ -31,129 +31,71 @@ class AMDGCN_RegisterDef<string name, string typeMnemonic, list<Trait> traits = 
 }
 
 //===----------------------------------------------------------------------===//
-// AGPR like types
+// GP register types
 //===----------------------------------------------------------------------===//
 
-def AGPRType : AMDGCN_RegisterDef<"AGPR", "agpr", [MemRefElementTypeInterface]> {
+def GPRegTrait : NativeTypeTrait<"GPRegTrait"> {
+  let cppNamespace = "::mlir::aster::amdgcn";
+  let extraConcreteClassDeclaration = [{
+    Register getReg() const { return getRange().begin(); }
+
+    //===------------------------------------------------------------------===//
+    // RegisterTypeInterface
+    //===------------------------------------------------------------------===//
+    RegisterRange getAsRange() const {
+      return getRange();
+    }
+    RegisterKind getRegisterKind() const {
+      return kRegisterKind;
+    }
+    RegisterTypeInterface cloneRegisterType(RegisterRange range) const {
+      return get(getContext(), range);
+    }
+    int64_t getSizeInBits() const {
+      return static_cast<int64_t>(getRange().size()) * 32;
+    }
+
+    //===------------------------------------------------------------------===//
+    // ResourceTypeInterface
+    //===------------------------------------------------------------------===//
+    Resource *getResource() const;
+  }];
+}
+
+class GPRegTypeBase<string name, string mnemonic>
+    : AMDGCN_RegisterDef<name, mnemonic, [MemRefElementTypeInterface, GPRegTrait]> {
+  let parameters = (ins
+    DefaultValuedParameter<"RegisterRange", "RegisterRange()">:$range
+  );
+  let assemblyFormat = "(`<` $range^ `>`)?";
+  let builders = [
+    TypeBuilder<(ins CArg<"Register", "Register()">:$reg,
+        CArg<"int16_t", "1">:$size,
+        CArg<"int16_t", "1">:$alignment), [{
+      return $_get($_ctxt, RegisterRange(reg, size, alignment));
+    }]>
+  ];
+  let genVerifyDecl = 1;
+}
+
+def AGPRType : GPRegTypeBase<"AGPR", "agpr"> {
   let summary = "AGPR type";
-  let parameters = (ins
-    DefaultValuedParameter<"RegisterRange", "RegisterRange()">:$range
-  );
-  let assemblyFormat = "(`<` $range^ `>`)?";
-  let builders = [
-    TypeBuilder<(ins CArg<"Register", "Register()">:$reg, CArg<"int16_t", "1">:$size,
-        CArg<"int16_t", "1">:$alignment), [{
-      return $_get($_ctxt, RegisterRange(reg, size, alignment));
-    }]>
-  ];
-  let genVerifyDecl = 1;
   let extraClassDeclaration = [{
-    Register getReg() const { return getRange().begin(); }
-    //===------------------------------------------------------------------===//
-    // RegisterTypeInterface
-    //===------------------------------------------------------------------===//
-    RegisterRange getAsRange() const {
-      return getRange();
-    }
-    RegisterKind getRegisterKind() const {
-      return RegisterKind::AGPR;
-    }
-    RegisterTypeInterface cloneRegisterType(RegisterRange range) const {
-      return AGPRType::get(getContext(), range);
-    }
-    int64_t getSizeInBits() const {
-      return static_cast<int64_t>(getRange().size()) * 32;
-    }
-
-    //===------------------------------------------------------------------===//
-    // ResourceTypeInterface
-    //===------------------------------------------------------------------===//
-    Resource *getResource() const;
+    static constexpr RegisterKind kRegisterKind = RegisterKind::AGPR;
   }];
 }
 
-//===----------------------------------------------------------------------===//
-// SGPR like types
-//===----------------------------------------------------------------------===//
-
-def SGPRType : AMDGCN_RegisterDef<"SGPR", "sgpr", [MemRefElementTypeInterface]> {
+def SGPRType : GPRegTypeBase<"SGPR", "sgpr"> {
   let summary = "SGPR type";
-  let parameters = (ins
-    DefaultValuedParameter<"RegisterRange", "RegisterRange()">:$range
-  );
-  let assemblyFormat = "(`<` $range^ `>`)?";
-  let builders = [
-    TypeBuilder<(ins CArg<"Register", "Register()">:$reg, CArg<"int16_t", "1">:$size,
-        CArg<"int16_t", "1">:$alignment), [{
-      return $_get($_ctxt, RegisterRange(reg, size, alignment));
-    }]>
-  ];
-  let genVerifyDecl = 1;
   let extraClassDeclaration = [{
-    Register getReg() const { return getRange().begin(); }
-    //===------------------------------------------------------------------===//
-    // RegisterTypeInterface
-    //===------------------------------------------------------------------===//
-    RegisterRange getAsRange() const {
-      return getRange();
-    }
-    RegisterKind getRegisterKind() const {
-      return RegisterKind::SGPR;
-    }
-    RegisterTypeInterface cloneRegisterType(RegisterRange range) const {
-      return SGPRType::get(getContext(), range);
-    }
-    int64_t getSizeInBits() const {
-      return static_cast<int64_t>(getRange().size()) * 32;
-    }
-
-    //===------------------------------------------------------------------===//
-    // ResourceTypeInterface
-    //===------------------------------------------------------------------===//
-    Resource *getResource() const;
+    static constexpr RegisterKind kRegisterKind = RegisterKind::SGPR;
   }];
 }
 
-//===----------------------------------------------------------------------===//
-// VGPR like types
-//===----------------------------------------------------------------------===//
-
-def VGPRType : AMDGCN_RegisterDef<"VGPR", "vgpr", [MemRefElementTypeInterface]> {
+def VGPRType : GPRegTypeBase<"VGPR", "vgpr"> {
   let summary = "VGPR type";
-  let parameters = (ins
-    DefaultValuedParameter<"RegisterRange", "RegisterRange()">:$range
-  );
-  let assemblyFormat = "(`<` $range^ `>`)?";
-  let builders = [
-    TypeBuilder<(ins CArg<"Register", "Register()">:$reg, CArg<"int16_t", "1">:$size,
-        CArg<"int16_t", "1">:$alignment), [{
-      return $_get($_ctxt, RegisterRange(reg, size, alignment));
-    }]>
-  ];
-  let genVerifyDecl = 1;
   let extraClassDeclaration = [{
-    Register getReg() const { return getRange().begin(); }
-
-    //===------------------------------------------------------------------===//
-    // RegisterTypeInterface
-    //===------------------------------------------------------------------===//
-    RegisterRange getAsRange() const {
-      return getRange();
-    }
-    RegisterKind getRegisterKind() const {
-      return RegisterKind::VGPR;
-    }
-    RegisterTypeInterface cloneRegisterType(RegisterRange range) const {
-      return VGPRType::get(getContext(), range);
-    }
-    int64_t getSizeInBits() const {
-      return static_cast<int64_t>(getRange().size()) * 32;
-    }
-
-    //===------------------------------------------------------------------===//
-    // ResourceTypeInterface
-    //===------------------------------------------------------------------===//
-    Resource *getResource() const;
+    static constexpr RegisterKind kRegisterKind = RegisterKind::VGPR;
   }];
 }
 


### PR DESCRIPTION
Apply the same pattern as SpecialRegTrait to AGPR, SGPR, and VGPR. Introduce GPRegTrait (NativeTypeTrait + C++ CRTP struct) to hold all common method implementations, and GPRegTypeBase as the invariant tablegen structure. Consolidate the three separate sections into a single GP register types section. Each def now only declares its kRegisterKind constant.