### PR TITLE
[amdgcn] Add IsStatusReg/IsReadOnly props and enforce SREG semantics

### DIFF
--- a/include/aster/Dialect/AMDGCN/IR/AMDGCNOps.td
+++ b/include/aster/Dialect/AMDGCN/IR/AMDGCNOps.td
@@ -60,6 +60,7 @@ def AMDGCN_AllocaOp : AMDGCN_Op<"alloca", [
   let extraClassDeclaration = [{
     ::mlir::Value getAlloca() { return getResult(); }
   }];
+  let hasVerifier = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/aster/Dialect/AMDGCN/IR/AMDGCNTypes.td
+++ b/include/aster/Dialect/AMDGCN/IR/AMDGCNTypes.td
@@ -179,6 +179,7 @@ class SRegTypeBase<string name, string mnemonic>
     }]>
   ];
   let skipDefaultBuilders = 1;
+  let genVerifyDecl = 1;
 }
 
 /// Special registers to model state.
@@ -190,7 +191,6 @@ def VCCType : SRegTypeBase<"VCC", "vcc"> {
     static constexpr RegisterProps kRegisterProps =
         RegisterProps::IsComposite |
         RegisterProps::AcceptsValueSemantics |
-        RegisterProps::AcceptsUnallocatedSemantics |
         RegisterProps::AcceptsAllocatedSemantics;
   }];
 }
@@ -203,7 +203,6 @@ def VCCLoType : SRegTypeBase<"VCCLo", "vcc_lo"> {
     static constexpr RegisterProps kRegisterProps =
         RegisterProps::AcceptsComposite |
         RegisterProps::AcceptsValueSemantics |
-        RegisterProps::AcceptsUnallocatedSemantics |
         RegisterProps::AcceptsAllocatedSemantics;
   }];
 }
@@ -215,19 +214,22 @@ def VCCHiType : SRegTypeBase<"VCCHi", "vcc_hi"> {
     static constexpr int64_t kSizeInBits = 32;
     static constexpr RegisterProps kRegisterProps =
         RegisterProps::AcceptsValueSemantics |
-        RegisterProps::AcceptsUnallocatedSemantics |
         RegisterProps::AcceptsAllocatedSemantics;
   }];
 }
 
+/// VCCZ is a read-only status register. When used with value semantics, it
+/// represents a frozen-in-time snapshot of the VCC zero flag at the point the
+/// value was created. Value-semantic VCCZ may be promoted to SGPRs.
 def VCCZType : SRegTypeBase<"VCCZ", "vccz"> {
   let summary = "VCCZ special register type";
   let extraClassDeclaration = [{
     static constexpr RegisterKind kRegisterKind = RegisterKind::VCCZ;
     static constexpr int64_t kSizeInBits = 1;
     static constexpr RegisterProps kRegisterProps =
+        RegisterProps::IsStatusReg |
+        RegisterProps::IsReadOnly |
         RegisterProps::AcceptsValueSemantics |
-        RegisterProps::AcceptsUnallocatedSemantics |
         RegisterProps::AcceptsAllocatedSemantics;
   }];
 }
@@ -239,8 +241,6 @@ def EXECType : SRegTypeBase<"EXEC", "exec"> {
     static constexpr int64_t kSizeInBits = 64;
     static constexpr RegisterProps kRegisterProps =
         RegisterProps::IsComposite |
-        RegisterProps::AcceptsValueSemantics |
-        RegisterProps::AcceptsUnallocatedSemantics |
         RegisterProps::AcceptsAllocatedSemantics;
   }];
 }
@@ -252,8 +252,6 @@ def EXECLoType : SRegTypeBase<"EXECLo", "exec_lo"> {
     static constexpr int64_t kSizeInBits = 32;
     static constexpr RegisterProps kRegisterProps =
         RegisterProps::AcceptsComposite |
-        RegisterProps::AcceptsValueSemantics |
-        RegisterProps::AcceptsUnallocatedSemantics |
         RegisterProps::AcceptsAllocatedSemantics;
   }];
 }
@@ -264,20 +262,22 @@ def EXECHiType : SRegTypeBase<"EXECHi", "exec_hi"> {
     static constexpr RegisterKind kRegisterKind = RegisterKind::EXEC_HI;
     static constexpr int64_t kSizeInBits = 32;
     static constexpr RegisterProps kRegisterProps =
-        RegisterProps::AcceptsValueSemantics |
-        RegisterProps::AcceptsUnallocatedSemantics |
         RegisterProps::AcceptsAllocatedSemantics;
   }];
 }
 
+/// EXECZ is a read-only status register. When used with value semantics, it
+/// represents a frozen-in-time snapshot of the EXEC zero flag at the point the
+/// value was created. Value-semantic EXECZ may be promoted to SGPRs.
 def EXECZType : SRegTypeBase<"EXECZ", "execz"> {
   let summary = "EXECZ special register type";
   let extraClassDeclaration = [{
     static constexpr RegisterKind kRegisterKind = RegisterKind::EXECZ;
     static constexpr int64_t kSizeInBits = 1;
     static constexpr RegisterProps kRegisterProps =
+        RegisterProps::IsStatusReg |
+        RegisterProps::IsReadOnly |
         RegisterProps::AcceptsValueSemantics |
-        RegisterProps::AcceptsUnallocatedSemantics |
         RegisterProps::AcceptsAllocatedSemantics;
   }];
 }
@@ -289,7 +289,6 @@ def M0Type : SRegTypeBase<"M0", "m0"> {
     static constexpr int64_t kSizeInBits = 32;
     static constexpr RegisterProps kRegisterProps =
         RegisterProps::AcceptsValueSemantics |
-        RegisterProps::AcceptsUnallocatedSemantics |
         RegisterProps::AcceptsAllocatedSemantics;
   }];
 }
@@ -300,8 +299,8 @@ def SCCType : SRegTypeBase<"SCC", "scc"> {
     static constexpr RegisterKind kRegisterKind = RegisterKind::SCC;
     static constexpr int64_t kSizeInBits = 1;
     static constexpr RegisterProps kRegisterProps =
+        RegisterProps::IsStatusReg |
         RegisterProps::AcceptsValueSemantics |
-        RegisterProps::AcceptsUnallocatedSemantics |
         RegisterProps::AcceptsAllocatedSemantics;
   }];
 }

--- a/include/aster/Interfaces/RegisterSemantics.td
+++ b/include/aster/Interfaces/RegisterSemantics.td
@@ -39,10 +39,12 @@ def RegisterProps : I8BitEnum<"RegisterProps",
     I8BitEnumCaseNone<"None", "none">,
     I8BitEnumCase<"IsGeneralPurpose", 1, "is_general_purpose">,
     I8BitEnumCase<"IsComposite", 2, "is_composite">,
-    I8BitEnumCase<"AcceptsComposite", 4, "accepts_composite">,
-    I8BitEnumCase<"AcceptsValueSemantics", 8, "accepts_value_semantics">,
-    I8BitEnumCase<"AcceptsUnallocatedSemantics", 16, "accepts_unallocated_semantics">,
-    I8BitEnumCase<"AcceptsAllocatedSemantics", 32, "accepts_allocated_semantics">
+    I8BitEnumCase<"IsStatusReg", 4, "is_status_reg">,
+    I8BitEnumCase<"IsReadOnly", 8, "is_read_only">,
+    I8BitEnumCase<"AcceptsComposite", 16, "accepts_composite">,
+    I8BitEnumCase<"AcceptsValueSemantics", 32, "accepts_value_semantics">,
+    I8BitEnumCase<"AcceptsUnallocatedSemantics", 64, "accepts_unallocated_semantics">,
+    I8BitEnumCase<"AcceptsAllocatedSemantics", 128, "accepts_allocated_semantics">
   ]> {
   let cppNamespace = "::mlir::aster";
 }

--- a/lib/Dialect/AMDGCN/IR/AMDGCN.cpp
+++ b/lib/Dialect/AMDGCN/IR/AMDGCN.cpp
@@ -258,6 +258,15 @@ mlir::aster::amdgcn::getRegisterKind(AMDGCNRegisterTypeInterface type) {
 // AllocaOp
 //===----------------------------------------------------------------------===//
 
+LogicalResult AllocaOp::verify() {
+  RegisterTypeInterface regTy = getType();
+  if (bitEnumContainsAll(regTy.getProps(), RegisterProps::IsReadOnly) &&
+      regTy.hasValueSemantics())
+    return emitOpError("cannot allocate read-only register with value "
+                       "semantics");
+  return success();
+}
+
 Speculation::Speculatability AllocaOp::getSpeculatability() {
   if (getType().hasAllocatedSemantics())
     return Speculation::Speculatability::Speculatable;

--- a/lib/Dialect/AMDGCN/IR/AMDGCNTypes.cpp
+++ b/lib/Dialect/AMDGCN/IR/AMDGCNTypes.cpp
@@ -143,6 +143,44 @@ LogicalResult verifyRegisterRange(function_ref<InFlightDiagnostic()> emitError,
 }
 } // namespace
 
+//===----------------------------------------------------------------------===//
+// SREG type verification
+//===----------------------------------------------------------------------===//
+
+static LogicalResult
+verifySRegSemantics(function_ref<InFlightDiagnostic()> emitError, Register reg,
+                    RegisterProps props, StringRef name) {
+  RegisterSemantics sem = reg.getSemantics();
+  if (sem == RegisterSemantics::Value &&
+      !bitEnumContainsAll(props, RegisterProps::AcceptsValueSemantics))
+    return emitError() << name << " does not accept value semantics";
+  if (sem == RegisterSemantics::Unallocated &&
+      !bitEnumContainsAll(props, RegisterProps::AcceptsUnallocatedSemantics))
+    return emitError() << name << " does not accept unallocated semantics";
+  return success();
+}
+
+#define SREG_VERIFY(TypeName, Name)                                            \
+  LogicalResult TypeName::verify(function_ref<InFlightDiagnostic()> emitError, \
+                                 Register reg) {                               \
+    return verifySRegSemantics(emitError, reg, kRegisterProps, Name);          \
+  }
+
+SREG_VERIFY(VCCType, "vcc")
+SREG_VERIFY(VCCLoType, "vcc_lo")
+SREG_VERIFY(VCCHiType, "vcc_hi")
+SREG_VERIFY(VCCZType, "vccz")
+SREG_VERIFY(EXECType, "exec")
+SREG_VERIFY(EXECLoType, "exec_lo")
+SREG_VERIFY(EXECHiType, "exec_hi")
+SREG_VERIFY(EXECZType, "execz")
+SREG_VERIFY(M0Type, "m0")
+SREG_VERIFY(SCCType, "scc")
+
+#undef SREG_VERIFY
+
+//===----------------------------------------------------------------------===//
+
 bool mlir::aster::amdgcn::compareLessAMDGCNRegisterTypes(
     AMDGCNRegisterTypeInterface lhs, AMDGCNRegisterTypeInterface rhs) {
   if (lhs.getRegisterKind() != rhs.getRegisterKind())

--- a/test/Dialect/AMDGCN/Transforms/lower-sreg-block-args.mlir
+++ b/test/Dialect/AMDGCN/Transforms/lower-sreg-block-args.mlir
@@ -65,15 +65,15 @@ amdgcn.kernel @allocated_scc_unchanged {
 
 // -----
 
-// Unallocated SCC (`<?>`) has non-value semantics; the pass must not rewrite.
-// CHECK-LABEL: kernel @unallocated_scc_unchanged
-// CHECK:         cf.br ^{{bb[0-9]+}}(%{{.*}} : !amdgcn.scc<?>)
-// CHECK:       ^{{bb[0-9]+}}(%{{.*}}: !amdgcn.scc<?>):
-amdgcn.kernel @unallocated_scc_unchanged {
+// Allocated SCC (`<0>`) has non-value semantics; the pass must not rewrite.
+// CHECK-LABEL: kernel @allocated_scc_through_unchanged
+// CHECK:         cf.br ^{{bb[0-9]+}}(%{{.*}} : !amdgcn.scc<0>)
+// CHECK:       ^{{bb[0-9]+}}(%{{.*}}: !amdgcn.scc<0>):
+amdgcn.kernel @allocated_scc_through_unchanged {
 ^bb0:
-  %scc = amdgcn.alloca : !amdgcn.scc<?>
-  cf.br ^bb1(%scc : !amdgcn.scc<?>)
-^bb1(%arg : !amdgcn.scc<?>):
+  %scc = amdgcn.alloca : !amdgcn.scc<0>
+  cf.br ^bb1(%scc : !amdgcn.scc<0>)
+^bb1(%arg : !amdgcn.scc<0>):
   amdgcn.end_kernel
 }
 

--- a/test/Dialect/AMDGCN/invalid.mlir
+++ b/test/Dialect/AMDGCN/invalid.mlir
@@ -151,7 +151,7 @@ func.func @alloca_composite_vcc() {
 // -----
 
 func.func @alloca_composite_exec() {
-  // expected-error@+1 {{'amdgcn.alloca' op result #0 must be allocatable register like type, but got '!amdgcn.exec'}}
+  // expected-error@+2 {{exec does not accept value semantics}}
   %0 = amdgcn.alloca : !amdgcn.exec
   return
 }

--- a/test/Dialect/AMDGCN/type-invalid.mlir
+++ b/test/Dialect/AMDGCN/type-invalid.mlir
@@ -23,3 +23,134 @@
 // size == 5 -> align to next power of 2 == 8 by default
 // expected-error@+1 {{index begin (3) must be aligned to align (8)}}
 !invalid_6 = !amdgcn.sgpr<[3 : 8]>
+
+// -----
+
+// EXEC rejects value semantics.
+// expected-error@+3 {{exec does not accept value semantics}}
+func.func @exec_value_semantics(
+  %arg0: !amdgcn.exec
+) { return }
+
+// -----
+
+// EXEC rejects unallocated semantics.
+func.func @exec_unalloc_semantics(
+  // expected-error@+1 {{exec does not accept unallocated semantics}}
+  %arg0: !amdgcn.exec<?>
+) { return }
+
+// -----
+
+// EXEC_LO rejects value semantics.
+// expected-error@+3 {{exec_lo does not accept value semantics}}
+func.func @exec_lo_value_semantics(
+  %arg0: !amdgcn.exec_lo
+) { return }
+
+// -----
+
+// EXEC_LO rejects unallocated semantics.
+func.func @exec_lo_unalloc_semantics(
+  // expected-error@+1 {{exec_lo does not accept unallocated semantics}}
+  %arg0: !amdgcn.exec_lo<?>
+) { return }
+
+// -----
+
+// EXEC_HI rejects value semantics.
+// expected-error@+3 {{exec_hi does not accept value semantics}}
+func.func @exec_hi_value_semantics(
+  %arg0: !amdgcn.exec_hi
+) { return }
+
+// -----
+
+// EXEC_HI rejects unallocated semantics.
+func.func @exec_hi_unalloc_semantics(
+  // expected-error@+1 {{exec_hi does not accept unallocated semantics}}
+  %arg0: !amdgcn.exec_hi<?>
+) { return }
+
+// -----
+
+// VCCZ rejects unallocated semantics.
+func.func @vccz_unalloc_semantics(
+  // expected-error@+1 {{vccz does not accept unallocated semantics}}
+  %arg0: !amdgcn.vccz<?>
+) { return }
+
+// -----
+
+// EXECZ rejects unallocated semantics.
+func.func @execz_unalloc_semantics(
+  // expected-error@+1 {{execz does not accept unallocated semantics}}
+  %arg0: !amdgcn.execz<?>
+) { return }
+
+// -----
+
+// All SREGs reject unallocated semantics (VCC).
+func.func @vcc_unalloc_semantics(
+  // expected-error@+1 {{vcc does not accept unallocated semantics}}
+  %arg0: !amdgcn.vcc<?>
+) { return }
+
+// -----
+
+// All SREGs reject unallocated semantics (VCC_LO).
+func.func @vcc_lo_unalloc_semantics(
+  // expected-error@+1 {{vcc_lo does not accept unallocated semantics}}
+  %arg0: !amdgcn.vcc_lo<?>
+) { return }
+
+// -----
+
+// All SREGs reject unallocated semantics (VCC_HI).
+func.func @vcc_hi_unalloc_semantics(
+  // expected-error@+1 {{vcc_hi does not accept unallocated semantics}}
+  %arg0: !amdgcn.vcc_hi<?>
+) { return }
+
+// -----
+
+// All SREGs reject unallocated semantics (M0).
+func.func @m0_unalloc_semantics(
+  // expected-error@+1 {{m0 does not accept unallocated semantics}}
+  %arg0: !amdgcn.m0<?>
+) { return }
+
+// -----
+
+// All SREGs reject unallocated semantics (SCC).
+func.func @scc_unalloc_semantics(
+  // expected-error@+1 {{scc does not accept unallocated semantics}}
+  %arg0: !amdgcn.scc<?>
+) { return }
+
+// -----
+
+// IsReadOnly register cannot be allocated with value semantics.
+func.func @alloca_readonly_vccz() {
+  // expected-error@+1 {{'amdgcn.alloca' op cannot allocate read-only register with value semantics}}
+  %0 = amdgcn.alloca : !amdgcn.vccz
+  return
+}
+
+// -----
+
+// IsReadOnly register cannot be allocated with value semantics.
+func.func @alloca_readonly_execz() {
+  // expected-error@+1 {{'amdgcn.alloca' op cannot allocate read-only register with value semantics}}
+  %0 = amdgcn.alloca : !amdgcn.execz
+  return
+}
+
+// -----
+
+// IsReadOnly register with allocated semantics is fine.
+func.func @alloca_readonly_allocated_ok() {
+  %0 = amdgcn.alloca : !amdgcn.vccz<0>
+  %1 = amdgcn.alloca : !amdgcn.execz<0>
+  return
+}


### PR DESCRIPTION
Add two new RegisterProps flags: IsStatusReg (for SCC, EXECZ, VCCZ)
and IsReadOnly (for EXECZ, VCCZ). Remove AcceptsUnallocatedSemantics
from all SREG types and restrict EXEC/EXECLo/EXECHi to allocated
semantics only. Add type verification for all SREGs and forbid
value-semantics alloca of IsReadOnly registers.

Co-authored-by: Cursor <cursoragent@cursor.com>
Signed-off-by: Fabian Mora <fabian.mora-cordero@amd.com>