### PR TITLE
[amdgcn] Make VCC/EXEC composite types and forbid alloca of composites

### DIFF
--- a/examples/01_hello_asm/kernel.mlir
+++ b/examples/01_hello_asm/kernel.mlir
@@ -28,7 +28,9 @@ module {
       amdgcn.v_add_u32 outs(%v0) ins(%v1, %v2) : outs(!amdgcn.vgpr<0>) ins(!amdgcn.vgpr<1>, !amdgcn.vgpr<2>)
 
       // Self-check: trap if result != 42
-      %vcc = amdgcn.alloca : !amdgcn.vcc
+      %vcc_lo = alloca : !amdgcn.vcc_lo
+      %vcc_hi = alloca : !amdgcn.vcc_hi
+      %vcc = amdgcn.make_register_range %vcc_lo, %vcc_hi : !amdgcn.vcc_lo, !amdgcn.vcc_hi
       %c42 = arith.constant 42 : i32
       amdgcn.v_cmp_ne_i32 outs(%vcc) ins(%c42, %v0) : outs(!amdgcn.vcc) ins(i32, !amdgcn.vgpr<0>)
       amdgcn.s_cbranch_vccnz %vcc, true(^trap) false(^ok)

--- a/examples/02_nop_insertion/kernel.mlir
+++ b/examples/02_nop_insertion/kernel.mlir
@@ -40,7 +40,9 @@ module {
       amdgcn.v_mov_b32 outs(%v0) ins(%c7) : outs(!amdgcn.vgpr<0>) ins(i32)
 
       // Self-check: v0 should be 7 after the overwrite
-      %vcc = amdgcn.alloca : !amdgcn.vcc
+      %vcc_lo = alloca : !amdgcn.vcc_lo
+      %vcc_hi = alloca : !amdgcn.vcc_hi
+      %vcc = amdgcn.make_register_range %vcc_lo, %vcc_hi : !amdgcn.vcc_lo, !amdgcn.vcc_hi
       amdgcn.v_cmp_ne_i32 outs(%vcc) ins(%c7, %v0) : outs(!amdgcn.vcc) ins(i32, !amdgcn.vgpr<0>)
       amdgcn.s_cbranch_vccnz %vcc, true(^trap) false(^ok)
         : !amdgcn.vcc

--- a/include/aster/Dialect/AMDGCN/IR/AMDGCNOps.td
+++ b/include/aster/Dialect/AMDGCN/IR/AMDGCNOps.td
@@ -55,7 +55,7 @@ def AMDGCN_AllocaOp : AMDGCN_Op<"alloca", [
     Allocates a register.
   }];
   let arguments = (ins);
-  let results = (outs RegisterLike:$result);
+  let results = (outs AllocatableRegisterLike:$result);
   let assemblyFormat = "attr-dict `:` type($result)";
   let extraClassDeclaration = [{
     ::mlir::Value getAlloca() { return getResult(); }
@@ -468,7 +468,7 @@ def AMDGCN_MakeRegisterRangeOp : AMDGCN_Op<"make_register_range", [
     Creates a register range from a variadic number of registers.
   }];
   let arguments = (ins Variadic<RegisterLike>:$inputs);
-  let results = (outs RegisterRangeLike:$result);
+  let results = (outs CompositeRegisterLike:$result);
   let assemblyFormat = "$inputs attr-dict `:` type($inputs)";
   let extraClassDeclaration = [{
     ::mlir::ValueRange unpackBundle() {
@@ -517,7 +517,7 @@ def AMDGCN_SplitRegisterRangeOp : AMDGCN_Op<"split_register_range", [
   let description = [{
     Splits a register range into individual registers.
   }];
-  let arguments = (ins RegisterRangeLike:$input);
+  let arguments = (ins CompositeRegisterLike:$input);
   let results = (outs Variadic<RegisterLike>:$results);
   let assemblyFormat = "$input attr-dict `:` type($input)";
 }

--- a/include/aster/Dialect/AMDGCN/IR/AMDGCNTypeConstraints.td
+++ b/include/aster/Dialect/AMDGCN/IR/AMDGCNTypeConstraints.td
@@ -157,6 +157,13 @@ def RegisterLike :  Type<CPred<"::mlir::aster::amdgcn::isRegisterLike($_self)">,
   }];
 }
 
+/// A register like type excluding composite types (VCC, EXEC).
+def AllocatableRegisterLike : Type<
+    CPred<"::mlir::aster::amdgcn::isAllocatableRegisterLike($_self)">,
+    "allocatable register like type",
+    "::mlir::aster::amdgcn::AMDGCNRegisterTypeInterface"
+  >, PrintOperand;
+
 /// A register like type that matches AGPRRange, SGPRRange, or VGPRRange types.
 def RegisterRangeLike : AnyRegOf<[AGPRType, SGPRType, VGPRType]> {
   let summary = "Register range like types";
@@ -165,6 +172,13 @@ def RegisterRangeLike : AnyRegOf<[AGPRType, SGPRType, VGPRType]> {
     ranges (AGPR, SGPR, VGPR) in the AMDGCN architecture.
   }];
 }
+
+/// A composite register type (has IsComposite property).
+def CompositeRegisterLike : Type<
+    CPred<"::mlir::aster::amdgcn::isCompositeRegisterLike($_self)">,
+    "composite register like type",
+    "::mlir::aster::amdgcn::AMDGCNRegisterTypeInterface"
+  >, PrintOperand;
 
 /// A register type that matches either a VGPR or an AGPR type.
 def VGPROrAGPRType : AnyRegOf<[AGPRType, VGPRType]>;

--- a/include/aster/Dialect/AMDGCN/IR/AMDGCNTypes.h
+++ b/include/aster/Dialect/AMDGCN/IR/AMDGCNTypes.h
@@ -44,6 +44,13 @@ struct GPRegTrait
 
 /// Returns true if it's a register type with size 1.
 bool isRegisterLike(Type type);
+
+/// Returns true if it's an allocatable register type (register-like, not
+/// composite).
+bool isAllocatableRegisterLike(Type type);
+
+/// Returns true if the type has the IsComposite register property.
+bool isCompositeRegisterLike(Type type);
 } // namespace mlir::aster::amdgcn
 
 #define GET_TYPEDEF_CLASSES

--- a/include/aster/Dialect/AMDGCN/IR/AMDGCNTypes.td
+++ b/include/aster/Dialect/AMDGCN/IR/AMDGCNTypes.td
@@ -141,9 +141,7 @@ def SpecialRegTrait : NativeTypeTrait<"SpecialRegTrait"> {
       return kSizeInBits;
     }
     RegisterProps getProps() const {
-      return RegisterProps::AcceptsValueSemantics |
-             RegisterProps::AcceptsUnallocatedSemantics |
-             RegisterProps::AcceptsAllocatedSemantics;
+      return kRegisterProps;
     }
     RegisterTypeInterface getCompositeType(TypeRange types,
         std::optional<int16_t> alignment,
@@ -189,6 +187,11 @@ def VCCType : SRegTypeBase<"VCC", "vcc"> {
   let extraClassDeclaration = [{
     static constexpr RegisterKind kRegisterKind = RegisterKind::VCC;
     static constexpr int64_t kSizeInBits = 64;
+    static constexpr RegisterProps kRegisterProps =
+        RegisterProps::IsComposite |
+        RegisterProps::AcceptsValueSemantics |
+        RegisterProps::AcceptsUnallocatedSemantics |
+        RegisterProps::AcceptsAllocatedSemantics;
   }];
 }
 
@@ -197,6 +200,11 @@ def VCCLoType : SRegTypeBase<"VCCLo", "vcc_lo"> {
   let extraClassDeclaration = [{
     static constexpr RegisterKind kRegisterKind = RegisterKind::VCC_LO;
     static constexpr int64_t kSizeInBits = 32;
+    static constexpr RegisterProps kRegisterProps =
+        RegisterProps::AcceptsComposite |
+        RegisterProps::AcceptsValueSemantics |
+        RegisterProps::AcceptsUnallocatedSemantics |
+        RegisterProps::AcceptsAllocatedSemantics;
   }];
 }
 
@@ -205,6 +213,10 @@ def VCCHiType : SRegTypeBase<"VCCHi", "vcc_hi"> {
   let extraClassDeclaration = [{
     static constexpr RegisterKind kRegisterKind = RegisterKind::VCC_HI;
     static constexpr int64_t kSizeInBits = 32;
+    static constexpr RegisterProps kRegisterProps =
+        RegisterProps::AcceptsValueSemantics |
+        RegisterProps::AcceptsUnallocatedSemantics |
+        RegisterProps::AcceptsAllocatedSemantics;
   }];
 }
 
@@ -213,6 +225,10 @@ def VCCZType : SRegTypeBase<"VCCZ", "vccz"> {
   let extraClassDeclaration = [{
     static constexpr RegisterKind kRegisterKind = RegisterKind::VCCZ;
     static constexpr int64_t kSizeInBits = 1;
+    static constexpr RegisterProps kRegisterProps =
+        RegisterProps::AcceptsValueSemantics |
+        RegisterProps::AcceptsUnallocatedSemantics |
+        RegisterProps::AcceptsAllocatedSemantics;
   }];
 }
 
@@ -221,6 +237,11 @@ def EXECType : SRegTypeBase<"EXEC", "exec"> {
   let extraClassDeclaration = [{
     static constexpr RegisterKind kRegisterKind = RegisterKind::EXEC;
     static constexpr int64_t kSizeInBits = 64;
+    static constexpr RegisterProps kRegisterProps =
+        RegisterProps::IsComposite |
+        RegisterProps::AcceptsValueSemantics |
+        RegisterProps::AcceptsUnallocatedSemantics |
+        RegisterProps::AcceptsAllocatedSemantics;
   }];
 }
 
@@ -229,6 +250,11 @@ def EXECLoType : SRegTypeBase<"EXECLo", "exec_lo"> {
   let extraClassDeclaration = [{
     static constexpr RegisterKind kRegisterKind = RegisterKind::EXEC_LO;
     static constexpr int64_t kSizeInBits = 32;
+    static constexpr RegisterProps kRegisterProps =
+        RegisterProps::AcceptsComposite |
+        RegisterProps::AcceptsValueSemantics |
+        RegisterProps::AcceptsUnallocatedSemantics |
+        RegisterProps::AcceptsAllocatedSemantics;
   }];
 }
 
@@ -237,6 +263,10 @@ def EXECHiType : SRegTypeBase<"EXECHi", "exec_hi"> {
   let extraClassDeclaration = [{
     static constexpr RegisterKind kRegisterKind = RegisterKind::EXEC_HI;
     static constexpr int64_t kSizeInBits = 32;
+    static constexpr RegisterProps kRegisterProps =
+        RegisterProps::AcceptsValueSemantics |
+        RegisterProps::AcceptsUnallocatedSemantics |
+        RegisterProps::AcceptsAllocatedSemantics;
   }];
 }
 
@@ -245,6 +275,10 @@ def EXECZType : SRegTypeBase<"EXECZ", "execz"> {
   let extraClassDeclaration = [{
     static constexpr RegisterKind kRegisterKind = RegisterKind::EXECZ;
     static constexpr int64_t kSizeInBits = 1;
+    static constexpr RegisterProps kRegisterProps =
+        RegisterProps::AcceptsValueSemantics |
+        RegisterProps::AcceptsUnallocatedSemantics |
+        RegisterProps::AcceptsAllocatedSemantics;
   }];
 }
 
@@ -253,6 +287,10 @@ def M0Type : SRegTypeBase<"M0", "m0"> {
   let extraClassDeclaration = [{
     static constexpr RegisterKind kRegisterKind = RegisterKind::M0;
     static constexpr int64_t kSizeInBits = 32;
+    static constexpr RegisterProps kRegisterProps =
+        RegisterProps::AcceptsValueSemantics |
+        RegisterProps::AcceptsUnallocatedSemantics |
+        RegisterProps::AcceptsAllocatedSemantics;
   }];
 }
 
@@ -261,6 +299,10 @@ def SCCType : SRegTypeBase<"SCC", "scc"> {
   let extraClassDeclaration = [{
     static constexpr RegisterKind kRegisterKind = RegisterKind::SCC;
     static constexpr int64_t kSizeInBits = 1;
+    static constexpr RegisterProps kRegisterProps =
+        RegisterProps::AcceptsValueSemantics |
+        RegisterProps::AcceptsUnallocatedSemantics |
+        RegisterProps::AcceptsAllocatedSemantics;
   }];
 }
 

--- a/include/aster/Dialect/AMDGCN/IR/Utils.h
+++ b/include/aster/Dialect/AMDGCN/IR/Utils.h
@@ -49,7 +49,8 @@ struct KernelArgSegmentInfo {
   static KernelArgSegmentInfo get(KernelOp kernel);
 };
 
-/// Create an allocation for a given register type.
+/// Create an allocation for a given register type. Composite types are
+/// decomposed into their parts and combined with make_register_range.
 Value createAllocation(OpBuilder &builder, Location loc,
                        RegisterTypeInterface regTy);
 

--- a/lib/Dialect/AMDGCN/IR/AMDGCN.cpp
+++ b/lib/Dialect/AMDGCN/IR/AMDGCN.cpp
@@ -233,6 +233,20 @@ bool mlir::aster::amdgcn::isRegisterLike(Type type) {
   return range.size() == 1;
 }
 
+bool mlir::aster::amdgcn::isAllocatableRegisterLike(Type type) {
+  if (!isRegisterLike(type))
+    return false;
+  RegisterTypeInterface regType = cast<RegisterTypeInterface>(type);
+  return !bitEnumContainsAll(regType.getProps(), RegisterProps::IsComposite);
+}
+
+bool mlir::aster::amdgcn::isCompositeRegisterLike(Type type) {
+  auto regType = dyn_cast<RegisterTypeInterface>(type);
+  if (!regType)
+    return false;
+  return bitEnumContainsAll(regType.getProps(), RegisterProps::IsComposite);
+}
+
 RegisterKind
 mlir::aster::amdgcn::getRegisterKind(AMDGCNRegisterTypeInterface type) {
   if (auto rTy = dyn_cast<AMDGCNRegisterTypeInterface>(type))

--- a/lib/Dialect/AMDGCN/IR/AMDGCNTypes.cpp
+++ b/lib/Dialect/AMDGCN/IR/AMDGCNTypes.cpp
@@ -233,15 +233,105 @@ GP_REG_COMPOSITE_SPLIT(VGPRType)
     return getSplitSRegImpl(emitError);                                        \
   }
 
-SPECIAL_REG_COMPOSITE_SPLIT(VCCType)
-SPECIAL_REG_COMPOSITE_SPLIT(VCCLoType)
 SPECIAL_REG_COMPOSITE_SPLIT(VCCHiType)
 SPECIAL_REG_COMPOSITE_SPLIT(VCCZType)
-SPECIAL_REG_COMPOSITE_SPLIT(EXECType)
-SPECIAL_REG_COMPOSITE_SPLIT(EXECLoType)
 SPECIAL_REG_COMPOSITE_SPLIT(EXECHiType)
 SPECIAL_REG_COMPOSITE_SPLIT(EXECZType)
 SPECIAL_REG_COMPOSITE_SPLIT(M0Type)
 SPECIAL_REG_COMPOSITE_SPLIT(SCCType)
 
 #undef SPECIAL_REG_COMPOSITE_SPLIT
+
+//===----------------------------------------------------------------------===//
+// VCC composite/split
+//===----------------------------------------------------------------------===//
+
+RegisterTypeInterface VCCLoType::getCompositeType(
+    TypeRange types, std::optional<int16_t> alignment,
+    llvm::function_ref<InFlightDiagnostic()> emitError) const {
+  assert(!alignment.has_value() &&
+         "alignment is not supported for special register composites");
+  if (types.size() != 1 || !isa<VCCHiType>(types[0])) {
+    if (emitError)
+      emitError() << "expected exactly one vcc_hi operand";
+    return nullptr;
+  }
+  if (cast<VCCHiType>(types[0]).getSemantics() != getSemantics()) {
+    if (emitError)
+      emitError() << "expected matching semantics";
+    return nullptr;
+  }
+  return VCCType::get(getContext(), getReg());
+}
+
+LogicalResult VCCLoType::getSplitType(
+    SmallVectorImpl<RegisterTypeInterface> &regs,
+    llvm::function_ref<InFlightDiagnostic()> emitError) const {
+  (void)regs;
+  if (emitError)
+    emitError() << "vcc_lo is not a composite type and cannot be split";
+  return failure();
+}
+
+RegisterTypeInterface VCCType::getCompositeType(
+    TypeRange types, std::optional<int16_t> alignment,
+    llvm::function_ref<InFlightDiagnostic()> emitError) const {
+  (void)types;
+  (void)alignment;
+  return getCompositeSRegImpl(emitError);
+}
+
+LogicalResult VCCType::getSplitType(
+    SmallVectorImpl<RegisterTypeInterface> &regs,
+    llvm::function_ref<InFlightDiagnostic()> emitError) const {
+  regs.push_back(VCCLoType::get(getContext(), getReg()));
+  regs.push_back(VCCHiType::get(getContext(), getReg()));
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// EXEC composite/split
+//===----------------------------------------------------------------------===//
+
+RegisterTypeInterface EXECLoType::getCompositeType(
+    TypeRange types, std::optional<int16_t> alignment,
+    llvm::function_ref<InFlightDiagnostic()> emitError) const {
+  assert(!alignment.has_value() &&
+         "alignment is not supported for special register composites");
+  if (types.size() != 1 || !isa<EXECHiType>(types[0])) {
+    if (emitError)
+      emitError() << "expected exactly one exec_hi operand";
+    return nullptr;
+  }
+  if (cast<EXECHiType>(types[0]).getSemantics() != getSemantics()) {
+    if (emitError)
+      emitError() << "expected matching semantics";
+    return nullptr;
+  }
+  return EXECType::get(getContext(), getReg());
+}
+
+LogicalResult EXECLoType::getSplitType(
+    SmallVectorImpl<RegisterTypeInterface> &regs,
+    llvm::function_ref<InFlightDiagnostic()> emitError) const {
+  (void)regs;
+  if (emitError)
+    emitError() << "exec_lo is not a composite type and cannot be split";
+  return failure();
+}
+
+RegisterTypeInterface EXECType::getCompositeType(
+    TypeRange types, std::optional<int16_t> alignment,
+    llvm::function_ref<InFlightDiagnostic()> emitError) const {
+  (void)types;
+  (void)alignment;
+  return getCompositeSRegImpl(emitError);
+}
+
+LogicalResult EXECType::getSplitType(
+    SmallVectorImpl<RegisterTypeInterface> &regs,
+    llvm::function_ref<InFlightDiagnostic()> emitError) const {
+  regs.push_back(EXECLoType::get(getContext(), getReg()));
+  regs.push_back(EXECHiType::get(getContext(), getReg()));
+  return success();
+}

--- a/lib/Dialect/AMDGCN/IR/Utils.cpp
+++ b/lib/Dialect/AMDGCN/IR/Utils.cpp
@@ -30,7 +30,18 @@ using namespace mlir::aster::amdgcn;
 
 Value mlir::aster::amdgcn::createAllocation(OpBuilder &builder, Location loc,
                                             RegisterTypeInterface rTy) {
-  if (!rTy.isRegisterRange() || rTy.getAsRange().size() == 1)
+  // Handle composite special registers (VCC, EXEC).
+  if (bitEnumContainsAll(rTy.getProps(), RegisterProps::IsComposite)) {
+    SmallVector<RegisterTypeInterface> parts;
+    LogicalResult result = rTy.getSplitType(parts, nullptr);
+    assert(succeeded(result) && "composite type must be splittable");
+    SmallVector<Value> allocs;
+    allocs.reserve(parts.size());
+    for (RegisterTypeInterface part : parts)
+      allocs.push_back(AllocaOp::create(builder, loc, part));
+    return MakeRegisterRangeOp::create(builder, loc, rTy, allocs);
+  }
+  if (!rTy.isRegisterRange())
     return amdgcn::AllocaOp::create(
         builder, loc, rTy.cloneRegisterType(rTy.getAsRange().begin()));
   SmallVector<Value> results;
@@ -52,11 +63,11 @@ mlir::aster::amdgcn::getRegKind(RegisterTypeInterface regTy) {
 }
 
 OperandKind mlir::aster::amdgcn::getOperandKind(Type type) {
-  if (isa<SGPRType, SGPRType>(type))
+  if (isa<SGPRType>(type))
     return OperandKind::SGPR;
-  if (isa<VGPRType, VGPRType>(type))
+  if (isa<VGPRType>(type))
     return OperandKind::VGPR;
-  if (isa<AGPRType, AGPRType>(type))
+  if (isa<AGPRType>(type))
     return OperandKind::AGPR;
   if (auto iTy = dyn_cast<IntegerType>(type)) {
     if (iTy.isSignless() && (iTy.getWidth() == 32 || iTy.getWidth() == 64))

--- a/lib/Dialect/AMDGCN/Transforms/LegalizeCF.cpp
+++ b/lib/Dialect/AMDGCN/Transforms/LegalizeCF.cpp
@@ -23,6 +23,7 @@
 #include "aster/Dialect/AMDGCN/IR/AMDGCNAttrs.h"
 #include "aster/Dialect/AMDGCN/IR/AMDGCNOps.h"
 #include "aster/Dialect/AMDGCN/IR/AMDGCNTypes.h"
+#include "aster/Dialect/AMDGCN/IR/Utils.h"
 #include "aster/Dialect/AMDGCN/Transforms/Passes.h"
 #include "aster/Dialect/LSIR/IR/LSIRDialect.h"
 #include "aster/Dialect/LSIR/IR/LSIROps.h"
@@ -220,8 +221,9 @@ Value LegalizeCF::getOrCreateLoweredCmp(lsir::CmpIOp cmpOp,
       std::swap(lhs, rhs);
       pred = swapPredicate(pred);
     }
-    Type vccType = VCCType::get(rewriter.getContext(), Register(0));
-    Value vcc = AllocaOp::create(rewriter, loc, vccType);
+    RegisterTypeInterface vccTy =
+        VCCType::get(rewriter.getContext(), Register(0));
+    Value vcc = createAllocation(rewriter, loc, vccTy);
     createVectorCompare(rewriter, loc, pred, vcc, lhs, rhs);
     loweredCmpMap[cmpOp] = vcc;
     return vcc;

--- a/test/Dialect/AMDGCN/Transforms/legalize-cf.mlir
+++ b/test/Dialect/AMDGCN/Transforms/legalize-cf.mlir
@@ -493,7 +493,9 @@ amdgcn.module @test_crossblock_mod target = <gfx942> {
 // Branch uses s_cbranch_vccnz: true(^bb1) when VCC != 0 (condition true), false(^bb2).
 
 // CHECK-LABEL: kernel @test_vopc_cond_branch
-// CHECK:         %[[VCC:.*]] = alloca : !amdgcn.vcc<0>
+// CHECK:         alloca : !amdgcn.vcc_lo<0>
+// CHECK:         alloca : !amdgcn.vcc_hi<0>
+// CHECK:         %[[VCC:.*]] = make_register_range
 // CHECK:         v_cmp_lt_i32 outs(%[[VCC]]) ins(%{{.*}}, %{{.*}}) : outs(!amdgcn.vcc<0>) ins(i32, !amdgcn.vgpr<0>)
 // CHECK:         s_cbranch_vccnz %[[VCC]], true(^bb1) false(^bb2) : !amdgcn.vcc<0>
 // CHECK:       ^bb1:
@@ -564,7 +566,7 @@ amdgcn.module @test_vopc_vv_mod target = <gfx942> {
 // src0/src1 must be register-typed (VOP2 constraint), so we use VGPRs.
 
 // CHECK-LABEL: kernel @test_vopc_select
-// CHECK:         %[[VCC:.*]] = alloca : !amdgcn.vcc<0>
+// CHECK:         %[[VCC:.*]] = make_register_range
 // CHECK:         v_cmp_eq_i32 outs(%[[VCC]]) ins(%{{.*}}, %{{.*}}) : outs(!amdgcn.vcc<0>) ins(!amdgcn.vgpr<0>, !amdgcn.vgpr<1>)
 // CHECK:         v_cndmask_b32 outs(%{{.*}}) ins(%{{.*}}, %{{.*}}, %[[VCC]])
 // CHECK:         end_kernel
@@ -587,7 +589,7 @@ amdgcn.module @test_vopc_select_mod target = <gfx942> {
 // Materialize the true value into dst via v_mov_b32_e32 first.
 
 // CHECK-LABEL: kernel @test_vopc_select_nonvgpr_true
-// CHECK:         %[[VCC:.*]] = alloca : !amdgcn.vcc<0>
+// CHECK:         %[[VCC:.*]] = make_register_range
 // CHECK:         v_cmp_eq_i32 outs(%[[VCC]]) ins(%{{.*}}, %{{.*}}) : outs(!amdgcn.vcc<0>) ins(!amdgcn.vgpr<0>, !amdgcn.vgpr<1>)
 // CHECK:         v_mov_b32 outs(%{{.*}}) ins(%{{.*}}) : outs(!amdgcn.vgpr<2>) ins(i32)
 // CHECK:         v_cndmask_b32 outs(%{{.*}}) ins(%{{.*}}, %{{.*}}, %[[VCC]])
@@ -609,7 +611,7 @@ amdgcn.module @test_vopc_select_imm_true_mod target = <gfx942> {
 // Same as above: true value in SGPR still needs v_mov_b32_e32 into dst for src1.
 
 // CHECK-LABEL: kernel @test_vopc_select_sgpr_true
-// CHECK:         %[[VCC:.*]] = alloca : !amdgcn.vcc<0>
+// CHECK:         %[[VCC:.*]] = make_register_range
 // CHECK:         v_cmp_eq_i32 outs(%[[VCC]]) ins(%{{.*}}, %{{.*}}) : outs(!amdgcn.vcc<0>) ins(!amdgcn.vgpr<0>, !amdgcn.vgpr<1>)
 // CHECK:         v_mov_b32 outs(%{{.*}}) ins(%{{.*}}) : outs(!amdgcn.vgpr<2>) ins(!amdgcn.sgpr<0>)
 // CHECK:         v_cndmask_b32 outs(%{{.*}}) ins(%{{.*}}, %{{.*}}, %[[VCC]])

--- a/test/Dialect/AMDGCN/Transforms/ll-sched-archreg-edges.mlir
+++ b/test/Dialect/AMDGCN/Transforms/ll-sched-archreg-edges.mlir
@@ -34,7 +34,9 @@ amdgcn.module @vcc_raw target = #amdgcn.target<gfx942> {
     %v_a = amdgcn.alloca : !v
     %v_b = amdgcn.alloca : !v
     %v_d = amdgcn.alloca : !v
-    %vcc = amdgcn.alloca : !amdgcn.vcc<0>
+    %vcc_lo = amdgcn.alloca : !amdgcn.vcc_lo<0>
+    %vcc_hi = amdgcn.alloca : !amdgcn.vcc_hi<0>
+    %vcc = amdgcn.make_register_range %vcc_lo, %vcc_hi : !amdgcn.vcc_lo<0>, !amdgcn.vcc_hi<0>
     amdgcn.v_cmp_eq_i32 outs(%vcc) ins(%v_a, %v_b) : outs(!amdgcn.vcc<0>) ins(!v, !v)
     %sel = amdgcn.v_cndmask_b32 outs(%v_d) ins(%v_a, %v_b, %vcc) : outs(!v) ins(!v, !v, !amdgcn.vcc<0>)
     amdgcn.end_kernel
@@ -109,7 +111,9 @@ amdgcn.module @scc_vcc_independent target = #amdgcn.target<gfx942> {
     %s_b = amdgcn.alloca : !s
     %s_d1 = amdgcn.alloca : !s
     %s_d2 = amdgcn.alloca : !s
-    %vcc   = amdgcn.alloca : !amdgcn.vcc<0>
+    %vcc_lo = amdgcn.alloca : !amdgcn.vcc_lo<0>
+    %vcc_hi = amdgcn.alloca : !amdgcn.vcc_hi<0>
+    %vcc   = amdgcn.make_register_range %vcc_lo, %vcc_hi : !amdgcn.vcc_lo<0>, !amdgcn.vcc_hi<0>
     %scc_w = amdgcn.alloca : !amdgcn.scc<0>
     %scc_r = amdgcn.alloca : !amdgcn.scc<0>
     amdgcn.v_cmp_eq_i32 outs(%vcc) ins(%v_a, %v_b) : outs(!amdgcn.vcc<0>) ins(!v, !v)

--- a/test/Dialect/AMDGCN/Transforms/lower-sreg-block-args.mlir
+++ b/test/Dialect/AMDGCN/Transforms/lower-sreg-block-args.mlir
@@ -78,12 +78,16 @@ amdgcn.kernel @unallocated_scc_unchanged {
 // CHECK:         %[[CPY0:.*]] = lsir.copy %{{.*}}, %{{.*}} : !amdgcn.sgpr{{.*}}, !amdgcn.vcc
 // CHECK:         cf.br ^[[BB1:bb[0-9]+]](%[[CPY0]] : !amdgcn.sgpr<[? + 2]>)
 // CHECK:       ^[[BB1]](%[[A:.*]]: !amdgcn.sgpr<[? + 2]>):
-// CHECK:         %[[VC:.*]] = alloca : !amdgcn.vcc
-// CHECK:         %[[CPY1:.*]] = lsir.copy %[[VC]], %[[A]] : !amdgcn.vcc{{.*}}, !amdgcn.sgpr{{.*}}
+// CHECK:         alloca : !amdgcn.vcc_lo
+// CHECK:         alloca : !amdgcn.vcc_hi
+// CHECK:         make_register_range
+// CHECK:         %[[CPY1:.*]] = lsir.copy %{{.*}}, %[[A]] : !amdgcn.vcc{{.*}}, !amdgcn.sgpr{{.*}}
 // CHECK:         end_kernel
 amdgcn.kernel @vcc_through_sgpr {
 ^bb0:
-  %vcc = amdgcn.alloca : !amdgcn.vcc
+  %vcc_lo = amdgcn.alloca : !amdgcn.vcc_lo
+  %vcc_hi = amdgcn.alloca : !amdgcn.vcc_hi
+  %vcc = amdgcn.make_register_range %vcc_lo, %vcc_hi : !amdgcn.vcc_lo, !amdgcn.vcc_hi
   cf.br ^bb1(%vcc : !amdgcn.vcc)
 ^bb1(%arg : !amdgcn.vcc):
   amdgcn.end_kernel

--- a/test/Dialect/AMDGCN/invalid.mlir
+++ b/test/Dialect/AMDGCN/invalid.mlir
@@ -139,3 +139,19 @@ func.func @make_range_from_composite() {
   %4 = amdgcn.make_register_range %3, %2 : !amdgcn.vgpr<[0 : 2]>, !amdgcn.vgpr<2>
   return
 }
+
+// -----
+
+func.func @alloca_composite_vcc() {
+  // expected-error@+1 {{'amdgcn.alloca' op result #0 must be allocatable register like type, but got '!amdgcn.vcc'}}
+  %0 = amdgcn.alloca : !amdgcn.vcc
+  return
+}
+
+// -----
+
+func.func @alloca_composite_exec() {
+  // expected-error@+1 {{'amdgcn.alloca' op result #0 must be allocatable register like type, but got '!amdgcn.exec'}}
+  %0 = amdgcn.alloca : !amdgcn.exec
+  return
+}

--- a/test/Dialect/AMDGCN/ops.mlir
+++ b/test/Dialect/AMDGCN/ops.mlir
@@ -168,6 +168,22 @@ func.func @test_make_register_ranges_relocatable() -> (!amdgcn.vgpr, !amdgcn.vgp
   return %4, %5: !amdgcn.vgpr, !amdgcn.vgpr
 }
 
+func.func @test_vcc_composite() {
+  %lo = amdgcn.alloca : !amdgcn.vcc_lo
+  %hi = amdgcn.alloca : !amdgcn.vcc_hi
+  %vcc = amdgcn.make_register_range %lo, %hi : !amdgcn.vcc_lo, !amdgcn.vcc_hi
+  %lo2, %hi2 = amdgcn.split_register_range %vcc : !amdgcn.vcc
+  return
+}
+
+func.func @test_exec_composite() {
+  %lo = amdgcn.alloca : !amdgcn.exec_lo<0>
+  %hi = amdgcn.alloca : !amdgcn.exec_hi<0>
+  %exec = amdgcn.make_register_range %lo, %hi : !amdgcn.exec_lo<0>, !amdgcn.exec_hi<0>
+  %lo2, %hi2 = amdgcn.split_register_range %exec : !amdgcn.exec<0>
+  return
+}
+
 //===----------------------------------------------------------------------===//
 // VOP1 Operations
 //===----------------------------------------------------------------------===//

--- a/test/Target/ASM/vopc-branch.mlir
+++ b/test/Target/ASM/vopc-branch.mlir
@@ -33,7 +33,9 @@ amdgcn.module @vopc_branch_mod target = #amdgcn.target<gfx942> {
   amdgcn.kernel @test_vcmp_lt_i32_vccnz {
   ^entry:
     %v0 = amdgcn.alloca : !amdgcn.vgpr<0>
-    %vcc = amdgcn.alloca : !amdgcn.vcc<0>
+    %vcc_lo = amdgcn.alloca : !amdgcn.vcc_lo<0>
+    %vcc_hi = amdgcn.alloca : !amdgcn.vcc_hi<0>
+    %vcc = amdgcn.make_register_range %vcc_lo, %vcc_hi : !amdgcn.vcc_lo<0>, !amdgcn.vcc_hi<0>
     %c0 = arith.constant 0 : i32
     amdgcn.v_cmp_lt_i32 outs(%vcc) ins(%c0, %v0) : outs(!amdgcn.vcc<0>) ins(i32, !amdgcn.vgpr<0>)
     amdgcn.s_cbranch_vccz %vcc, true(^taken) false(^fallthru)
@@ -49,7 +51,9 @@ amdgcn.module @vopc_branch_mod target = #amdgcn.target<gfx942> {
   ^entry:
     %v0 = amdgcn.alloca : !amdgcn.vgpr<0>
     %v1 = amdgcn.alloca : !amdgcn.vgpr<1>
-    %vcc = amdgcn.alloca : !amdgcn.vcc<0>
+    %vcc_lo = amdgcn.alloca : !amdgcn.vcc_lo<0>
+    %vcc_hi = amdgcn.alloca : !amdgcn.vcc_hi<0>
+    %vcc = amdgcn.make_register_range %vcc_lo, %vcc_hi : !amdgcn.vcc_lo<0>, !amdgcn.vcc_hi<0>
     amdgcn.v_cmp_eq_i32 outs(%vcc) ins(%v0, %v1) : outs(!amdgcn.vcc<0>) ins(!amdgcn.vgpr<0>, !amdgcn.vgpr<1>)
     amdgcn.s_cbranch_vccz %vcc, true(^taken) false(^fallthru)
       : !amdgcn.vcc<0>
@@ -63,7 +67,9 @@ amdgcn.module @vopc_branch_mod target = #amdgcn.target<gfx942> {
   amdgcn.kernel @test_vcmp_gt_swap {
   ^entry:
     %v0 = amdgcn.alloca : !amdgcn.vgpr<0>
-    %vcc = amdgcn.alloca : !amdgcn.vcc<0>
+    %vcc_lo = amdgcn.alloca : !amdgcn.vcc_lo<0>
+    %vcc_hi = amdgcn.alloca : !amdgcn.vcc_hi<0>
+    %vcc = amdgcn.make_register_range %vcc_lo, %vcc_hi : !amdgcn.vcc_lo<0>, !amdgcn.vcc_hi<0>
     %c32 = arith.constant 32 : i32
     amdgcn.v_cmp_gt_i32 outs(%vcc) ins(%c32, %v0) : outs(!amdgcn.vcc<0>) ins(i32, !amdgcn.vgpr<0>)
     amdgcn.s_cbranch_vccz %vcc, true(^taken) false(^fallthru)

--- a/test/Target/ASM/vopc-cndmask.mlir
+++ b/test/Target/ASM/vopc-cndmask.mlir
@@ -21,7 +21,9 @@ amdgcn.module @vopc_cndmask_mod target = #amdgcn.target<gfx942> {
     %v0 = amdgcn.alloca : !amdgcn.vgpr<0>
     %v1 = amdgcn.alloca : !amdgcn.vgpr<1>
     %v2 = amdgcn.alloca : !amdgcn.vgpr<2>
-    %vcc = amdgcn.alloca : !amdgcn.vcc<0>
+    %vcc_lo = amdgcn.alloca : !amdgcn.vcc_lo<0>
+    %vcc_hi = amdgcn.alloca : !amdgcn.vcc_hi<0>
+    %vcc = amdgcn.make_register_range %vcc_lo, %vcc_hi : !amdgcn.vcc_lo<0>, !amdgcn.vcc_hi<0>
     amdgcn.v_cndmask_b32 outs(%v2) ins(%v0, %v1, %vcc) : outs(!amdgcn.vgpr<2>) ins(!amdgcn.vgpr<0>, !amdgcn.vgpr<1>, !amdgcn.vcc<0>)
     amdgcn.end_kernel
   }
@@ -31,7 +33,9 @@ amdgcn.module @vopc_cndmask_mod target = #amdgcn.target<gfx942> {
   ^entry:
     %v0 = amdgcn.alloca : !amdgcn.vgpr<0>
     %v2 = amdgcn.alloca : !amdgcn.vgpr<2>
-    %vcc = amdgcn.alloca : !amdgcn.vcc<0>
+    %vcc_lo = amdgcn.alloca : !amdgcn.vcc_lo<0>
+    %vcc_hi = amdgcn.alloca : !amdgcn.vcc_hi<0>
+    %vcc = amdgcn.make_register_range %vcc_lo, %vcc_hi : !amdgcn.vcc_lo<0>, !amdgcn.vcc_hi<0>
     %c42 = arith.constant 42 : i32
     amdgcn.v_mov_b32 outs(%v2) ins(%c42) : outs(!amdgcn.vgpr<2>) ins(i32)
     amdgcn.v_cndmask_b32 outs(%v2) ins(%v0, %v2, %vcc) : outs(!amdgcn.vgpr<2>) ins(!amdgcn.vgpr<0>, !amdgcn.vgpr<2>, !amdgcn.vcc<0>)
@@ -43,7 +47,9 @@ amdgcn.module @vopc_cndmask_mod target = #amdgcn.target<gfx942> {
     %v0 = amdgcn.alloca : !amdgcn.vgpr<0>
     %v2 = amdgcn.alloca : !amdgcn.vgpr<2>
     %s0 = amdgcn.alloca : !amdgcn.sgpr<0>
-    %vcc = amdgcn.alloca : !amdgcn.vcc<0>
+    %vcc_lo = amdgcn.alloca : !amdgcn.vcc_lo<0>
+    %vcc_hi = amdgcn.alloca : !amdgcn.vcc_hi<0>
+    %vcc = amdgcn.make_register_range %vcc_lo, %vcc_hi : !amdgcn.vcc_lo<0>, !amdgcn.vcc_hi<0>
     amdgcn.v_mov_b32 outs(%v2) ins(%s0) : outs(!amdgcn.vgpr<2>) ins(!amdgcn.sgpr<0>)
     amdgcn.v_cndmask_b32 outs(%v2) ins(%v0, %v2, %vcc) : outs(!amdgcn.vgpr<2>) ins(!amdgcn.vgpr<0>, !amdgcn.vgpr<2>, !amdgcn.vcc<0>)
     amdgcn.end_kernel


### PR DESCRIPTION
Mark VCCType and EXECType as IsComposite, and VCCLoType and EXECLoType as AcceptsComposite via per-type kRegisterProps in SpecialRegTrait. Implement getCompositeType for VCCLoType/EXECLoType (compose lo+hi into VCC/EXEC) and getSplitType for VCCType/EXECType (split into lo+hi).

Forbid direct allocation of composite types by introducing an AllocatableRegisterLike type constraint (isRegisterLike && !IsComposite) for AllocaOp's result. Add a CompositeRegisterLike constraint backed by the IsComposite property for MakeRegisterRangeOp and SplitRegisterRangeOp.

Update createAllocation to decompose composite types via getSplitType, and update LegalizeCF to use it for VCC allocation. Update all tests and examples to use the decomposed alloca pattern (vcc_lo + vcc_hi + make_register_range) and add invalid tests for composite alloca.