### PR TITLE
[amdgcn] Add special register value promotion in bufferization

### DIFF
--- a/lib/Dialect/AMDGCN/Transforms/AMDGCNBufferization.cpp
+++ b/lib/Dialect/AMDGCN/Transforms/AMDGCNBufferization.cpp
@@ -16,6 +16,7 @@
 #include "aster/Dialect/AMDGCN/Transforms/Passes.h"
 #include "aster/Dialect/LSIR/IR/LSIRDialect.h"
 #include "aster/Dialect/LSIR/IR/LSIROps.h"
+#include "aster/IR/CFG.h"
 #include "aster/Interfaces/RegisterType.h"
 #include "mlir/Analysis/DataFlow/Utils.h"
 #include "mlir/Analysis/DataFlowFramework.h"
@@ -26,6 +27,7 @@
 #include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Transforms/CSE.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/ScopedHashTable.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/DebugLog.h"
 #include <cstdint>
@@ -45,12 +47,23 @@ using namespace mlir;
 using namespace mlir::aster;
 using namespace mlir::aster::amdgcn;
 
-/// Returns true if `type` is a special register (SCC, VCC, …) with value
+/// Returns true if `type` is a special register (SCC, VCC, ...) with value
 /// semantics, i.e. a register that must be tunnelled through an SGPR carrier.
 static bool isSpecialReg(Type type) {
   if (!type.hasTrait<SpecialRegTrait>())
     return false;
   return cast<RegisterTypeInterface>(type).hasValueSemantics();
+}
+
+/// Returns the SGPR carrier type for a given special register type.
+static RegisterTypeInterface getSGPRCarrier(Type sregTy) {
+  auto regTy = cast<RegisterTypeInterface>(sregTy);
+  int64_t sizeInBits = regTy.getSizeInBits();
+  assert(sizeInBits > 0 &&
+         sizeInBits <= 32 * std::numeric_limits<int16_t>::max() &&
+         "register size out of range");
+  int16_t words = static_cast<int16_t>((sizeInBits + 31) / 32);
+  return getSGPR(sregTy.getContext(), words);
 }
 
 namespace {
@@ -248,21 +261,15 @@ void BufferizationImpl::handleBlockArgument(RewriterBase &rewriter,
   Block *block = arg.getOwner();
 
   // Insert allocas to handle the breakage of the phi-node. For special
-  // registers (SCC, VCC, …) the phi carrier must be an SGPR because
+  // registers (SCC, VCC, ...) the phi carrier must be an SGPR because
   // unallocated SCC/VCC are not valid intermediaries.
   OpBuilder::InsertionGuard guard(rewriter);
   rewriter.setInsertionPointToStart(entryBlock);
   RegisterTypeInterface carrierTy;
   if (isSpecialReg(arg.getType())) {
-    int64_t sizeInBits = regTy.getSizeInBits();
-    assert(sizeInBits > 0 &&
-           sizeInBits <= 32 * std::numeric_limits<int16_t>::max() &&
-           "register size out of range");
-    int16_t words = static_cast<int16_t>((sizeInBits + 31) / 32);
     // Use the unallocated SGPR slot so the phi-forward copy has a resource
     // side-effect and is not eliminated as dead code.
-    carrierTy = cast<RegisterTypeInterface>(getSGPR(arg.getContext(), words))
-                    .getAsUnallocated();
+    carrierTy = getSGPRCarrier(arg.getType()).getAsUnallocated();
   } else {
     carrierTy = regTy.getAsUnallocated();
   }
@@ -453,6 +460,182 @@ static void canonicalizeSRegAllocas(IRRewriter &rewriter, Allocator &allocator,
   }
 }
 
+//===----------------------------------------------------------------------===//
+// SRegBufferization
+//===----------------------------------------------------------------------===//
+
+/// Returns true if the use of a special register value requires
+/// materialization (i.e., the use demands the physical special register).
+static bool requiresMaterialization(OpOperand &use) {
+  Operation *owner = use.getOwner();
+
+  // lsir.cond_br always requires the physical special register.
+  if (auto brOp = dyn_cast<lsir::CondBranchOp>(owner);
+      brOp &&
+      brOp.getConditionMutable().getOperandNumber() == use.getOperandNumber())
+    return true;
+
+  // For InstOpInterface, check if this operand is a special operand.
+  auto instOp = dyn_cast<InstOpInterface>(owner);
+  if (!instOp)
+    return false;
+
+  SmallVector<SpecialOperand> specials;
+  instOp.getSpecialOperands(specials);
+  for (SpecialOperand &sp : specials) {
+    if (sp.get() == &use)
+      return true;
+  }
+  return false;
+}
+
+namespace {
+/// Tracks the current definition of each special register type and detects
+/// clobbering. Values that are clobbered are promoted to SGPRs.
+struct SRegBufferization : CFGWalker<SRegBufferization> {
+  SRegBufferization(IRRewriter &rewriter, Allocator &allocator,
+                    DominanceInfo &domInfo)
+      : rewriter(rewriter), allocator(allocator), domInfo(domInfo) {}
+
+  LogicalResult run(FunctionOpInterface funcOp);
+  LogicalResult visitOp(Operation *op);
+  LogicalResult visitControlFlowEdge(const BranchPoint &branchPoint,
+                                     const Successor &successor);
+
+  /// Push a scope before descending into a branch so that definitions made
+  /// inside the branch are automatically undone when the scope is destroyed.
+  LogicalResult handleBranch(const BranchPoint &branchPoint,
+                             const Successor &successor);
+
+private:
+  /// Record a new definition of a special register, promoting any live prior
+  /// value that would be clobbered.
+  void recordDefinition(Value newDef, Type sregTy, Operation *insertBefore);
+
+  /// Promote a special register value to an SGPR. Inserts a copy before
+  /// `insertBefore` and rewrites uses dominated by the clobber point.
+  void promoteValue(Value sregVal, Operation *insertBefore);
+
+  /// Rewrite a single use of a promoted value, either amending or
+  /// materializing.
+  void rewriteUse(OpOperand &use, Value sgprVal, Type sregTy);
+
+  IRRewriter &rewriter;
+  Allocator &allocator;
+  DominanceInfo &domInfo;
+  /// Maps a special register type to its current live definition.
+  llvm::ScopedHashTable<Type, Value> currentDef;
+};
+} // namespace
+
+void SRegBufferization::recordDefinition(Value newDef, Type sregTy,
+                                         Operation *insertBefore) {
+  Value prevDef = currentDef.lookup(sregTy);
+  // If there is a live previous definition, promote it before it is
+  // clobbered.
+  if (prevDef && prevDef != newDef)
+    promoteValue(prevDef, insertBefore);
+  currentDef.insert(sregTy, newDef);
+}
+
+void SRegBufferization::promoteValue(Value sregVal, Operation *insertBefore) {
+  // Collect uses that need rewriting. Only rewrite uses that are dominated by
+  // the clobber point: same-block uses after the clobber, or uses in blocks
+  // dominated by the clobber's block.
+  Block *clobberBlock = insertBefore->getBlock();
+  SmallVector<OpOperand *> usesToRewrite;
+  for (OpOperand &use : sregVal.getUses()) {
+    Operation *owner = use.getOwner();
+    if (owner->getBlock() == clobberBlock) {
+      if (owner->isBeforeInBlock(insertBefore))
+        continue;
+      usesToRewrite.push_back(&use);
+    } else if (domInfo.dominates(clobberBlock, owner->getBlock())) {
+      usesToRewrite.push_back(&use);
+    }
+  }
+
+  // Nothing to promote if the clobbered value has no remaining uses.
+  if (usesToRewrite.empty())
+    return;
+
+  Type sregTy = sregVal.getType();
+  RegisterTypeInterface sgprTy = getSGPRCarrier(sregTy);
+  Location loc = sregVal.getLoc();
+
+  // Create an SGPR alloca and copy the special register value into it.
+  OpBuilder::InsertionGuard guard(rewriter);
+  rewriter.setInsertionPoint(insertBefore);
+  Value sgprSlot = createAllocation(rewriter, loc, sgprTy);
+  lsir::CopyOp copyOp = lsir::CopyOp::create(rewriter, loc, sgprSlot, sregVal);
+  Value sgprVal = copyOp.getTargetRes();
+
+  for (OpOperand *use : usesToRewrite)
+    rewriteUse(*use, sgprVal, sregTy);
+}
+
+void SRegBufferization::rewriteUse(OpOperand &use, Value sgprVal, Type sregTy) {
+  if (!requiresMaterialization(use)) {
+    // The use accepts an SGPR directly -- just amend the operand.
+    use.set(sgprVal);
+    return;
+  }
+
+  // The use requires the physical special register. Materialize it by copying
+  // the SGPR value back into the special register alloca.
+  OpBuilder::InsertionGuard guard(rewriter);
+  rewriter.setInsertionPoint(use.getOwner());
+  Value sregSlot =
+      allocator.getOrCreateAlloc(rewriter, sgprVal.getLoc(), sregTy);
+  lsir::CopyOp materialize =
+      lsir::CopyOp::create(rewriter, sgprVal.getLoc(), sregSlot, sgprVal);
+  use.set(materialize.getTargetRes());
+}
+
+LogicalResult SRegBufferization::visitOp(Operation *op) {
+  auto instOp = dyn_cast<InstOpInterface>(op);
+  if (!instOp)
+    return success();
+
+  // Scan all results for special register definitions.
+  for (OpResult result : instOp.getInstResults()) {
+    Type resultTy = result.getType();
+    if (!isSpecialReg(resultTy))
+      continue;
+    recordDefinition(result, resultTy, op);
+  }
+
+  return success();
+}
+
+LogicalResult
+SRegBufferization::visitControlFlowEdge(const BranchPoint &branchPoint,
+                                        const Successor &successor) {
+  if (!successor.isBlock())
+    return success();
+
+  Block *block = successor.getTarget<Block *>();
+  // Block arguments with special register types are definitions.
+  for (BlockArgument arg : block->getArguments()) {
+    if (!isSpecialReg(arg.getType()))
+      continue;
+    recordDefinition(arg, arg.getType(), &block->front());
+  }
+  return success();
+}
+
+LogicalResult SRegBufferization::handleBranch(const BranchPoint &branchPoint,
+                                              const Successor &successor) {
+  // Push a new scope so definitions made inside this branch are undone when
+  // the scope is destroyed, restoring the predecessor's state for siblings.
+  llvm::ScopedHashTableScope<Type, Value> scope(currentDef);
+  return CFGWalker<SRegBufferization>::handleBranch(branchPoint, successor);
+}
+
+LogicalResult SRegBufferization::run(FunctionOpInterface funcOp) {
+  return walk(funcOp);
+}
+
 /// Run the bufferization transform on the given function.
 static LogicalResult runOnFunction(FunctionOpInterface op,
                                    DominanceInfo &domInfo) {
@@ -484,6 +667,11 @@ static LogicalResult runOnFunction(FunctionOpInterface op,
   // Run the bufferization transform.
   BufferizationImpl impl(allocator, domInfo, *dpsResult, *livenessResult);
   impl.run(rewriter, op);
+
+  // Promote special register values that are clobbered by later definitions.
+  SRegBufferization sregImpl(rewriter, allocator, domInfo);
+  if (failed(sregImpl.run(op)))
+    return op->emitError() << "failed to run special register bufferization";
 
   return success();
 }

--- a/test/Dialect/AMDGCN/Transforms/bufferization-sreg.mlir
+++ b/test/Dialect/AMDGCN/Transforms/bufferization-sreg.mlir
@@ -1,0 +1,311 @@
+// RUN: aster-opt %s --aster-amdgcn-bufferization --split-input-file | FileCheck %s
+
+// Basic SCC clobber: two s_cmp_eq_i32 in sequence, first SCC used after second.
+// The first SCC value must be promoted to SGPR.
+
+// CHECK-LABEL: amdgcn.kernel @basic_scc_clobber {
+// CHECK:         %[[SCC_ALLOC:.*]] = alloca : !amdgcn.scc
+// CHECK:         %[[A:.*]] = alloca : !amdgcn.sgpr
+// CHECK:         %[[B:.*]] = alloca : !amdgcn.sgpr
+// CHECK:         %[[C:.*]] = alloca : !amdgcn.sgpr
+// CHECK:         %[[SCC0:.*]] = s_cmp_eq_i32 outs(%[[SCC_ALLOC]]) ins(%[[A]], %[[B]])
+// CHECK:         %[[PROMO:.*]] = alloca : !amdgcn.sgpr
+// CHECK:         %[[PROMOTED:.*]] = lsir.copy %[[PROMO]], %[[SCC0]]
+// CHECK:         %[[SCC1:.*]] = s_cmp_eq_i32 outs(%[[SCC_ALLOC]]) ins(%[[A]], %[[C]])
+// CHECK:         test_inst ins %[[PROMOTED]], %[[SCC1]]
+// CHECK:         end_kernel
+amdgcn.kernel @basic_scc_clobber {
+  %scc = alloca : !amdgcn.scc
+  %a = alloca : !amdgcn.sgpr
+  %b = alloca : !amdgcn.sgpr
+  %c = alloca : !amdgcn.sgpr
+  %scc0 = s_cmp_eq_i32 outs(%scc) ins(%a, %b) : outs(!amdgcn.scc) ins(!amdgcn.sgpr, !amdgcn.sgpr)
+  %scc1 = s_cmp_eq_i32 outs(%scc) ins(%a, %c) : outs(!amdgcn.scc) ins(!amdgcn.sgpr, !amdgcn.sgpr)
+  test_inst ins %scc0, %scc1 : (!amdgcn.scc, !amdgcn.scc) -> ()
+  end_kernel
+}
+
+// -----
+
+// No promotion needed: only the last SCC definition is used.
+// The first s_cmp_eq_i32 is dead and removed by CSE.
+
+// CHECK-LABEL: amdgcn.kernel @no_promotion_needed {
+// CHECK:         %[[SCC_ALLOC:.*]] = alloca : !amdgcn.scc
+// CHECK-NOT:     lsir.copy
+// CHECK:         %[[SCC1:.*]] = s_cmp_eq_i32 outs(%[[SCC_ALLOC]])
+// CHECK:         test_inst ins %[[SCC1]]
+// CHECK:         end_kernel
+amdgcn.kernel @no_promotion_needed {
+  %scc = alloca : !amdgcn.scc
+  %a = alloca : !amdgcn.sgpr
+  %b = alloca : !amdgcn.sgpr
+  %c = alloca : !amdgcn.sgpr
+  %scc0 = s_cmp_eq_i32 outs(%scc) ins(%a, %b) : outs(!amdgcn.scc) ins(!amdgcn.sgpr, !amdgcn.sgpr)
+  %scc1 = s_cmp_eq_i32 outs(%scc) ins(%a, %c) : outs(!amdgcn.scc) ins(!amdgcn.sgpr, !amdgcn.sgpr)
+  test_inst ins %scc1 : (!amdgcn.scc) -> ()
+  end_kernel
+}
+
+// -----
+
+// SCC clobber by s_and_b32: the SCC from s_cmp_eq_i32 must be promoted.
+// The use of scc0 is a general (non-special) operand of test_inst, so it is
+// amended to the promoted SGPR value.
+
+// CHECK-LABEL: amdgcn.kernel @scc_clobber_s_and {
+// CHECK:         %[[SCC_ALLOC:.*]] = alloca : !amdgcn.scc
+// CHECK:         %[[A:.*]] = alloca : !amdgcn.sgpr
+// CHECK:         %[[B:.*]] = alloca : !amdgcn.sgpr
+// CHECK:         %[[C:.*]] = alloca : !amdgcn.sgpr
+// CHECK:         %[[DST:.*]] = alloca : !amdgcn.sgpr
+// CHECK:         %[[SCC0:.*]] = s_cmp_eq_i32 outs(%[[SCC_ALLOC]]) ins(%[[A]], %[[B]])
+// CHECK:         %[[PROMO:.*]] = alloca : !amdgcn.sgpr
+// CHECK:         %[[PROMOTED:.*]] = lsir.copy %[[PROMO]], %[[SCC0]]
+// CHECK:         %[[AND_RES:.*]], %{{.*}} = s_and_b32 outs(%[[DST]], %[[SCC_ALLOC]]) ins(%[[A]], %[[C]])
+// CHECK:         test_inst ins %[[PROMOTED]], %[[AND_RES]]
+// CHECK:         end_kernel
+amdgcn.kernel @scc_clobber_s_and {
+  %scc = alloca : !amdgcn.scc
+  %a = alloca : !amdgcn.sgpr
+  %b = alloca : !amdgcn.sgpr
+  %c = alloca : !amdgcn.sgpr
+  %dst = alloca : !amdgcn.sgpr
+  %scc0 = s_cmp_eq_i32 outs(%scc) ins(%a, %b) : outs(!amdgcn.scc) ins(!amdgcn.sgpr, !amdgcn.sgpr)
+  %and, %scc1 = s_and_b32 outs(%dst, %scc) ins(%a, %c) : outs(!amdgcn.sgpr, !amdgcn.scc) ins(!amdgcn.sgpr, !amdgcn.sgpr)
+  test_inst ins %scc0, %and : (!amdgcn.scc, !amdgcn.sgpr) -> ()
+  end_kernel
+}
+
+// -----
+
+// Chain of SCC clobbers: three definitions with all used afterwards.
+// scc0 and scc1 must be promoted; scc2 stays in SCC.
+
+// CHECK-LABEL: amdgcn.kernel @chain_of_scc_clobbers {
+// CHECK:         %[[SCC_ALLOC:.*]] = alloca : !amdgcn.scc
+// CHECK:         %[[A:.*]] = alloca : !amdgcn.sgpr
+// CHECK:         %[[B:.*]] = alloca : !amdgcn.sgpr
+// CHECK:         %[[C:.*]] = alloca : !amdgcn.sgpr
+// CHECK:         %[[D:.*]] = alloca : !amdgcn.sgpr
+// CHECK:         %[[SCC0:.*]] = s_cmp_eq_i32 outs(%[[SCC_ALLOC]]) ins(%[[A]], %[[B]])
+// CHECK:         %[[PROMO0_ALLOC:.*]] = alloca : !amdgcn.sgpr
+// CHECK:         %[[PROMO0:.*]] = lsir.copy %[[PROMO0_ALLOC]], %[[SCC0]]
+// CHECK:         %[[SCC1:.*]] = s_cmp_eq_i32 outs(%[[SCC_ALLOC]]) ins(%[[A]], %[[C]])
+// CHECK:         %[[PROMO1_ALLOC:.*]] = alloca : !amdgcn.sgpr
+// CHECK:         %[[PROMO1:.*]] = lsir.copy %[[PROMO1_ALLOC]], %[[SCC1]]
+// CHECK:         %[[SCC2:.*]] = s_cmp_eq_i32 outs(%[[SCC_ALLOC]]) ins(%[[A]], %[[D]])
+// CHECK:         test_inst ins %[[PROMO0]], %[[PROMO1]], %[[SCC2]]
+// CHECK:         end_kernel
+amdgcn.kernel @chain_of_scc_clobbers {
+  %scc = alloca : !amdgcn.scc
+  %a = alloca : !amdgcn.sgpr
+  %b = alloca : !amdgcn.sgpr
+  %c = alloca : !amdgcn.sgpr
+  %d = alloca : !amdgcn.sgpr
+  %scc0 = s_cmp_eq_i32 outs(%scc) ins(%a, %b) : outs(!amdgcn.scc) ins(!amdgcn.sgpr, !amdgcn.sgpr)
+  %scc1 = s_cmp_eq_i32 outs(%scc) ins(%a, %c) : outs(!amdgcn.scc) ins(!amdgcn.sgpr, !amdgcn.sgpr)
+  %scc2 = s_cmp_eq_i32 outs(%scc) ins(%a, %d) : outs(!amdgcn.scc) ins(!amdgcn.sgpr, !amdgcn.sgpr)
+  test_inst ins %scc0, %scc1, %scc2 : (!amdgcn.scc, !amdgcn.scc, !amdgcn.scc) -> ()
+  end_kernel
+}
+
+// -----
+
+// Efficient codegen: only scc0 is promoted because scc1 is the latest
+// definition and can stay in SCC.
+
+// CHECK-LABEL: amdgcn.kernel @efficient_last_def {
+// CHECK:         %[[SCC_ALLOC:.*]] = alloca : !amdgcn.scc
+// CHECK:         %[[A:.*]] = alloca : !amdgcn.sgpr
+// CHECK:         %[[B:.*]] = alloca : !amdgcn.sgpr
+// CHECK:         %[[C:.*]] = alloca : !amdgcn.sgpr
+// CHECK:         %[[SCC0:.*]] = s_cmp_eq_i32 outs(%[[SCC_ALLOC]]) ins(%[[A]], %[[B]])
+// CHECK:         %[[PROMO:.*]] = alloca : !amdgcn.sgpr
+// CHECK:         %[[PROMOTED:.*]] = lsir.copy %[[PROMO]], %[[SCC0]]
+// CHECK:         %[[SCC1:.*]] = s_cmp_eq_i32 outs(%[[SCC_ALLOC]]) ins(%[[A]], %[[C]])
+// CHECK:         test_inst ins %[[PROMOTED]], %[[SCC1]]
+// CHECK:         end_kernel
+amdgcn.kernel @efficient_last_def {
+  %scc = alloca : !amdgcn.scc
+  %a = alloca : !amdgcn.sgpr
+  %b = alloca : !amdgcn.sgpr
+  %c = alloca : !amdgcn.sgpr
+  %scc0 = s_cmp_eq_i32 outs(%scc) ins(%a, %b) : outs(!amdgcn.scc) ins(!amdgcn.sgpr, !amdgcn.sgpr)
+  %scc1 = s_cmp_eq_i32 outs(%scc) ins(%a, %c) : outs(!amdgcn.scc) ins(!amdgcn.sgpr, !amdgcn.sgpr)
+  test_inst ins %scc0, %scc1 : (!amdgcn.scc, !amdgcn.scc) -> ()
+  end_kernel
+}
+
+// -----
+
+// VCC clobber: two v_cmp_eq_i32 in sequence, first VCC used after second.
+// VCC is a 64-bit composite register promoted to a 2-word SGPR.
+
+// CHECK-LABEL: amdgcn.kernel @vcc_clobber {
+// CHECK:         %[[VCC_LO:.*]] = alloca : !amdgcn.vcc_lo
+// CHECK:         %[[VCC_HI:.*]] = alloca : !amdgcn.vcc_hi
+// CHECK:         %[[VCC:.*]] = make_register_range %[[VCC_LO]], %[[VCC_HI]]
+// CHECK:         %[[V1:.*]] = alloca : !amdgcn.vgpr
+// CHECK:         %[[V2:.*]] = alloca : !amdgcn.vgpr
+// CHECK:         %[[VCC0:.*]] = v_cmp_eq_i32 outs(%[[VCC]])
+// CHECK:         %[[PROMO_LO:.*]] = alloca : !amdgcn.sgpr
+// CHECK:         %[[PROMO_HI:.*]] = alloca : !amdgcn.sgpr
+// CHECK:         %[[PROMO:.*]] = make_register_range %[[PROMO_LO]], %[[PROMO_HI]]
+// CHECK:         %[[PROMOTED:.*]] = lsir.copy %[[PROMO]], %[[VCC0]]
+// CHECK:         %[[VCC1:.*]] = v_cmp_eq_i32 outs(%[[VCC]])
+// CHECK:         test_inst ins %[[PROMOTED]], %[[VCC1]]
+// CHECK:         end_kernel
+amdgcn.kernel @vcc_clobber {
+  %vcc_lo = alloca : !amdgcn.vcc_lo
+  %vcc_hi = alloca : !amdgcn.vcc_hi
+  %vcc = make_register_range %vcc_lo, %vcc_hi : !amdgcn.vcc_lo, !amdgcn.vcc_hi
+  %a = alloca : !amdgcn.sgpr
+  %v1 = alloca : !amdgcn.vgpr
+  %v2 = alloca : !amdgcn.vgpr
+  %vcc0 = v_cmp_eq_i32 outs(%vcc) ins(%a, %v1) : outs(!amdgcn.vcc) ins(!amdgcn.sgpr, !amdgcn.vgpr)
+  %vcc1 = v_cmp_eq_i32 outs(%vcc) ins(%a, %v2) : outs(!amdgcn.vcc) ins(!amdgcn.sgpr, !amdgcn.vgpr)
+  test_inst ins %vcc0, %vcc1 : (!amdgcn.vcc, !amdgcn.vcc) -> ()
+  end_kernel
+}
+
+// -----
+
+// lsir.cond_br materialization: a promoted SCC is materialized back to the
+// special register for the branch condition.
+
+// CHECK-LABEL: amdgcn.kernel @cond_br_materialization {
+// CHECK:         %[[SCC_ALLOC:.*]] = alloca : !amdgcn.scc
+// CHECK:         %[[SCC0:.*]] = s_cmp_eq_i32 outs(%[[SCC_ALLOC]])
+// CHECK:         %[[PROMO:.*]] = alloca : !amdgcn.sgpr
+// CHECK:         %[[PROMOTED:.*]] = lsir.copy %[[PROMO]], %[[SCC0]]
+// CHECK:         %[[MATERIALIZED:.*]] = lsir.copy %[[SCC_ALLOC]], %[[PROMOTED]]
+// CHECK:         lsir.cond_br %[[MATERIALIZED]] : !amdgcn.scc
+amdgcn.kernel @cond_br_materialization {
+  %scc = alloca : !amdgcn.scc
+  %a = alloca : !amdgcn.sgpr
+  %b = alloca : !amdgcn.sgpr
+  %c = alloca : !amdgcn.sgpr
+  %scc0 = s_cmp_eq_i32 outs(%scc) ins(%a, %b) : outs(!amdgcn.scc) ins(!amdgcn.sgpr, !amdgcn.sgpr)
+  %scc1 = s_cmp_eq_i32 outs(%scc) ins(%a, %c) : outs(!amdgcn.scc) ins(!amdgcn.sgpr, !amdgcn.sgpr)
+  test_inst ins %scc1 : (!amdgcn.scc) -> ()
+  lsir.cond_br %scc0 : !amdgcn.scc, ^bb1, ^bb2
+^bb1:
+  end_kernel
+^bb2:
+  end_kernel
+}
+
+// -----
+
+// Cross-block SCC clobber: SCC defined in entry, clobbered only in one
+// successor. The other successor uses SCC directly without promotion.
+
+func.func private @rand() -> i1
+// CHECK-LABEL: amdgcn.kernel @cross_block_scc {
+// CHECK:         %[[SCC_ALLOC:.*]] = alloca : !amdgcn.scc
+// CHECK:         %[[SCC0:.*]] = s_cmp_eq_i32 outs(%[[SCC_ALLOC]])
+// CHECK:         cf.cond_br
+// CHECK:       ^bb1:
+// CHECK:         %[[PROMO:.*]] = alloca : !amdgcn.sgpr
+// CHECK:         %[[PROMOTED:.*]] = lsir.copy %[[PROMO]], %[[SCC0]]
+// CHECK:         %[[SCC1:.*]] = s_cmp_eq_i32 outs(%[[SCC_ALLOC]])
+// CHECK:         test_inst ins %[[PROMOTED]], %[[SCC1]]
+// CHECK:         end_kernel
+// CHECK:       ^bb2:
+// CHECK:         test_inst ins %[[SCC0]]
+// CHECK:         end_kernel
+amdgcn.kernel @cross_block_scc {
+  %scc = alloca : !amdgcn.scc
+  %a = alloca : !amdgcn.sgpr
+  %b = alloca : !amdgcn.sgpr
+  %c = alloca : !amdgcn.sgpr
+  %cond = func.call @rand() : () -> i1
+  %scc0 = s_cmp_eq_i32 outs(%scc) ins(%a, %b) : outs(!amdgcn.scc) ins(!amdgcn.sgpr, !amdgcn.sgpr)
+  cf.cond_br %cond, ^bb1, ^bb2
+^bb1:
+  %scc1 = s_cmp_eq_i32 outs(%scc) ins(%a, %c) : outs(!amdgcn.scc) ins(!amdgcn.sgpr, !amdgcn.sgpr)
+  test_inst ins %scc0, %scc1 : (!amdgcn.scc, !amdgcn.scc) -> ()
+  end_kernel
+^bb2:
+  test_inst ins %scc0 : (!amdgcn.scc) -> ()
+  end_kernel
+}
+
+// -----
+
+// Diamond CFG: SCC defined in entry, clobbered in both branches, used in both.
+// Each branch independently promotes scc0 before its own clobber.
+
+func.func private @rand() -> i1
+// CHECK-LABEL: amdgcn.kernel @diamond_both_clobber {
+// CHECK:         %[[SCC_ALLOC:.*]] = alloca : !amdgcn.scc
+// CHECK:         %[[SCC0:.*]] = s_cmp_eq_i32 outs(%[[SCC_ALLOC]])
+// CHECK:         cf.cond_br
+// CHECK:       ^bb1:
+// CHECK:         %[[PROMO1:.*]] = alloca : !amdgcn.sgpr
+// CHECK:         %[[PROMOTED1:.*]] = lsir.copy %[[PROMO1]], %[[SCC0]]
+// CHECK:         %[[SCC1:.*]] = s_cmp_eq_i32 outs(%[[SCC_ALLOC]])
+// CHECK:         test_inst ins %[[PROMOTED1]], %[[SCC1]]
+// CHECK:       ^bb2:
+// CHECK:         %[[PROMO2:.*]] = alloca : !amdgcn.sgpr
+// CHECK:         %[[PROMOTED2:.*]] = lsir.copy %[[PROMO2]], %[[SCC0]]
+// CHECK:         %[[SCC2:.*]] = s_cmp_eq_i32 outs(%[[SCC_ALLOC]])
+// CHECK:         test_inst ins %[[PROMOTED2]], %[[SCC2]]
+amdgcn.kernel @diamond_both_clobber {
+  %scc = alloca : !amdgcn.scc
+  %a = alloca : !amdgcn.sgpr
+  %b = alloca : !amdgcn.sgpr
+  %c = alloca : !amdgcn.sgpr
+  %d = alloca : !amdgcn.sgpr
+  %cond = func.call @rand() : () -> i1
+  %scc0 = s_cmp_eq_i32 outs(%scc) ins(%a, %b) : outs(!amdgcn.scc) ins(!amdgcn.sgpr, !amdgcn.sgpr)
+  cf.cond_br %cond, ^bb1, ^bb2
+^bb1:
+  %scc1 = s_cmp_eq_i32 outs(%scc) ins(%a, %c) : outs(!amdgcn.scc) ins(!amdgcn.sgpr, !amdgcn.sgpr)
+  test_inst ins %scc0, %scc1 : (!amdgcn.scc, !amdgcn.scc) -> ()
+  cf.br ^merge
+^bb2:
+  %scc2 = s_cmp_eq_i32 outs(%scc) ins(%a, %d) : outs(!amdgcn.scc) ins(!amdgcn.sgpr, !amdgcn.sgpr)
+  test_inst ins %scc0, %scc2 : (!amdgcn.scc, !amdgcn.scc) -> ()
+  cf.br ^merge
+^merge:
+  end_kernel
+}
+
+// -----
+
+// Multiple special register types live simultaneously: SCC and VCC are
+// independently tracked and promoted without interfering.
+
+// CHECK-LABEL: amdgcn.kernel @scc_and_vcc_simultaneous {
+// CHECK:         %[[SCC_ALLOC:.*]] = alloca : !amdgcn.scc
+// CHECK:         %[[SCC0:.*]] = s_cmp_eq_i32 outs(%[[SCC_ALLOC]])
+// CHECK:         %[[VCC0:.*]] = v_cmp_eq_i32
+// CHECK:         %[[SCC_PROMO:.*]] = alloca : !amdgcn.sgpr
+// CHECK:         %[[SCC_PROMOTED:.*]] = lsir.copy %[[SCC_PROMO]], %[[SCC0]]
+// CHECK:         %[[SCC1:.*]] = s_cmp_eq_i32 outs(%[[SCC_ALLOC]])
+// CHECK:         %[[VCC_PROMO_LO:.*]] = alloca : !amdgcn.sgpr
+// CHECK:         %[[VCC_PROMO_HI:.*]] = alloca : !amdgcn.sgpr
+// CHECK:         %[[VCC_PROMO:.*]] = make_register_range %[[VCC_PROMO_LO]], %[[VCC_PROMO_HI]]
+// CHECK:         %[[VCC_PROMOTED:.*]] = lsir.copy %[[VCC_PROMO]], %[[VCC0]]
+// CHECK:         %[[VCC1:.*]] = v_cmp_eq_i32
+// CHECK:         test_inst ins %[[SCC_PROMOTED]], %[[VCC_PROMOTED]], %[[SCC1]], %[[VCC1]]
+// CHECK:         end_kernel
+amdgcn.kernel @scc_and_vcc_simultaneous {
+  %scc = alloca : !amdgcn.scc
+  %vcc_lo = alloca : !amdgcn.vcc_lo
+  %vcc_hi = alloca : !amdgcn.vcc_hi
+  %vcc = make_register_range %vcc_lo, %vcc_hi : !amdgcn.vcc_lo, !amdgcn.vcc_hi
+  %a = alloca : !amdgcn.sgpr
+  %b = alloca : !amdgcn.sgpr
+  %c = alloca : !amdgcn.sgpr
+  %v1 = alloca : !amdgcn.vgpr
+  %v2 = alloca : !amdgcn.vgpr
+  %scc0 = s_cmp_eq_i32 outs(%scc) ins(%a, %b) : outs(!amdgcn.scc) ins(!amdgcn.sgpr, !amdgcn.sgpr)
+  %vcc0 = v_cmp_eq_i32 outs(%vcc) ins(%a, %v1) : outs(!amdgcn.vcc) ins(!amdgcn.sgpr, !amdgcn.vgpr)
+  %scc1 = s_cmp_eq_i32 outs(%scc) ins(%a, %c) : outs(!amdgcn.scc) ins(!amdgcn.sgpr, !amdgcn.sgpr)
+  %vcc1 = v_cmp_eq_i32 outs(%vcc) ins(%a, %v2) : outs(!amdgcn.vcc) ins(!amdgcn.sgpr, !amdgcn.vgpr)
+  test_inst ins %scc0, %vcc0, %scc1, %vcc1 : (!amdgcn.scc, !amdgcn.vcc, !amdgcn.scc, !amdgcn.vcc) -> ()
+  end_kernel
+}


### PR DESCRIPTION
Walk the CFG to track live special register definitions. When a new
definition clobbers a prior live value, promote the old value to an
SGPR via lsir.copy. Uses that can accept an SGPR are amended directly;
uses that require the physical special register (getSpecialOperands or
lsir.cond_br) get a materialization copy back.

Co-authored-by: Cursor <cursoragent@cursor.com>
Signed-off-by: Fabian Mora <fabian.mora-cordero@amd.com>