### PR TITLE
[amdgcn] Reject single-register make/split_register_range ops

### DIFF
--- a/examples/02_nop_insertion/kernel.mlir
+++ b/examples/02_nop_insertion/kernel.mlir
@@ -32,9 +32,8 @@ module {
       amdgcn.v_lshlrev_b32 outs(%v1) ins(%c2, %v0) : outs(!amdgcn.vgpr<1>) ins(i32, !amdgcn.vgpr<0>)
 
       // Store thread ID (v0) to output[tid]
-      %data_r = amdgcn.make_register_range %v0 : !amdgcn.vgpr<0>
       %c0 = arith.constant 0 : i32
-      amdgcn.global_store_dword data %data_r addr %out_ptr offset d(%v1) + c(%c0) : ins(!amdgcn.vgpr<[0 : 1]>, !amdgcn.sgpr<[2 : 4]>, !amdgcn.vgpr<1>) mods(i32) -> !amdgcn.write_token<flat>
+      amdgcn.global_store_dword data %v0 addr %out_ptr offset d(%v1) + c(%c0) : ins(!amdgcn.vgpr<[0 : 1]>, !amdgcn.sgpr<[2 : 4]>, !amdgcn.vgpr<1>) mods(i32) -> !amdgcn.write_token<flat>
 
       // Immediately overwrite v0 -- HAZARD: memory still reading v0
       %c7 = arith.constant 7 : i32

--- a/examples/03_vector_add/kernel.mlir
+++ b/examples/03_vector_add/kernel.mlir
@@ -70,12 +70,10 @@ module {
       amdgcn.v_lshlrev_b32 outs(%v1) ins(%c2, %v0) : outs(!amdgcn.vgpr<1>) ins(i32, !amdgcn.vgpr<0>)
 
       // Load a[tid] and b[tid]
-      %a_data = amdgcn.make_register_range %v2 : !amdgcn.vgpr<2>
       %c0 = arith.constant 0 : i32
-      amdgcn.global_load_dword dest %a_data addr %a_ptr offset d(%v1) + c(%c0) : outs(!amdgcn.vgpr<[2 : 3]>) ins(!amdgcn.sgpr<[2 : 4]>, !amdgcn.vgpr<1>) mods(i32) -> !amdgcn.read_token<flat>
+      amdgcn.global_load_dword dest %v2 addr %a_ptr offset d(%v1) + c(%c0) : outs(!amdgcn.vgpr<[2 : 3]>) ins(!amdgcn.sgpr<[2 : 4]>, !amdgcn.vgpr<1>) mods(i32) -> !amdgcn.read_token<flat>
 
-      %b_data = amdgcn.make_register_range %v3 : !amdgcn.vgpr<3>
-      amdgcn.global_load_dword dest %b_data addr %b_ptr offset d(%v1) + c(%c0) : outs(!amdgcn.vgpr<[3 : 4]>) ins(!amdgcn.sgpr<[4 : 6]>, !amdgcn.vgpr<1>) mods(i32) -> !amdgcn.read_token<flat>
+      amdgcn.global_load_dword dest %v3 addr %b_ptr offset d(%v1) + c(%c0) : outs(!amdgcn.vgpr<[3 : 4]>) ins(!amdgcn.sgpr<[4 : 6]>, !amdgcn.vgpr<1>) mods(i32) -> !amdgcn.read_token<flat>
 
       // Wait for all outstanding vector memory operations
       amdgcn.s_waitcnt vmcnt = 0
@@ -84,8 +82,7 @@ module {
       amdgcn.v_add_u32 outs(%v2) ins(%v2, %v3) : outs(!amdgcn.vgpr<2>) ins(!amdgcn.vgpr<2>, !amdgcn.vgpr<3>)
 
       // Store result
-      %c_data = amdgcn.make_register_range %v2 : !amdgcn.vgpr<2>
-      amdgcn.global_store_dword data %c_data addr %c_ptr offset d(%v1) + c(%c0) : ins(!amdgcn.vgpr<[2 : 3]>, !amdgcn.sgpr<[6 : 8]>, !amdgcn.vgpr<1>) mods(i32) -> !amdgcn.write_token<flat>
+      amdgcn.global_store_dword data %v2 addr %c_ptr offset d(%v1) + c(%c0) : ins(!amdgcn.vgpr<[2 : 3]>, !amdgcn.sgpr<[6 : 8]>, !amdgcn.vgpr<1>) mods(i32) -> !amdgcn.write_token<flat>
 
       amdgcn.s_waitcnt vmcnt = 0
       end_kernel

--- a/lib/Dialect/AMDGCN/IR/AMDGCN.cpp
+++ b/lib/Dialect/AMDGCN/IR/AMDGCN.cpp
@@ -339,10 +339,10 @@ LogicalResult MakeRegisterRangeOp::inferReturnTypes(
     MLIRContext *context, std::optional<Location> location, ValueRange operands,
     DictionaryAttr attributes, PropertyRef properties, RegionRange regions,
     SmallVectorImpl<Type> &inferredReturnTypes) {
-  // Fail if there are no operands.
-  if (operands.empty()) {
+  // Fail if there are fewer than two operands.
+  if (operands.size() < 2) {
     if (location)
-      mlir::emitError(*location) << "expected at least one operand";
+      mlir::emitError(*location) << "expected at least two operands";
     return failure();
   }
 
@@ -456,6 +456,12 @@ LogicalResult SplitRegisterRangeOp::inferReturnTypes(
   // Get the range information.
   RegisterRange range = rangeType.getAsRange();
   int size = range.size();
+
+  if (size <= 1) {
+    if (location)
+      mlir::emitError(*location) << "cannot split a single register";
+    return failure();
+  }
 
   // Create a function to make individual register types.
   auto makeRegister = [&](Register reg) -> Type {

--- a/mlir_kernels/library/common/register-init.mlir
+++ b/mlir_kernels/library/common/register-init.mlir
@@ -35,8 +35,7 @@ amdgcn.library @common_register_init isa = [#amdgcn.isa<cdna3>] {
   // Allocate a VGPRx1 range
   func.func private @alloc_vgprx1() -> !vx1 {
     %r0 = amdgcn.alloca : !v
-    %range = amdgcn.make_register_range %r0 : !v
-    return %range : !vx1
+    return %r0 : !vx1
   }
 
   // Allocate a VGPRx2 range
@@ -110,8 +109,7 @@ amdgcn.library @common_register_init isa = [#amdgcn.isa<cdna3>] {
   // Allocate a SGPRx1 range
   func.func private @alloc_sgprx1() -> !sx1 {
     %r0 = amdgcn.alloca : !s
-    %range = amdgcn.make_register_range %r0 : !s
-    return %range : !sx1
+    return %r0 : !sx1
   }
 
   // Allocate a SGPRx2 range
@@ -144,8 +142,7 @@ amdgcn.library @common_register_init isa = [#amdgcn.isa<cdna3>] {
   // Allocate an AGPRx1 range
   func.func private @alloc_agprx1() -> !ax1 {
     %r0 = amdgcn.alloca : !a
-    %range = amdgcn.make_register_range %r0 : !a
-    return %range : !ax1
+    return %r0 : !ax1
   }
 
   // Allocate an AGPRx2 range
@@ -301,8 +298,7 @@ amdgcn.library @common_register_init isa = [#amdgcn.isa<cdna3>] {
   func.func private @init_agprx1(%cst: i32) -> !ax1 {
     %r0 = amdgcn.alloca : !a
     %a0 = amdgcn.v_accvgpr_write outs(%r0) ins(%cst) : outs(!amdgcn.agpr) ins(i32)
-    %range = amdgcn.make_register_range %a0 : !a
-    return %range : !ax1
+    return %a0 : !ax1
   }
 
   // Initialize an AGPRx2 range to %cst

--- a/test/Dialect/AMDGCN/Analysis/cdna3-hazards.mlir
+++ b/test/Dialect/AMDGCN/Analysis/cdna3-hazards.mlir
@@ -114,14 +114,6 @@ func.func @cdna3_valu_sgpr_vmem_hazard_detected(%arg0: !amdgcn.vgpr<0>, %arg1: !
 // CHECK:     ]
 // CHECK:     nop counts = {v:0, s:0, ds:0}
 // CHECK:   }
-// CHECK: Op: %{{.*}} = amdgcn.make_register_range %{{.*}} : !amdgcn.vgpr<0>
-// CHECK:   HAZARD STATE AFTER: {
-// CHECK:     active = [
-// CHECK:       {#amdgcn.cdna3_store_write_data_hazard, %{{.*}} = amdgcn.global_store_dword data %{{.*}} addr %{{.*}} offset d(%{{.*}}) + c(%{{.*}}) : ins(!amdgcn.vgpr<0>, !amdgcn.sgpr<[0 : 2]>, !amdgcn.vgpr<2>) mods(i32) -> !amdgcn.write_token<flat>, 0, {v:1, s:0, ds:0}},
-// CHECK:       {#amdgcn.cdna3_store_hazard, %{{.*}} = amdgcn.global_store_dword data %{{.*}} addr %{{.*}} offset d(%{{.*}}) + c(%{{.*}}) : ins(!amdgcn.vgpr<0>, !amdgcn.sgpr<[0 : 2]>, !amdgcn.vgpr<2>) mods(i32) -> !amdgcn.write_token<flat>, 0, {v:2, s:0, ds:0}}
-// CHECK:     ]
-// CHECK:     nop counts = {v:0, s:0, ds:0}
-// CHECK:   }
 // CHECK: Op: %{{.*}} = amdgcn.global_load_dword dest %{{.*}} addr %{{.*}} offset d(%{{.*}}) + c(%{{.*}}) : outs(!amdgcn.vgpr<0>) ins(!amdgcn.sgpr<[0 : 2]>, !amdgcn.vgpr<3>) mods(i32) -> !amdgcn.read_token<flat>
 // CHECK:   HAZARD STATE AFTER: {
 // CHECK:     active = []
@@ -133,9 +125,8 @@ func.func @cdna3_store_write_data_hazard_detected(%arg0: !amdgcn.vgpr<0>, %arg1:
   %voff_st = amdgcn.alloca : !amdgcn.vgpr<2>
   %1 = amdgcn.global_store_dword data %arg0 addr %0 offset d(%voff_st) + c(%c0_i32_mig2) : ins(!amdgcn.vgpr<0>, !amdgcn.sgpr<[0 : 2]>, !amdgcn.vgpr<2>) mods(i32) -> !amdgcn.write_token<flat>
   %2 = amdgcn.alloca : !amdgcn.vgpr<0>
-  %3 = amdgcn.make_register_range %2 : !amdgcn.vgpr<0>
   %voff_ld = amdgcn.alloca : !amdgcn.vgpr<3>
-  %token = amdgcn.global_load_dword dest %3 addr %0 offset d(%voff_ld) + c(%c0_i32_mig2) : outs(!amdgcn.vgpr<0>) ins(!amdgcn.sgpr<[0 : 2]>, !amdgcn.vgpr<3>) mods(i32) -> !amdgcn.read_token<flat>
+  %token = amdgcn.global_load_dword dest %2 addr %0 offset d(%voff_ld) + c(%c0_i32_mig2) : outs(!amdgcn.vgpr<0>) ins(!amdgcn.sgpr<[0 : 2]>, !amdgcn.vgpr<3>) mods(i32) -> !amdgcn.read_token<flat>
   return
 }
 

--- a/test/Dialect/AMDGCN/Analysis/range-constraints.mlir
+++ b/test/Dialect/AMDGCN/Analysis/range-constraints.mlir
@@ -87,8 +87,6 @@ amdgcn.module @range_tests target = <gfx942> {
 // CHECK:  results: [2 = `%{{.*}}`]
 // CHECK:  Operation: `%{{.*}} = amdgcn.make_register_range %{{.*}}, %{{.*}}, %{{.*}} : !amdgcn.vgpr<?>, !amdgcn.vgpr<?>, !amdgcn.vgpr<?>`
 // CHECK:  results: [3 = `%{{.*}}`]
-// CHECK:  Operation: `%{{.*}} = amdgcn.make_register_range %{{.*}} : !amdgcn.vgpr<?>`
-// CHECK:  results: [4 = `%{{.*}}`]
 // CHECK:  Symbol: subset_range
 // CHECK:  Range constraints:
 // CHECK:    Constraint 0: range_constraint<alignment = 4, allocations = [0 = `%{{.*}}`, 1 = `%{{.*}}`, 2 = `%{{.*}}`]>
@@ -101,9 +99,8 @@ amdgcn.module @range_tests target = <gfx942> {
     test_inst outs %1 : (!amdgcn.vgpr<?>) -> ()
     test_inst outs %2 : (!amdgcn.vgpr<?>) -> ()
     %6 = make_register_range %0, %1, %2 : !amdgcn.vgpr<?>, !amdgcn.vgpr<?>, !amdgcn.vgpr<?>
-    %7 = make_register_range %1 : !amdgcn.vgpr<?>
     test_inst ins %6 : (!amdgcn.vgpr<[? : ? + 3]>) -> ()
-    test_inst ins %7 : (!amdgcn.vgpr<?>) -> ()
+    test_inst ins %1 : (!amdgcn.vgpr<?>) -> ()
     end_kernel
   }
 }

--- a/test/Dialect/AMDGCN/Analysis/wait-analysis.mlir
+++ b/test/Dialect/AMDGCN/Analysis/wait-analysis.mlir
@@ -27,9 +27,8 @@ func.func @test_duplicated_waits() {
   %1 = amdgcn.alloca : !amdgcn.vgpr
   %2 = amdgcn.make_register_range %0, %1 : !amdgcn.vgpr, !amdgcn.vgpr
   %3 = amdgcn.alloca : !amdgcn.vgpr
-  %4 = amdgcn.make_register_range %3 : !amdgcn.vgpr
   %c0_i32_mig1 = arith.constant 0 : i32
-  %result, %token = amdgcn.global_load_dword dest %4 addr %2 offset c(%c0_i32_mig1) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
+  %result, %token = amdgcn.global_load_dword dest %3 addr %2 offset c(%c0_i32_mig1) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
   amdgcn.wait deps %token : !amdgcn.read_token<flat>
   // Wait again on the same token, so the second wait is redundant.
   amdgcn.wait deps %token : !amdgcn.read_token<flat>

--- a/test/Dialect/AMDGCN/Transforms/amdgcn-nop-insertion.mlir
+++ b/test/Dialect/AMDGCN/Transforms/amdgcn-nop-insertion.mlir
@@ -54,10 +54,9 @@ amdgcn.module @test_case10_valu_sgpr_vmem target = #amdgcn.target<gfx942> {
 
     // VMEM instruction (global_load) that reads from the SGPR written by VALU.
     // This should trigger case 10 (requires 5 NOPs).
-    %dst_range = amdgcn.make_register_range %result0 : !amdgcn.vgpr<1>
     %voff = amdgcn.alloca : !amdgcn.vgpr<2>
     %c0_i32_mig1 = arith.constant 0 : i32
-    %tok_load = amdgcn.global_load_dword dest %dst_range addr %sgpr_carry offset d(%voff) + c(%c0_i32_mig1) : outs(!amdgcn.vgpr<1>) ins(!amdgcn.sgpr<[0 : 2]>, !amdgcn.vgpr<2>) mods(i32) -> !amdgcn.read_token<flat>
+    %tok_load = amdgcn.global_load_dword dest %result0 addr %sgpr_carry offset d(%voff) + c(%c0_i32_mig1) : outs(!amdgcn.vgpr<1>) ins(!amdgcn.sgpr<[0 : 2]>, !amdgcn.vgpr<2>) mods(i32) -> !amdgcn.read_token<flat>
 
     amdgcn.end_kernel
   }
@@ -162,10 +161,9 @@ amdgcn.module @test_case10_no_overlap_sgpr target = #amdgcn.target<gfx942> {
     // VMEM instruction reads from different SGPRs (no overlap) - should NOT trigger case 10
     // Reading from SGPRs 0-1, but VALU wrote to SGPR 10
     %addr_range = amdgcn.make_register_range %addr0, %addr1 : !amdgcn.sgpr<0>, !amdgcn.sgpr<1>
-    %dst_range = amdgcn.make_register_range %result0 : !amdgcn.vgpr<1>
     %voff = amdgcn.alloca : !amdgcn.vgpr<2>
     %c0_i32_mig2 = arith.constant 0 : i32
-    %tok_load = amdgcn.global_load_dword dest %dst_range addr %addr_range offset d(%voff) + c(%c0_i32_mig2) : outs(!amdgcn.vgpr<1>) ins(!amdgcn.sgpr<[0 : 2]>, !amdgcn.vgpr<2>) mods(i32) -> !amdgcn.read_token<flat>
+    %tok_load = amdgcn.global_load_dword dest %result0 addr %addr_range offset d(%voff) + c(%c0_i32_mig2) : outs(!amdgcn.vgpr<1>) ins(!amdgcn.sgpr<[0 : 2]>, !amdgcn.vgpr<2>) mods(i32) -> !amdgcn.read_token<flat>
 
     amdgcn.end_kernel
   }

--- a/test/Dialect/AMDGCN/Transforms/convert-waits.mlir
+++ b/test/Dialect/AMDGCN/Transforms/convert-waits.mlir
@@ -9,9 +9,8 @@ func.func @test_duplicated_waits() {
   %1 = amdgcn.alloca : !amdgcn.vgpr
   %2 = amdgcn.make_register_range %0, %1 : !amdgcn.vgpr, !amdgcn.vgpr
   %3 = amdgcn.alloca : !amdgcn.vgpr
-  %4 = amdgcn.make_register_range %3 : !amdgcn.vgpr
   %c0_i32_mig1 = arith.constant 0 : i32
-  %result, %token = amdgcn.global_load_dword dest %4 addr %2 offset c(%c0_i32_mig1) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
+  %result, %token = amdgcn.global_load_dword dest %3 addr %2 offset c(%c0_i32_mig1) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
   amdgcn.wait deps %token : !amdgcn.read_token<flat>
   amdgcn.wait deps %token : !amdgcn.read_token<flat>
   %5 = amdgcn.global_store_dword data %result addr %2 offset c(%c0_i32_mig1) : ins(!amdgcn.vgpr, !amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.write_token<flat>

--- a/test/Dialect/AMDGCN/Transforms/ll-sched.mlir
+++ b/test/Dialect/AMDGCN/Transforms/ll-sched.mlir
@@ -291,14 +291,12 @@ amdgcn.module @test target = #amdgcn.target<gfx942> {
     %dd3 = amdgcn.alloca : !v
     %dst = amdgcn.make_register_range %dd0, %dd1, %dd2, %dd3 : !v, !v, !v, !v
     %off = amdgcn.alloca : !v
-    %dr0 = amdgcn.make_register_range %data0 : !v
-    %dr1 = amdgcn.make_register_range %data1 : !v
     %c0_i32_mig6 = arith.constant 0 : i32
-    %wt0 = amdgcn.global_store_dword data %dr0 addr %addr offset c(%c0_i32_mig6) : ins(!v, !sx2) mods(i32) -> !amdgcn.write_token<flat>
+    %wt0 = amdgcn.global_store_dword data %data0 addr %addr offset c(%c0_i32_mig6) : ins(!v, !sx2) mods(i32) -> !amdgcn.write_token<flat>
     %c0_i32_mig7 = arith.constant 0 : i32
     %rr0, %rt0 = amdgcn.global_load_dwordx4 dest %dst addr %addr offset d(%off) + c(%c0_i32_mig7) : outs(!vx4) ins(!sx2, !v) mods(i32) -> !amdgcn.read_token<flat>
     %c0_i32_mig8 = arith.constant 0 : i32
-    %wt1 = amdgcn.global_store_dword data %dr1 addr %addr offset c(%c0_i32_mig8) : ins(!v, !sx2) mods(i32) -> !amdgcn.write_token<flat>
+    %wt1 = amdgcn.global_store_dword data %data1 addr %addr offset c(%c0_i32_mig8) : ins(!v, !sx2) mods(i32) -> !amdgcn.write_token<flat>
     amdgcn.end_kernel
   }
 

--- a/test/Dialect/AMDGCN/cdna3-ops.mlir
+++ b/test/Dialect/AMDGCN/cdna3-ops.mlir
@@ -103,15 +103,13 @@ func.func @test_mfma_inst_mod_partial(
 func.func @test_ds_read_b32(%addr: !amdgcn.vgpr, %d: !amdgcn.vgpr) -> !amdgcn.vgpr {
   %offset = arith.constant 0 : i32
   %result, %tok = amdgcn.ds_read_b32 dest %d addr %addr offset c(%offset) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
-  %0 = amdgcn.split_register_range %result : !amdgcn.vgpr
-  return %0 : !amdgcn.vgpr
+  return %result : !amdgcn.vgpr
 }
 
 func.func @test_ds_read_b32_with_offset(%addr: !amdgcn.vgpr, %dst1: !amdgcn.vgpr) -> !amdgcn.vgpr {
   %offset = arith.constant 4 : i32
   %result, %tok = amdgcn.ds_read_b32 dest %dst1 addr %addr offset c(%offset) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
-  %0 = amdgcn.split_register_range %result : !amdgcn.vgpr
-  return %0 : !amdgcn.vgpr
+  return %result : !amdgcn.vgpr
 }
 
 func.func @test_ds_read_b64(%addr: !amdgcn.vgpr, %dst2: !amdgcn.vgpr<[? + 2]>) -> (!amdgcn.vgpr, !amdgcn.vgpr) {
@@ -143,32 +141,28 @@ func.func @test_ds_bpermute_b32(%addr: !amdgcn.vgpr, %data: !amdgcn.vgpr, %dst: 
   %offset = arith.constant 0 : i32
   %result, %tok = amdgcn.ds_bpermute_b32 outs(%dst) ins(%addr, %data) args(%offset)
       : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr, !amdgcn.vgpr) args(i32) -> !amdgcn.read_token<shared>
-  %0 = amdgcn.split_register_range %result : !amdgcn.vgpr
-  return %0 : !amdgcn.vgpr
+  return %result : !amdgcn.vgpr
 }
 
 func.func @test_ds_bpermute_b32_with_offset(%addr: !amdgcn.vgpr, %data: !amdgcn.vgpr, %dst: !amdgcn.vgpr) -> !amdgcn.vgpr {
   %offset = arith.constant 4 : i32
   %result, %tok = amdgcn.ds_bpermute_b32 outs(%dst) ins(%addr, %data) args(%offset)
       : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr, !amdgcn.vgpr) args(i32) -> !amdgcn.read_token<shared>
-  %0 = amdgcn.split_register_range %result : !amdgcn.vgpr
-  return %0 : !amdgcn.vgpr
+  return %result : !amdgcn.vgpr
 }
 
 func.func @test_ds_permute_b32(%addr: !amdgcn.vgpr, %data: !amdgcn.vgpr, %dst: !amdgcn.vgpr) -> !amdgcn.vgpr {
   %offset = arith.constant 0 : i32
   %result, %tok = amdgcn.ds_permute_b32 outs(%dst) ins(%addr, %data) args(%offset)
       : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr, !amdgcn.vgpr) args(i32) -> !amdgcn.read_token<shared>
-  %0 = amdgcn.split_register_range %result : !amdgcn.vgpr
-  return %0 : !amdgcn.vgpr
+  return %result : !amdgcn.vgpr
 }
 
 func.func @test_ds_permute_b32_with_offset(%addr: !amdgcn.vgpr, %data: !amdgcn.vgpr, %dst: !amdgcn.vgpr) -> !amdgcn.vgpr {
   %offset = arith.constant 4 : i32
   %result, %tok = amdgcn.ds_permute_b32 outs(%dst) ins(%addr, %data) args(%offset)
       : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr, !amdgcn.vgpr) args(i32) -> !amdgcn.read_token<shared>
-  %0 = amdgcn.split_register_range %result : !amdgcn.vgpr
-  return %0 : !amdgcn.vgpr
+  return %result : !amdgcn.vgpr
 }
 
 //===----------------------------------------------------------------------===//
@@ -176,16 +170,14 @@ func.func @test_ds_permute_b32_with_offset(%addr: !amdgcn.vgpr, %data: !amdgcn.v
 //===----------------------------------------------------------------------===//
 
 func.func @test_ds_write_b32(%addr: !amdgcn.vgpr, %val: !amdgcn.vgpr) {
-  %val_range = amdgcn.make_register_range %val : !amdgcn.vgpr
   %offset = arith.constant 0 : i32
-  %tok = amdgcn.ds_write_b32 data %val_range addr %addr offset c(%offset) : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
+  %tok = amdgcn.ds_write_b32 data %val addr %addr offset c(%offset) : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
   return
 }
 
 func.func @test_ds_write_b32_with_offset(%addr: !amdgcn.vgpr, %val: !amdgcn.vgpr) {
-  %val_range = amdgcn.make_register_range %val : !amdgcn.vgpr
   %offset = arith.constant 8 : i32
-  %tok = amdgcn.ds_write_b32 data %val_range addr %addr offset c(%offset) : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
+  %tok = amdgcn.ds_write_b32 data %val addr %addr offset c(%offset) : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
   return
 }
 
@@ -225,8 +217,7 @@ func.func @test_global_load_dword(%addr_lo: !amdgcn.vgpr, %addr_hi: !amdgcn.vgpr
   %addr_range = amdgcn.make_register_range %addr_lo, %addr_hi : !amdgcn.vgpr, !amdgcn.vgpr
   %c0_i32_mig1 = arith.constant 0 : i32
   %result, %tok = amdgcn.global_load_dword dest %dst addr %addr_range offset c(%c0_i32_mig1) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
-  %0 = amdgcn.split_register_range %result : !amdgcn.vgpr
-  return %0 : !amdgcn.vgpr
+  return %result : !amdgcn.vgpr
 }
 
 func.func @test_global_load_dwordx2(%addr_lo: !amdgcn.vgpr, %addr_hi: !amdgcn.vgpr, %dst: !amdgcn.vgpr<[? + 2]>) -> (!amdgcn.vgpr, !amdgcn.vgpr) {
@@ -259,9 +250,8 @@ func.func @test_global_load_dwordx4(%addr_lo: !amdgcn.vgpr, %addr_hi: !amdgcn.vg
 
 func.func @test_global_store_dword(%addr_lo: !amdgcn.vgpr, %addr_hi: !amdgcn.vgpr, %val: !amdgcn.vgpr) {
   %addr_range = amdgcn.make_register_range %addr_lo, %addr_hi : !amdgcn.vgpr, !amdgcn.vgpr
-  %val_range = amdgcn.make_register_range %val : !amdgcn.vgpr
   %c0_i32_mig1 = arith.constant 0 : i32
-  %tok = amdgcn.global_store_dword data %val_range addr %addr_range offset c(%c0_i32_mig1) : ins(!amdgcn.vgpr, !amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.write_token<flat>
+  %tok = amdgcn.global_store_dword data %val addr %addr_range offset c(%c0_i32_mig1) : ins(!amdgcn.vgpr, !amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.write_token<flat>
   return
 }
 
@@ -281,8 +271,7 @@ func.func @test_smem_load_dword(%addr_lo: !amdgcn.sgpr, %addr_hi: !amdgcn.sgpr, 
   %addr_range = amdgcn.make_register_range %addr_lo, %addr_hi : !amdgcn.sgpr, !amdgcn.sgpr
   %c0_i32_mig1 = arith.constant 0 : i32
   %result, %tok = amdgcn.s_load_dword dest %dst addr %addr_range offset c(%c0_i32_mig1) : outs(!amdgcn.sgpr) ins(!amdgcn.sgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<constant>
-  %0 = amdgcn.split_register_range %result : !amdgcn.sgpr
-  return %0 : !amdgcn.sgpr
+  return %result : !amdgcn.sgpr
 }
 
 //===----------------------------------------------------------------------===//
@@ -291,9 +280,8 @@ func.func @test_smem_load_dword(%addr_lo: !amdgcn.sgpr, %addr_hi: !amdgcn.sgpr, 
 
 func.func @test_smem_store_dword(%addr_lo: !amdgcn.sgpr, %addr_hi: !amdgcn.sgpr, %val: !amdgcn.sgpr) {
   %addr_range = amdgcn.make_register_range %addr_lo, %addr_hi : !amdgcn.sgpr, !amdgcn.sgpr
-  %val_range = amdgcn.make_register_range %val : !amdgcn.sgpr
   %c0_i32_mig1 = arith.constant 0 : i32
-  %tok = amdgcn.s_store_dword data %val_range addr %addr_range offset c(%c0_i32_mig1) : ins(!amdgcn.sgpr, !amdgcn.sgpr<[? + 2]>) mods(i32) -> !amdgcn.write_token<constant>
+  %tok = amdgcn.s_store_dword data %val addr %addr_range offset c(%c0_i32_mig1) : ins(!amdgcn.sgpr, !amdgcn.sgpr<[? + 2]>) mods(i32) -> !amdgcn.write_token<constant>
   return
 }
 

--- a/test/Dialect/AMDGCN/effects.mlir
+++ b/test/Dialect/AMDGCN/effects.mlir
@@ -166,15 +166,14 @@ amdgcn.module @mod target = <gfx942> {
 // CHECK-NEXT:    v_mov_b32 outs(%[[R8]]) ins(%{{.*}}) : outs(!amdgcn.vgpr<11>) ins(!amdgcn.sgpr<3>)
 // CHECK-NEXT:    %[[R11:.*]] = make_register_range %[[R7]], %[[R8]] : !amdgcn.vgpr<10>, !amdgcn.vgpr<11>
 // CHECK-NEXT:    %[[R12:.*]] = alloca : !amdgcn.vgpr<12>
-// CHECK-NEXT:    %[[R13:.*]] = make_register_range %[[R12]] : !amdgcn.vgpr<12>
-// CHECK-NEXT:    %{{.*}} = global_load_dword dest %[[R13]] addr %[[R11]] offset c(%{{.*}}) : outs(!amdgcn.vgpr<12>) ins(!amdgcn.vgpr<[10 : 12]>) mods(i32) -> !amdgcn.read_token<flat>
+// CHECK-NEXT:    %{{.*}} = global_load_dword dest %[[R12]] addr %[[R11]] offset c(%{{.*}}) : outs(!amdgcn.vgpr<12>) ins(!amdgcn.vgpr<[10 : 12]>) mods(i32) -> !amdgcn.read_token<flat>
 // CHECK-NEXT:    %{{.*}} = s_load_dwordx2 dest %{{.*}} addr %{{.*}} offset c(%{{.*}}) : outs(!amdgcn.sgpr<[2 : 4]>) ins(!amdgcn.sgpr<[0 : 2]>) mods(i32) -> !amdgcn.read_token<constant>
 // CHECK-NEXT:    s_waitcnt vmcnt = 0
 //
 // We want to make sure R7, R8 and R11 are not reused after CSE: a proper liveness analysis is needed.
 // CHECK-NEXT:    v_mov_b32 outs(%[[R7]]) ins(%{{.*}}) : outs(!amdgcn.vgpr<10>) ins(!amdgcn.sgpr<2>)
 // CHECK-NEXT:    v_mov_b32 outs(%[[R8]]) ins(%{{.*}}) : outs(!amdgcn.vgpr<11>) ins(!amdgcn.sgpr<3>)
-// CHECK-NEXT:    %{{.*}} = global_store_dword data %[[R13]] addr %[[R11]] offset c(%{{.*}}) : ins(!amdgcn.vgpr<12>, !amdgcn.vgpr<[10 : 12]>) mods(i32) -> !amdgcn.write_token<flat>
+// CHECK-NEXT:    %{{.*}} = global_store_dword data %[[R12]] addr %[[R11]] offset c(%{{.*}}) : ins(!amdgcn.vgpr<12>, !amdgcn.vgpr<[10 : 12]>) mods(i32) -> !amdgcn.write_token<flat>
 // CHECK-NEXT:    end_kernel
   kernel @gpu_copy_kernel_unchecked {
     %0 = alloca : !amdgcn.sgpr<0>
@@ -192,8 +191,7 @@ amdgcn.module @mod target = <gfx942> {
     amdgcn.v_mov_b32 outs(%8) ins(%4) : outs(!amdgcn.vgpr<11>) ins(!amdgcn.sgpr<3>)
     %11 = make_register_range %7, %8 : !amdgcn.vgpr<10>, !amdgcn.vgpr<11>
     %12 = alloca : !amdgcn.vgpr<12>
-    %13 = make_register_range %12 : !amdgcn.vgpr<12>
-    %t2 = amdgcn.global_load_dword dest %13 addr %11 offset c(%c0_i32_mig1) : outs(!amdgcn.vgpr<12>) ins(!amdgcn.vgpr<[10 : 12]>) mods(i32) -> !amdgcn.read_token<flat>
+    %t2 = amdgcn.global_load_dword dest %12 addr %11 offset c(%c0_i32_mig1) : outs(!amdgcn.vgpr<12>) ins(!amdgcn.vgpr<[10 : 12]>) mods(i32) -> !amdgcn.read_token<flat>
     %15 = alloca : !amdgcn.sgpr<0>
     %16 = alloca : !amdgcn.sgpr<1>
     %17 = make_register_range %15, %16 : !amdgcn.sgpr<0>, !amdgcn.sgpr<1>
@@ -207,7 +205,7 @@ amdgcn.module @mod target = <gfx942> {
     amdgcn.v_mov_b32 outs(%22) ins(%18) : outs(!amdgcn.vgpr<10>) ins(!amdgcn.sgpr<2>)
     amdgcn.v_mov_b32 outs(%23) ins(%19) : outs(!amdgcn.vgpr<11>) ins(!amdgcn.sgpr<3>)
     %26 = make_register_range %22, %23 : !amdgcn.vgpr<10>, !amdgcn.vgpr<11>
-    %t4 = amdgcn.global_store_dword data %13 addr %26 offset c(%c0_i32_mig1) : ins(!amdgcn.vgpr<12>, !amdgcn.vgpr<[10 : 12]>) mods(i32) -> !amdgcn.write_token<flat>
+    %t4 = amdgcn.global_store_dword data %12 addr %26 offset c(%c0_i32_mig1) : ins(!amdgcn.vgpr<12>, !amdgcn.vgpr<[10 : 12]>) mods(i32) -> !amdgcn.write_token<flat>
     end_kernel
   }
 }

--- a/test/Dialect/AMDGCN/invalid.mlir
+++ b/test/Dialect/AMDGCN/invalid.mlir
@@ -109,3 +109,21 @@ func.func @offset_with_invalid_aligment() {
   %2 = amdgcn.alloc_lds 32 alignment 8 offset 33
   return
 }
+
+// -----
+
+func.func @split_single_register() {
+  %0 = amdgcn.alloca : !amdgcn.vgpr
+  // expected-error@+1 {{cannot split a single register}}
+  %1 = amdgcn.split_register_range %0 : !amdgcn.vgpr
+  return
+}
+
+// -----
+
+func.func @make_range_single_register() {
+  %0 = amdgcn.alloca : !amdgcn.vgpr
+  // expected-error@+1 {{expected at least two operands}}
+  %1 = amdgcn.make_register_range %0 : !amdgcn.vgpr
+  return
+}

--- a/test/Dialect/AMDGCN/ops.mlir
+++ b/test/Dialect/AMDGCN/ops.mlir
@@ -13,11 +13,6 @@ func.func @test_make_register_range() {
   return
 }
 
-func.func @test_make_register_range_single() {
-  %0 = amdgcn.alloca : !amdgcn.vgpr
-  %1 = amdgcn.make_register_range %0 : !amdgcn.vgpr
-  return
-}
 
 amdgcn.module @test_module target = #amdgcn.target<gfx940> {
   amdgcn.kernel @test_kernel {

--- a/test/Transforms/scf-pipeline-epilogue-parallel.mlir
+++ b/test/Transforms/scf-pipeline-epilogue-parallel.mlir
@@ -19,8 +19,7 @@
 // CHECK:         %[[K_D:.*]], %[[K_T:.*]] = amdgcn.global_load_dword
 // CHECK:         amdgcn.wait deps %[[A_T]]
 // CHECK:         %[[K_C:.*]] = amdgcn.test_inst outs %{{.*}} ins %[[A_D]]
-// CHECK:         amdgcn.make_register_range %[[A_C]]
-// CHECK:         amdgcn.global_store_dword
+// CHECK:         amdgcn.global_store_dword data %[[A_C]]
 // CHECK:         scf.yield %[[K_T]], %[[K_D]], %[[K_C]]
 
 // -- Epilogue section 1 --
@@ -29,13 +28,11 @@
 // CHECK:       %[[E1_C:.*]] = amdgcn.test_inst outs %{{.*}} ins %[[KER]]#1
 
 // Stage 2 ops for iter 4: MUST use %[[KER]]#2, NOT %[[E1_C]]
-// CHECK:       amdgcn.make_register_range %[[KER]]#2
-// CHECK:       amdgcn.global_store_dword
+// CHECK:       amdgcn.global_store_dword data %[[KER]]#2
 
 // -- Epilogue section 2 --
 // Stage 2 ops for iter 5: uses the freshly computed value from section 1
-// CHECK:       amdgcn.make_register_range %[[E1_C]]
-// CHECK:       amdgcn.global_store_dword
+// CHECK:       amdgcn.global_store_dword data %[[E1_C]]
 // CHECK:       return
 
 func.func @epilogue_parallel_lanes(%addr: !amdgcn.vgpr<[? + 2]>) {
@@ -49,8 +46,7 @@ func.func @epilogue_parallel_lanes(%addr: !amdgcn.vgpr<[? + 2]>) {
     %data, %rtok = amdgcn.global_load_dword dest %dest addr %addr offset c(%c0_i32_mig1) {sched.stage = 0 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
     amdgcn.wait deps %rtok {sched.stage = 1 : i32} : !amdgcn.read_token<flat>
     %computed = amdgcn.test_inst outs %s_compute ins %data {sched.stage = 1 : i32} : (!amdgcn.vgpr, !amdgcn.vgpr) -> !amdgcn.vgpr
-    %dr = amdgcn.make_register_range %computed {sched.stage = 2 : i32} : !amdgcn.vgpr
-    %wtok = amdgcn.global_store_dword data %dr addr %addr offset c(%c0_i32_mig1) {sched.stage = 2 : i32} : ins(!amdgcn.vgpr, !amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.write_token<flat>
+    %wtok = amdgcn.global_store_dword data %computed addr %addr offset c(%c0_i32_mig1) {sched.stage = 2 : i32} : ins(!amdgcn.vgpr, !amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.write_token<flat>
   }
   return
 }

--- a/test/Transforms/scf-pipeline-iter-args.mlir
+++ b/test/Transforms/scf-pipeline-iter-args.mlir
@@ -116,7 +116,6 @@ func.func @three_stage_with_iter_args() {
 // CHECK:       %[[EPI:.*]] = amdgcn.test_inst{{.*}} ins %[[KER]]
 
 // Original loop result replaced with epilogue result
-// CHECK:       amdgcn.make_register_range %[[EPI]]
 // CHECK:       return
 
 func.func @no_cross_stage_with_used_result() {
@@ -132,6 +131,5 @@ func.func @no_cross_stage_with_used_result() {
     %new_acc = amdgcn.test_inst outs %s1 ins %acc {sched.stage = 1 : i32} : (!amdgcn.vgpr, !amdgcn.vgpr) -> !amdgcn.vgpr
     scf.yield %new_acc : !amdgcn.vgpr
   }
-  %dr = amdgcn.make_register_range %r : !amdgcn.vgpr
   return
 }

--- a/test/Transforms/scf-pipeline-three-stage.mlir
+++ b/test/Transforms/scf-pipeline-three-stage.mlir
@@ -37,22 +37,19 @@
 // CHECK:         %[[K_D:.*]], %[[K_T:.*]] = amdgcn.global_load_dword
 // CHECK:         amdgcn.wait deps %[[A_T]]
 // CHECK:         %[[K_C:.*]] = amdgcn.test_inst outs %{{.*}} ins %[[A_D]]
-// CHECK:         amdgcn.make_register_range %[[A_C]]
-// CHECK:         amdgcn.global_store_dword
+// CHECK:         amdgcn.global_store_dword data %[[A_C]]
 // CHECK:         scf.yield %[[K_T]], %[[K_D]], %[[K_C]]
 
-// Epilogue section 1: wait+compute(iter 5) + make_range+store(iter 4)
+// Epilogue section 1: wait+compute(iter 5) + store(iter 4)
 // wait+compute uses kernel results #0, #1 (iter 5's stage 0 values).
-// make_range+store uses kernel result #2 (iter 4's stage 1 value).
+// store uses kernel result #2 (iter 4's stage 1 value).
 // CHECK:       amdgcn.wait deps %[[KER]]#0
 // CHECK:       %[[E1_C:.*]] = amdgcn.test_inst outs %{{.*}} ins %[[KER]]#1
-// CHECK:       amdgcn.make_register_range %[[KER]]#2
-// CHECK:       amdgcn.global_store_dword
+// CHECK:       amdgcn.global_store_dword data %[[KER]]#2
 
-// Epilogue section 2: make_range+store(iter 5)
+// Epilogue section 2: store(iter 5)
 // Uses the value computed in section 1 for iter 5.
-// CHECK:       amdgcn.make_register_range %[[E1_C]]
-// CHECK:       amdgcn.global_store_dword
+// CHECK:       amdgcn.global_store_dword data %[[E1_C]]
 // CHECK:       return
 
 func.func @three_stage_load_compute_store(%addr: !amdgcn.vgpr<[? + 2]>) {
@@ -66,8 +63,7 @@ func.func @three_stage_load_compute_store(%addr: !amdgcn.vgpr<[? + 2]>) {
     %data, %rtok = amdgcn.global_load_dword dest %dest addr %addr offset c(%c0_i32_mig1) {sched.stage = 0 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
     amdgcn.wait deps %rtok {sched.stage = 1 : i32} : !amdgcn.read_token<flat>
     %computed = amdgcn.test_inst outs %s_compute ins %data {sched.stage = 1 : i32} : (!amdgcn.vgpr, !amdgcn.vgpr) -> !amdgcn.vgpr
-    %dr = amdgcn.make_register_range %computed {sched.stage = 2 : i32} : !amdgcn.vgpr
-    %wtok = amdgcn.global_store_dword data %dr addr %addr offset c(%c0_i32_mig1) {sched.stage = 2 : i32} : ins(!amdgcn.vgpr, !amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.write_token<flat>
+    %wtok = amdgcn.global_store_dword data %computed addr %addr offset c(%c0_i32_mig1) {sched.stage = 2 : i32} : ins(!amdgcn.vgpr, !amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.write_token<flat>
   }
   return
 }


### PR DESCRIPTION
Enforce that make_register_range requires at least two operands and split_register_range rejects single registers. Update all tests to remove single-register make/split patterns and add negative tests.