### PR TITLE
[amdgcn] Allocate special registers at reg 0 in ToRegisterSemantics

### DIFF
--- a/include/aster/Interfaces/RegisterType.h
+++ b/include/aster/Interfaces/RegisterType.h
@@ -143,6 +143,11 @@ public:
     return RegisterRange(regBegin.getAsValue(), size(), indexAlignment);
   }
 
+  /// Get the register range as an allocated range.
+  RegisterRange getAsAllocatedRange(int16_t reg) const {
+    return RegisterRange(Register(reg), size(), indexAlignment);
+  }
+
   /// Check if the register range is equal to another register range.
   bool operator==(const RegisterRange &other) const {
     return regBegin == other.regBegin && rangeSize == other.rangeSize &&

--- a/include/aster/Interfaces/RegisterType.td
+++ b/include/aster/Interfaces/RegisterType.td
@@ -107,6 +107,11 @@ def RegisterTypeInterface : TypeInterface<"RegisterTypeInterface", [
       return $_type.cloneRegisterType($_type.getAsRange().getAsValueRange());
     }
 
+    /// This method returns a clone of the register type with allocated semantics.
+    ::mlir::aster::RegisterTypeInterface getAsAllocated(int16_t reg) const {
+      return $_type.cloneRegisterType($_type.getAsRange().getAsAllocatedRange(reg));
+    }
+
     /// Returns true if this register type represents a range of registers.
     bool isRegisterRange() const {
       return $_type.getAsRange().size() > 1;

--- a/lib/Dialect/AMDGCN/Transforms/ToRegisterSemantics.cpp
+++ b/lib/Dialect/AMDGCN/Transforms/ToRegisterSemantics.cpp
@@ -171,9 +171,11 @@ AllocaOpPattern::matchAndRewrite(AllocaOp op, PatternRewriter &rewriter) const {
     return rewriter.notifyMatchFailure(op,
                                        "alloca does not have value semantics");
 
-  // Create a new alloca with unallocated semantics.
-  AllocaOp newAlloca =
-      AllocaOp::create(rewriter, op.getLoc(), regTy.getAsUnallocated());
+  // Create a new alloca with non-value semantics.
+  RegisterTypeInterface newRegTy = regTy.hasTrait<SpecialRegTrait>()
+                                       ? regTy.getAsAllocated(0)
+                                       : regTy.getAsUnallocated();
+  AllocaOp newAlloca = AllocaOp::create(rewriter, op.getLoc(), newRegTy);
 
   // Create a tagged cast to the original type.
   auto castOp = createTaggedCast(rewriter, op.getLoc(), op.getType(),

--- a/test/Dialect/AMDGCN/Transforms/to-register-semantics.mlir
+++ b/test/Dialect/AMDGCN/Transforms/to-register-semantics.mlir
@@ -454,3 +454,26 @@ func.func @dealloc() -> !amdgcn.vgpr {
   %r = amdgcn.dealloc_cast %a : !amdgcn.vgpr<?>
   return %r : !amdgcn.vgpr
 }
+
+// -----
+
+// CHECK-LABEL:   func.func @special_reg_alloca_to_allocated() {
+// CHECK-DAG:       %[[SCC:.*]] = amdgcn.alloca : !amdgcn.scc<0>
+// CHECK-DAG:       %[[VCC_LO:.*]] = amdgcn.alloca : !amdgcn.vcc_lo<0>
+// CHECK-DAG:       %[[VCC_HI:.*]] = amdgcn.alloca : !amdgcn.vcc_hi<0>
+// CHECK:           %[[VCC:.*]] = amdgcn.make_register_range %[[VCC_LO]], %[[VCC_HI]] : !amdgcn.vcc_lo<0>, !amdgcn.vcc_hi<0>
+// CHECK-DAG:       %[[SGPR:.*]] = amdgcn.alloca : !amdgcn.sgpr<?>
+// CHECK:           amdgcn.test_inst outs %[[SGPR]] : (!amdgcn.sgpr<?>) -> ()
+// CHECK:           amdgcn.test_inst ins %[[SCC]], %[[VCC]], %[[SGPR]] : (!amdgcn.scc<0>, !amdgcn.vcc<0>, !amdgcn.sgpr<?>) -> ()
+// CHECK:           return
+// CHECK:         }
+func.func @special_reg_alloca_to_allocated() {
+  %0 = amdgcn.alloca : !amdgcn.scc
+  %1 = amdgcn.alloca : !amdgcn.vcc_lo
+  %2 = amdgcn.alloca : !amdgcn.vcc_hi
+  %3 = amdgcn.make_register_range %1, %2 : !amdgcn.vcc_lo, !amdgcn.vcc_hi
+  %4 = amdgcn.alloca : !amdgcn.sgpr
+  %5 = amdgcn.test_inst outs %4 : (!amdgcn.sgpr) -> !amdgcn.sgpr
+  amdgcn.test_inst ins %0, %3, %5 : (!amdgcn.scc, !amdgcn.vcc, !amdgcn.sgpr) -> ()
+  func.return
+}


### PR DESCRIPTION
Special registers (SCC, VCC, EXEC, etc.) are singletons so
"unallocated" semantics is meaningless for them. Convert
value-semantic special-register allocas to allocated-at-0 instead.

Co-authored-by: Cursor <cursoragent@cursor.com>
Signed-off-by: Fabian Mora <fabian.mora-cordero@amd.com>