### PR TITLE
[interfaces] Add RegisterProps enum and getProps interface method

### DIFF
--- a/include/aster/Dialect/AMDGCN/IR/AMDGCNTypes.td
+++ b/include/aster/Dialect/AMDGCN/IR/AMDGCNTypes.td
@@ -54,6 +54,15 @@ def GPRegTrait : NativeTypeTrait<"GPRegTrait"> {
     int64_t getSizeInBits() const {
       return static_cast<int64_t>(getRange().size()) * 32;
     }
+    RegisterProps getProps() const {
+      RegisterProps props = RegisterProps::IsGeneralPurpose |
+                            RegisterProps::AcceptsValueSemantics |
+                            RegisterProps::AcceptsUnallocatedSemantics |
+                            RegisterProps::AcceptsAllocatedSemantics;
+      if (getRange().size() > 1)
+        return props | RegisterProps::IsComposite;
+      return props | RegisterProps::AcceptsComposite;
+    }
 
     //===------------------------------------------------------------------===//
     // ResourceTypeInterface
@@ -124,6 +133,11 @@ def SpecialRegTrait : NativeTypeTrait<"SpecialRegTrait"> {
     }
     int64_t getSizeInBits() const {
       return kSizeInBits;
+    }
+    RegisterProps getProps() const {
+      return RegisterProps::AcceptsValueSemantics |
+             RegisterProps::AcceptsUnallocatedSemantics |
+             RegisterProps::AcceptsAllocatedSemantics;
     }
 
     //===------------------------------------------------------------------===//

--- a/include/aster/Interfaces/RegisterSemantics.td
+++ b/include/aster/Interfaces/RegisterSemantics.td
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This file defines aster register semantics.
+// This file defines aster register semantics and properties.
 //
 //===----------------------------------------------------------------------===//
 
@@ -26,6 +26,23 @@ def RegisterSemantics : AutoI8EnumCases<"RegisterSemantics",
     PrettyEnumCaseInfo<"allocated">,
     PrettyEnumCaseInfo<"unallocated">,
     PrettyEnumCaseInfo<"value">,
+  ]> {
+  let cppNamespace = "::mlir::aster";
+}
+
+//===----------------------------------------------------------------------===//
+// Aster register properties.
+//===----------------------------------------------------------------------===//
+
+def RegisterProps : I8BitEnum<"RegisterProps",
+  "Register type properties", [
+    I8BitEnumCaseNone<"None", "none">,
+    I8BitEnumCase<"IsGeneralPurpose", 1, "is_general_purpose">,
+    I8BitEnumCase<"IsComposite", 2, "is_composite">,
+    I8BitEnumCase<"AcceptsComposite", 4, "accepts_composite">,
+    I8BitEnumCase<"AcceptsValueSemantics", 8, "accepts_value_semantics">,
+    I8BitEnumCase<"AcceptsUnallocatedSemantics", 16, "accepts_unallocated_semantics">,
+    I8BitEnumCase<"AcceptsAllocatedSemantics", 32, "accepts_allocated_semantics">
   ]> {
   let cppNamespace = "::mlir::aster";
 }

--- a/include/aster/Interfaces/RegisterType.td
+++ b/include/aster/Interfaces/RegisterType.td
@@ -46,6 +46,11 @@ def RegisterTypeInterface : TypeInterface<"RegisterTypeInterface", [
         This method returns the size in bits of the register(s).
       }],
       "int64_t", "getSizeInBits"
+    >,
+    InterfaceMethod<[{
+        Returns the properties of the register type.
+      }],
+      "::mlir::aster::RegisterProps", "getProps"
     >
   ];
   let extraTraitClassDeclaration = [{

--- a/lib/Interfaces/RegisterType.cpp
+++ b/lib/Interfaces/RegisterType.cpp
@@ -9,6 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "aster/Interfaces/RegisterType.h"
+#include "llvm/ADT/StringExtras.h"
 
 #include "aster/Interfaces/RegisterSemantics.cpp.inc"
 


### PR DESCRIPTION
Add RegisterProps BitEnum with IsGeneralPurpose, IsComposite, AcceptsComposite, AcceptsValueSemantics, AcceptsUnallocatedSemantics, and AcceptsAllocatedSemantics cases. Add getProps method to RegisterTypeInterface, implemented in GPRegTrait and SpecialRegTrait.