### PR TITLE
[amdgcn] Add SpecialOperand extraction via getSpecialOperands

### DIFF
--- a/include/aster/Dialect/AMDGCN/IR/AMDGCNInstBase.td
+++ b/include/aster/Dialect/AMDGCN/IR/AMDGCNInstBase.td
@@ -53,6 +53,9 @@ def AMDInstTrait : InstructionTrait {
     }
 
     ArrayRef<ISAVersion> getISAVersions();
+
+    /// Get the special register operands of the instruction.
+    void getSpecialOperands(::llvm::SmallVectorImpl<::mlir::aster::SpecialOperand> &operands);
   }];
   let extraConcreteClassDefinition = [{
     OperandRange $cppClass::getInstOuts() {

--- a/include/aster/Dialect/AMDGCN/IR/AMDGCNTypeConstraints.td
+++ b/include/aster/Dialect/AMDGCN/IR/AMDGCNTypeConstraints.td
@@ -25,25 +25,28 @@ include "aster/Interfaces/DependentOpInterface.td"
 // Register type constraints (AMDReg)
 //===----------------------------------------------------------------------===//
 
-class AMDReg<string cppType, string name> :
+class AMDReg<string cppType, string name, bit _isSReg = false> :
   Type<CPred<"::llvm::isa<::mlir::aster::amdgcn::" # cppType # ">($_self)">,
        name # " type", "::mlir::aster::amdgcn::" # cppType>,
-  PrintOperand;
+  PrintOperand {
+  bit isSReg = _isSReg;
+}
 
 def AGPRType : AMDReg<"AGPRType", "AGPR">;
 def VGPRType : AMDReg<"VGPRType", "VGPR">;
 def SGPRType : AMDReg<"SGPRType", "SGPR">;
 
-def VCCType : AMDReg<"VCCType", "VCC">;
-def VCCLoType : AMDReg<"VCCLoType", "VCC Lo">;
-def VCCHiType : AMDReg<"VCCHiType", "VCC Hi">;
-def M0Type : AMDReg<"M0Type", "M0">;
-def EXECType : AMDReg<"EXECType", "EXEC">;
-def EXECLoType : AMDReg<"EXECLoType", "EXEC Lo">;
-def EXECHiType : AMDReg<"EXECHiType", "EXEC Hi">;
-def VCCZType : AMDReg<"VCCZType", "VCCZ">;
-def EXECZType : AMDReg<"EXECZType", "EXECZ">;
-def SCCType : AMDReg<"SCCType", "SCC">;
+// Special registers.
+def VCCType : AMDReg<"VCCType", "VCC", /*isSReg=*/true>;
+def VCCLoType : AMDReg<"VCCLoType", "VCC Lo", /*isSReg=*/true>;
+def VCCHiType : AMDReg<"VCCHiType", "VCC Hi", /*isSReg=*/true>;
+def M0Type : AMDReg<"M0Type", "M0", /*isSReg=*/true>;
+def EXECType : AMDReg<"EXECType", "EXEC", /*isSReg=*/true>;
+def EXECLoType : AMDReg<"EXECLoType", "EXEC Lo", /*isSReg=*/true>;
+def EXECHiType : AMDReg<"EXECHiType", "EXEC Hi", /*isSReg=*/true>;
+def VCCZType : AMDReg<"VCCZType", "VCCZ", /*isSReg=*/true>;
+def EXECZType : AMDReg<"EXECZType", "EXECZ", /*isSReg=*/true>;
+def SCCType : AMDReg<"SCCType", "SCC", /*isSReg=*/true>;
 
 //===----------------------------------------------------------------------===//
 // Special register constraint

--- a/include/aster/IR/Operand.h
+++ b/include/aster/IR/Operand.h
@@ -129,6 +129,18 @@ private:
   int32_t *segment = nullptr;
 };
 
+/// An operand that refers to a special register.
+struct SpecialOperand : Operand {
+  SpecialOperand() = default;
+  SpecialOperand(OpOperand &operand, bool isOutput, int32_t position)
+      : Operand(operand), isOutput(isOutput), position(position) {}
+
+  /// Whether this is an output operand (true) or input operand (false).
+  bool isOutput = false;
+  /// The index relative to the output or input operand list.
+  int32_t position = 0;
+};
+
 } // namespace mlir::aster
 
 #endif // ASTER_IR_OPERAND_H

--- a/include/aster/Interfaces/InstOpInterface.h
+++ b/include/aster/Interfaces/InstOpInterface.h
@@ -16,6 +16,7 @@
 #define ASTER_INTERFACES_INSTOPINTERFACE_H
 
 #include "aster/IR/OpSupport.h"
+#include "aster/IR/Operand.h"
 #include "aster/Interfaces/LivenessOpInterface.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/ValueRange.h"

--- a/include/aster/Interfaces/InstOpInterface.td
+++ b/include/aster/Interfaces/InstOpInterface.td
@@ -60,6 +60,14 @@ def InstOpInterface : OpInterface<"InstOpInterface", [LivenessOpInterface]> {
     InterfaceMethod<
       "Returns the operand and result information for the instruction",
       "InstOpInfo", "getInstInfo"
+    >,
+    InterfaceMethod<
+      "Get the special register operands of the instruction",
+      "void", "getSpecialOperands", (ins
+        "::llvm::SmallVectorImpl<::mlir::aster::SpecialOperand>&":$operands),
+      [{}], [{
+        /* default: no special operands */
+      }]
     >
   ];
   let verify = [{

--- a/tools/amdgcn-tblgen/InstMethodsGen.cpp
+++ b/tools/amdgcn-tblgen/InstMethodsGen.cpp
@@ -1151,6 +1151,77 @@ $_className::getInstProps() {
 }
 
 //===----------------------------------------------------------------------===//
+// getSpecialOperands generation
+//===----------------------------------------------------------------------===//
+
+/// Returns true if the type constraint record consists exclusively of special
+/// register types. Recurses into allowedTypes lists for AnyTypeOf.
+static bool isSpecialRegOnly(const llvm::Record *rec) {
+  if (rec->isSubClassOf("AMDReg"))
+    return rec->getValueAsBit("isSReg");
+  if (rec->isSubClassOf("AnyTypeOf")) {
+    const llvm::ListInit *allowedTypes =
+        rec->getValueAsListInit("allowedTypes");
+    if (allowedTypes->empty())
+      return false;
+    for (const llvm::Init *init : allowedTypes->getValues()) {
+      const auto *defInit = dyn_cast<llvm::DefInit>(init);
+      if (!defInit || !isSpecialRegOnly(defInit->getDef()))
+        return false;
+    }
+    return true;
+  }
+  return false;
+}
+
+/// Returns the effective constraint record for an operand, unwrapping Optional.
+static const llvm::Record *
+getEffectiveConstraintDef(const mlir::tblgen::NamedTypeConstraint &operand) {
+  const llvm::Record *rec = &operand.constraint.getDef();
+  if (operand.constraint.isOptional())
+    if (const llvm::Record *base = rec->getValueAsOptionalDef("baseType"))
+      return base;
+  return rec;
+}
+
+/// Generates the getSpecialOperands method definition for an instruction.
+/// The method is always emitted (even with an empty body) because the trait
+/// declares it in extraClassDeclaration, requiring a concrete definition.
+static void genGetSpecialOperands(const InstOp &instOp, StringRef className,
+                                  raw_ostream &os) {
+  const mlir::tblgen::Operator &op = instOp.getOperator();
+  int32_t numOutputs = instOp.getNumOutputs();
+  int32_t numInputs = instOp.getNumInputs();
+  mlir::tblgen::FmtContext ctx;
+  ctx.addSubst("_className", className);
+
+  os << mlir::tblgen::tgfmt(
+      R"(void $_className::getSpecialOperands(
+    ::llvm::SmallVectorImpl<::mlir::aster::SpecialOperand> &operands) {
+)",
+      &ctx);
+
+  for (int32_t i = 0; i < numOutputs; ++i) {
+    const llvm::Record *rec = getEffectiveConstraintDef(op.getOperand(i));
+    if (!isSpecialRegOnly(rec))
+      continue;
+    os << "  operands.emplace_back(getOperation()->getOpOperand(" << i
+       << "), /*isOutput=*/true, /*position=*/" << i << ");\n";
+  }
+
+  for (int32_t i = 0; i < numInputs; ++i) {
+    int32_t odsIdx = numOutputs + i;
+    const llvm::Record *rec = getEffectiveConstraintDef(op.getOperand(odsIdx));
+    if (!isSpecialRegOnly(rec))
+      continue;
+    os << "  operands.emplace_back(getOperation()->getOpOperand(" << odsIdx
+       << "), /*isOutput=*/false, /*position=*/" << i << ");\n";
+  }
+
+  os << "}\n\n";
+}
+
+//===----------------------------------------------------------------------===//
 // Top-level generators
 //===----------------------------------------------------------------------===//
 
@@ -1170,6 +1241,7 @@ static void genInstMethods(const llvm::Record *rec, raw_ostream &os) {
   genInferReturnTypes(instOp, className, os);
   genGetInstInfo(instOp, className, os);
   genGetInstProps(instOp, className, os);
+  genGetSpecialOperands(instOp, className, os);
 
   if (instOp.getGenInstAssemblyFormat()) {
     InstSegments segs = collectInstSegments(instOp);


### PR DESCRIPTION
Add infrastructure to identify and extract special register operands
(SCC, VCC, EXEC, M0, etc.) from instructions. This is needed for
downstream passes that must reason about implicit special register
usage.

- Add `isSReg` field to `AMDReg` tablegen class to tag special regs.
- Add `SpecialOperand` struct (derives from `Operand`) with output
  flag and dag-relative position.
- Add `getSpecialOperands` to `InstOpInterface` with a default no-op.
- Declare the method in `AMDInstTrait` and generate its definition in
  `amdgcn-tblgen` by inspecting operand type constraints recursively.

Co-authored-by: Cursor <cursoragent@cursor.com>
Signed-off-by: Fabian Mora <fabian.mora-cordero@amd.com>