### PR TITLE
[interfaces] Add getCompositeType/getSplitType to RegisterTypeInterface

### DIFF
--- a/include/aster/Dialect/AMDGCN/IR/AMDGCNTypes.td
+++ b/include/aster/Dialect/AMDGCN/IR/AMDGCNTypes.td
@@ -63,6 +63,12 @@ def GPRegTrait : NativeTypeTrait<"GPRegTrait"> {
         return props | RegisterProps::IsComposite;
       return props | RegisterProps::AcceptsComposite;
     }
+    RegisterTypeInterface getCompositeType(TypeRange types,
+        std::optional<int16_t> alignment,
+        llvm::function_ref<InFlightDiagnostic()> emitError) const;
+    LogicalResult getSplitType(
+        SmallVectorImpl<RegisterTypeInterface> &regs,
+        llvm::function_ref<InFlightDiagnostic()> emitError) const;
 
     //===------------------------------------------------------------------===//
     // ResourceTypeInterface
@@ -139,6 +145,12 @@ def SpecialRegTrait : NativeTypeTrait<"SpecialRegTrait"> {
              RegisterProps::AcceptsUnallocatedSemantics |
              RegisterProps::AcceptsAllocatedSemantics;
     }
+    RegisterTypeInterface getCompositeType(TypeRange types,
+        std::optional<int16_t> alignment,
+        llvm::function_ref<InFlightDiagnostic()> emitError) const;
+    LogicalResult getSplitType(
+        SmallVectorImpl<RegisterTypeInterface> &regs,
+        llvm::function_ref<InFlightDiagnostic()> emitError) const;
 
     //===------------------------------------------------------------------===//
     // AMDGCNRegisterTypeInterface

--- a/include/aster/Interfaces/RegisterType.td
+++ b/include/aster/Interfaces/RegisterType.td
@@ -51,6 +51,24 @@ def RegisterTypeInterface : TypeInterface<"RegisterTypeInterface", [
         Returns the properties of the register type.
       }],
       "::mlir::aster::RegisterProps", "getProps"
+    >,
+    InterfaceMethod<[{
+        Returns the composite register type formed by combining this register
+        with `types`. `alignment` controls the range alignment (nullopt means
+        natural). Returns nullptr on failure.
+      }],
+      "::mlir::aster::RegisterTypeInterface", "getCompositeType",
+      (ins "::mlir::TypeRange":$types,
+           "std::optional<int16_t>":$alignment,
+           "::llvm::function_ref<::mlir::InFlightDiagnostic()>":$emitError)
+    >,
+    InterfaceMethod<[{
+        Splits this composite register into its constituent single-register
+        parts. Returns failure if not splittable.
+      }],
+      "::mlir::LogicalResult", "getSplitType",
+      (ins "::llvm::SmallVectorImpl<::mlir::aster::RegisterTypeInterface> &":$regs,
+           "::llvm::function_ref<::mlir::InFlightDiagnostic()>":$emitError)
     >
   ];
   let extraTraitClassDeclaration = [{

--- a/lib/Dialect/AMDGCN/IR/AMDGCN.cpp
+++ b/lib/Dialect/AMDGCN/IR/AMDGCN.cpp
@@ -346,80 +346,20 @@ LogicalResult MakeRegisterRangeOp::inferReturnTypes(
     return failure();
   }
 
-  // Fail if any of the types is a register range.
-  if (llvm::any_of(TypeRange(operands), [](Type type) {
-        return cast<RegisterTypeInterface>(type).isRegisterRange();
-      })) {
-    if (location)
-      mlir::emitError(*location) << "expected all types to be single registers";
+  RegisterTypeInterface fTy =
+      cast<RegisterTypeInterface>(operands[0].getType());
+
+  auto emitErrorLambda = [&]() { return mlir::emitError(*location); };
+  llvm::function_ref<InFlightDiagnostic()> emitError = nullptr;
+  if (location)
+    emitError = emitErrorLambda;
+
+  TypeRange remaining = TypeRange(operands).drop_front();
+  RegisterTypeInterface result =
+      fTy.getCompositeType(remaining, std::nullopt, emitError);
+  if (!result)
     return failure();
-  }
-
-  // Fail if the types are not all of the same kind.
-  auto fTy = cast<AMDGCNRegisterTypeInterface>(operands[0].getType());
-  if (llvm::any_of(TypeRange(operands), [&](Type type) {
-        auto oTy = cast<AMDGCNRegisterTypeInterface>(type);
-        return fTy.getRegisterKind() != oTy.getRegisterKind() ||
-               fTy.getSemantics() != oTy.getSemantics();
-      })) {
-    if (location) {
-      mlir::emitError(*location)
-          << "expected all operand types to be of the same kind";
-    }
-    return failure();
-  }
-
-  // Create the appropriate register range type.
-  auto makeRange = [&](RegisterRange range) -> Type {
-    switch (getRegisterKind(fTy)) {
-    case RegisterKind::SGPR:
-      return SGPRType::get(context, range);
-    case RegisterKind::VGPR:
-      return VGPRType::get(context, range);
-    case RegisterKind::AGPR:
-      return AGPRType::get(context, range);
-    default:
-      llvm_unreachable("nyi register kind");
-    }
-  };
-
-  if (!fTy.hasAllocatedSemantics()) {
-    inferredReturnTypes.push_back(
-        makeRange(RegisterRange(fTy.getAsRange().begin(), operands.size())));
-    return success();
-  }
-
-  // Collect unique registers and find upper bound.
-  llvm::SmallDenseSet<int> uniqueRegs;
-  int ub = -1;
-
-  for (Type type : TypeRange(operands)) {
-    int reg = cast<AMDGCNRegisterTypeInterface>(type)
-                  .getAsRange()
-                  .begin()
-                  .getRegister();
-    if (!uniqueRegs.insert(reg).second) {
-      // Duplicate register found.
-      if (location)
-        mlir::emitError(*location) << "duplicate register found: " << reg;
-      return failure();
-    }
-    ub = std::max(ub, reg);
-  }
-
-  assert(ub >= 0 && "ub should have been set");
-  // Check for missing registers in the range.
-  int lb = ub - uniqueRegs.size() + 1;
-  for (int regNum = lb; regNum <= ub; ++regNum) {
-    if (!uniqueRegs.contains(regNum)) {
-      // Missing register found.
-      if (location)
-        mlir::emitError(*location) << "missing register in range: " << regNum;
-      return failure();
-    }
-  }
-  inferredReturnTypes.push_back(
-      makeRange(RegisterRange(Register(lb), operands.size())));
+  inferredReturnTypes.push_back(result);
   return success();
 }
 
@@ -451,35 +391,19 @@ LogicalResult SplitRegisterRangeOp::inferReturnTypes(
   }
 
   Type inputType = operands[0].getType();
-  auto rangeType = cast<AMDGCNRegisterTypeInterface>(inputType);
+  RegisterTypeInterface rangeType = cast<RegisterTypeInterface>(inputType);
 
-  // Get the range information.
-  RegisterRange range = rangeType.getAsRange();
-  int size = range.size();
+  auto emitErrorLambda = [&]() { return mlir::emitError(*location); };
+  llvm::function_ref<InFlightDiagnostic()> emitError = nullptr;
+  if (location)
+    emitError = emitErrorLambda;
 
-  if (size <= 1) {
-    if (location)
-      mlir::emitError(*location) << "cannot split a single register";
+  SmallVector<RegisterTypeInterface> regs;
+  if (failed(rangeType.getSplitType(regs, emitError)))
     return failure();
-  }
 
-  // Create a function to make individual register types.
-  auto makeRegister = [&](Register reg) -> Type {
-    return rangeType.cloneRegisterType(reg);
-  };
-
-  // If the range doesn't have allocated semantics, create individual registers.
-  if (!rangeType.hasAllocatedSemantics()) {
-    for (int i = 0; i < size; ++i)
-      inferredReturnTypes.push_back(makeRegister(range.begin()));
-    return success();
-  }
-
-  // Otherwise, create individual registers from the range.
-  int begin = range.begin().getRegister();
-  for (int i = 0; i < size; ++i) {
-    inferredReturnTypes.push_back(makeRegister(Register(begin + i)));
-  }
+  for (RegisterTypeInterface reg : regs)
+    inferredReturnTypes.push_back(reg);
   return success();
 }
 

--- a/lib/Dialect/AMDGCN/IR/AMDGCNTypes.cpp
+++ b/lib/Dialect/AMDGCN/IR/AMDGCNTypes.cpp
@@ -12,11 +12,102 @@
 #include "aster/Dialect/AMDGCN/IR/AMDGCNEnums.h"
 #include "aster/Dialect/AMDGCN/IR/AMDGCNOps.h"
 #include "aster/Interfaces/ResourceInterfaces.h"
+#include <limits>
 #include <optional>
 
 using namespace mlir;
 using namespace mlir::aster;
 using namespace mlir::aster::amdgcn;
+
+//===----------------------------------------------------------------------===//
+// GPRegTrait getCompositeType / getSplitType
+//===----------------------------------------------------------------------===//
+
+template <typename T>
+static RegisterTypeInterface
+getCompositeGPRImpl(T type, TypeRange types, std::optional<int16_t> alignment,
+                    llvm::function_ref<InFlightDiagnostic()> emitError) {
+  RegisterRange range = type.getAsRange();
+  if (range.size() > 1) {
+    if (emitError)
+      emitError() << "register is already composite";
+    return nullptr;
+  }
+
+  RegisterSemantics semantics = range.getSemantics();
+  RegisterKind kind = type.getRegisterKind();
+
+  // Registers must be contiguous and in ascending order (for allocated
+  // semantics). Validate kind, semantics, and size in the same pass.
+  int16_t expected = semantics == RegisterSemantics::Allocated
+                         ? static_cast<int16_t>(range.begin().getRegister() + 1)
+                         : int16_t{-1};
+
+  for (Type t : types) {
+    auto other = dyn_cast<AMDGCNRegisterTypeInterface>(t);
+    if (!other || other.getRegisterKind() != kind ||
+        other.getSemantics() != semantics) {
+      if (emitError)
+        emitError() << "expected register of the same kind and semantics";
+      return nullptr;
+    }
+    if (other.getAsRange().size() != 1) {
+      if (emitError)
+        emitError() << "expected a single register, not a range";
+      return nullptr;
+    }
+    if (semantics == RegisterSemantics::Allocated) {
+      int16_t reg = other.getAsRange().begin().getRegister();
+      if (reg != expected) {
+        if (emitError)
+          emitError() << "expected register " << expected << " but got " << reg;
+        return nullptr;
+      }
+      ++expected;
+    }
+  }
+
+  assert(types.size() <
+             static_cast<size_t>(std::numeric_limits<int16_t>::max()) &&
+         "register count overflows int16_t");
+  int16_t size = static_cast<int16_t>(types.size()) + 1;
+  int16_t align = alignment.value_or(defaultAlignment(size));
+  return T::get(type.getContext(), RegisterRange(range.begin(), size, align));
+}
+
+template <typename T>
+static LogicalResult
+getSplitGPRImpl(T type, SmallVectorImpl<RegisterTypeInterface> &regs,
+                llvm::function_ref<InFlightDiagnostic()> emitError) {
+  RegisterRange range = type.getAsRange();
+  if (range.size() <= 1) {
+    if (emitError)
+      emitError() << "register is not composite";
+    return failure();
+  }
+  for (int i = 0; i < range.size(); ++i)
+    regs.push_back(type.cloneRegisterType(RegisterRange(
+        range.begin().getWithOffset(static_cast<int16_t>(i)), 1)));
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// SpecialRegTrait getCompositeType / getSplitType
+//===----------------------------------------------------------------------===//
+
+static RegisterTypeInterface
+getCompositeSRegImpl(llvm::function_ref<InFlightDiagnostic()> emitError) {
+  if (emitError)
+    emitError() << "special registers cannot form composites";
+  return nullptr;
+}
+
+static LogicalResult
+getSplitSRegImpl(llvm::function_ref<InFlightDiagnostic()> emitError) {
+  if (emitError)
+    emitError() << "special registers cannot be split";
+  return failure();
+}
 
 //===----------------------------------------------------------------------===//
 // RegisterRangeType verification helper
@@ -100,3 +191,57 @@ LogicalResult VGPRType::verify(function_ref<InFlightDiagnostic()> emitError,
 }
 
 Resource *VGPRType::getResource() const { return VGPRResource::get(); }
+
+//===----------------------------------------------------------------------===//
+// GPRegTrait interface method definitions
+//===----------------------------------------------------------------------===//
+
+#define GP_REG_COMPOSITE_SPLIT(TypeName)                                       \
+  RegisterTypeInterface TypeName::getCompositeType(                            \
+      TypeRange types, std::optional<int16_t> alignment,                       \
+      llvm::function_ref<InFlightDiagnostic()> emitError) const {              \
+    return getCompositeGPRImpl(*this, types, alignment, emitError);            \
+  }                                                                            \
+  LogicalResult TypeName::getSplitType(                                        \
+      SmallVectorImpl<RegisterTypeInterface> &regs,                            \
+      llvm::function_ref<InFlightDiagnostic()> emitError) const {              \
+    return getSplitGPRImpl(*this, regs, emitError);                            \
+  }
+
+GP_REG_COMPOSITE_SPLIT(AGPRType)
+GP_REG_COMPOSITE_SPLIT(SGPRType)
+GP_REG_COMPOSITE_SPLIT(VGPRType)
+
+#undef GP_REG_COMPOSITE_SPLIT
+
+//===----------------------------------------------------------------------===//
+// SpecialRegTrait interface method definitions
+//===----------------------------------------------------------------------===//
+
+#define SPECIAL_REG_COMPOSITE_SPLIT(TypeName)                                  \
+  RegisterTypeInterface TypeName::getCompositeType(                            \
+      TypeRange types, std::optional<int16_t> alignment,                       \
+      llvm::function_ref<InFlightDiagnostic()> emitError) const {              \
+    (void)types;                                                               \
+    (void)alignment;                                                           \
+    return getCompositeSRegImpl(emitError);                                    \
+  }                                                                            \
+  LogicalResult TypeName::getSplitType(                                        \
+      SmallVectorImpl<RegisterTypeInterface> &regs,                            \
+      llvm::function_ref<InFlightDiagnostic()> emitError) const {              \
+    (void)regs;                                                                \
+    return getSplitSRegImpl(emitError);                                        \
+  }
+
+SPECIAL_REG_COMPOSITE_SPLIT(VCCType)
+SPECIAL_REG_COMPOSITE_SPLIT(VCCLoType)
+SPECIAL_REG_COMPOSITE_SPLIT(VCCHiType)
+SPECIAL_REG_COMPOSITE_SPLIT(VCCZType)
+SPECIAL_REG_COMPOSITE_SPLIT(EXECType)
+SPECIAL_REG_COMPOSITE_SPLIT(EXECLoType)
+SPECIAL_REG_COMPOSITE_SPLIT(EXECHiType)
+SPECIAL_REG_COMPOSITE_SPLIT(EXECZType)
+SPECIAL_REG_COMPOSITE_SPLIT(M0Type)
+SPECIAL_REG_COMPOSITE_SPLIT(SCCType)
+
+#undef SPECIAL_REG_COMPOSITE_SPLIT

--- a/test/Dialect/AMDGCN/invalid.mlir
+++ b/test/Dialect/AMDGCN/invalid.mlir
@@ -4,7 +4,7 @@ func.func @mixed_relocatable_registers() {
   %0 = amdgcn.alloca : !amdgcn.vgpr<1>
   %1 = amdgcn.alloca : !amdgcn.vgpr
   %2 = amdgcn.alloca : !amdgcn.vgpr
-  // expected-error@+1 {{expected all operand types to be of the same kind}}
+  // expected-error@+1 {{expected register of the same kind and semantics}}
   %3 = amdgcn.make_register_range %0, %1, %2 : !amdgcn.vgpr<1>, !amdgcn.vgpr, !amdgcn.vgpr
   return
 }
@@ -15,7 +15,7 @@ func.func @duplicate_registers() {
   %0 = amdgcn.alloca : !amdgcn.vgpr<1>
   %1 = amdgcn.alloca : !amdgcn.vgpr<1>
   %2 = amdgcn.alloca : !amdgcn.vgpr<2>
-  // expected-error@+1 {{duplicate register found: 1}}
+  // expected-error@+1 {{expected register 2 but got 1}}
   %3 = amdgcn.make_register_range %0, %1, %2 : !amdgcn.vgpr<1>, !amdgcn.vgpr<1>, !amdgcn.vgpr<2>
   return
 }
@@ -26,7 +26,7 @@ func.func @non_contiguous_range() {
   %0 = amdgcn.alloca : !amdgcn.vgpr<1>
   %1 = amdgcn.alloca : !amdgcn.vgpr<5>
   %2 = amdgcn.alloca : !amdgcn.vgpr<2>
-  // expected-error@+1 {{missing register in range: 3}}
+  // expected-error@+1 {{expected register 2 but got 5}}
   %3 = amdgcn.make_register_range %0, %1, %2 : !amdgcn.vgpr<1>, !amdgcn.vgpr<5>, !amdgcn.vgpr<2>
   return
 }
@@ -37,7 +37,7 @@ func.func @mixed_registers() {
   %0 = amdgcn.alloca : !amdgcn.vgpr<1>
   %1 = amdgcn.alloca : !amdgcn.agpr
   %2 = amdgcn.alloca : !amdgcn.vgpr
-  // expected-error@+1 {{expected all operand types to be of the same kind}}
+  // expected-error@+1 {{expected register of the same kind and semantics}}
   %3 = amdgcn.make_register_range %0, %1, %2 : !amdgcn.vgpr<1>, !amdgcn.agpr, !amdgcn.vgpr
   return
 }
@@ -114,7 +114,7 @@ func.func @offset_with_invalid_aligment() {
 
 func.func @split_single_register() {
   %0 = amdgcn.alloca : !amdgcn.vgpr
-  // expected-error@+1 {{cannot split a single register}}
+  // expected-error@+1 {{register is not composite}}
   %1 = amdgcn.split_register_range %0 : !amdgcn.vgpr
   return
 }
@@ -125,5 +125,17 @@ func.func @make_range_single_register() {
   %0 = amdgcn.alloca : !amdgcn.vgpr
   // expected-error@+1 {{expected at least two operands}}
   %1 = amdgcn.make_register_range %0 : !amdgcn.vgpr
+  return
+}
+
+// -----
+
+func.func @make_range_from_composite() {
+  %0 = amdgcn.alloca : !amdgcn.vgpr<0>
+  %1 = amdgcn.alloca : !amdgcn.vgpr<1>
+  %2 = amdgcn.alloca : !amdgcn.vgpr<2>
+  %3 = amdgcn.make_register_range %0, %1 : !amdgcn.vgpr<0>, !amdgcn.vgpr<1>
+  // expected-error@+1 {{register is already composite}}
+  %4 = amdgcn.make_register_range %3, %2 : !amdgcn.vgpr<[0 : 2]>, !amdgcn.vgpr<2>
   return
 }


### PR DESCRIPTION
Add getCompositeType and getSplitType methods to RegisterTypeInterface. The composite method validates kind/semantics consistency and contiguity for allocated registers. The split method checks the register is composite before splitting. Refactor MakeRegisterRangeOp and SplitRegisterRangeOp to use the new interface methods.