### PR TITLE
[amdgcn] Add PreColoringLegalization pass

### DIFF
--- a/include/aster/Dialect/AMDGCN/Transforms/AMDGCNPasses.td
+++ b/include/aster/Dialect/AMDGCN/Transforms/AMDGCNPasses.td
@@ -101,6 +101,19 @@ def RegisterColoring : Pass<"amdgcn-register-coloring"> {
   ];
 }
 
+def PreColoringLegalization : Pass<"amdgcn-pre-coloring-legalization"> {
+  let summary = "Legalize operations before register coloring";
+  let description = [{
+    This pass legalizes operations that cannot be directly lowered through
+    register coloring. It should run after register DCE and before register
+    coloring.
+  }];
+  let dependentDialects = [
+    "mlir::aster::amdgcn::AMDGCNDialect",
+    "mlir::arith::ArithDialect"
+  ];
+}
+
 def InstructionSchedulingAutoschedule : Pass<"amdgcn-instruction-scheduling-autoschedule"> {
   let summary = "Apply autoschedule rules to operations without explicit schedules";
   let description = [{

--- a/lib/Dialect/AMDGCN/Transforms/CMakeLists.txt
+++ b/lib/Dialect/AMDGCN/Transforms/CMakeLists.txt
@@ -16,6 +16,7 @@ add_mlir_library(AMDGCNTransforms
   OptimizeAMDGCN.cpp
   OptimizeInterferenceGraph.cpp
   Pipelines.cpp
+  PreColoringLegalization.cpp
   PreloadLibrary.cpp
   RegisterColoring.cpp
   RegisterDCE.cpp

--- a/lib/Dialect/AMDGCN/Transforms/Pipelines.cpp
+++ b/lib/Dialect/AMDGCN/Transforms/Pipelines.cpp
@@ -88,6 +88,7 @@ static void buildRegAllocPassPipeline(OpPassManager &pm,
   // Post-condition of to-register-semantics is now enforced by
   // KernelOp::verifyRegions() via the normal_forms attribute set by the pass.
   pm.addPass(createRegisterDCE());
+  pm.addPass(createPreColoringLegalization());
   RegisterColoringOptions coloringOpts;
   coloringOpts.buildMode = options.buildMode;
   coloringOpts.optimize = options.optimize;

--- a/lib/Dialect/AMDGCN/Transforms/PreColoringLegalization.cpp
+++ b/lib/Dialect/AMDGCN/Transforms/PreColoringLegalization.cpp
@@ -1,0 +1,70 @@
+//===- PreColoringLegalization.cpp - Legalize ops before register coloring ===//
+//
+// Copyright 2025 The ASTER Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "aster/Dialect/AMDGCN/IR/AMDGCNOps.h"
+#include "aster/Dialect/AMDGCN/Transforms/Passes.h"
+#include "aster/Dialect/LSIR/IR/LSIROps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/PatternMatch.h"
+
+#define DEBUG_TYPE "amdgcn-pre-coloring-legalization"
+
+namespace mlir::aster {
+namespace amdgcn {
+#define GEN_PASS_DEF_PRECOLORINGLEGALIZATION
+#include "aster/Dialect/AMDGCN/Transforms/Passes.h.inc"
+} // namespace amdgcn
+} // namespace mlir::aster
+
+using namespace mlir;
+using namespace mlir::aster;
+using namespace mlir::aster::amdgcn;
+
+namespace {
+//===----------------------------------------------------------------------===//
+// PreColoringLegalization pass
+//===----------------------------------------------------------------------===//
+struct PreColoringLegalization
+    : public amdgcn::impl::PreColoringLegalizationBase<
+          PreColoringLegalization> {
+  using Base::Base;
+  void runOnOperation() override;
+};
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// Legalization helpers
+//===----------------------------------------------------------------------===//
+
+// Legalize lsir.copy where the target is an SCC register and the source is an
+// SGPR into s_cmp_eq_u32, setting SCC to (sgpr == 1).
+static void legalizeScalarCopyToSCC(lsir::CopyOp copyOp, IRRewriter &rewriter) {
+  Value target = copyOp.getTarget();
+  Value source = copyOp.getSource();
+  if (!isa<SCCType>(target.getType()) || !isa<SGPRType>(source.getType()))
+    return;
+
+  rewriter.setInsertionPoint(copyOp);
+  Location loc = copyOp.getLoc();
+  Value c1 = arith::ConstantIntOp::create(rewriter, loc, 1, 32);
+  SCmpEqU32::create(rewriter, loc, target, source, c1);
+  rewriter.eraseOp(copyOp);
+}
+
+//===----------------------------------------------------------------------===//
+// PreColoringLegalization pass
+//===----------------------------------------------------------------------===//
+void PreColoringLegalization::runOnOperation() {
+  Operation *op = getOperation();
+  IRRewriter rewriter(op->getContext());
+  op->walk(
+      [&](lsir::CopyOp copyOp) { legalizeScalarCopyToSCC(copyOp, rewriter); });
+}

--- a/test/Dialect/AMDGCN/Transforms/pre-coloring-legalization.mlir
+++ b/test/Dialect/AMDGCN/Transforms/pre-coloring-legalization.mlir
@@ -1,0 +1,44 @@
+// RUN: aster-opt %s --amdgcn-pre-coloring-legalization --split-input-file | FileCheck %s
+
+// Verify that lsir.copy from an SGPR to SCC is replaced with s_cmp_eq_u32.
+// CHECK-LABEL: func.func @sgpr_to_scc
+// CHECK:         %[[SCC:.*]] = amdgcn.alloca : !amdgcn.scc<0>
+// CHECK:         %[[SGPR:.*]] = amdgcn.alloca : !amdgcn.sgpr<?>
+// CHECK:         %[[C1:.*]] = arith.constant 1 : i32
+// CHECK:         amdgcn.s_cmp_eq_u32 outs(%[[SCC]]) ins(%[[SGPR]], %[[C1]])
+// CHECK-NOT:     lsir.copy
+func.func @sgpr_to_scc() {
+  %scc = amdgcn.alloca : !amdgcn.scc<0>
+  %sgpr = amdgcn.alloca : !amdgcn.sgpr<?>
+  lsir.copy %scc, %sgpr : !amdgcn.scc<0>, !amdgcn.sgpr<?>
+  return
+}
+
+// -----
+
+// Verify that lsir.copy from VGPR to VGPR is not changed.
+// CHECK-LABEL: func.func @vgpr_to_vgpr
+// CHECK:         lsir.copy
+func.func @vgpr_to_vgpr() {
+  %dst = amdgcn.alloca : !amdgcn.vgpr<?>
+  %src = amdgcn.alloca : !amdgcn.vgpr<?>
+  lsir.copy %dst, %src : !amdgcn.vgpr<?>, !amdgcn.vgpr<?>
+  amdgcn.test_inst ins %dst : (!amdgcn.vgpr<?>) -> ()
+  return
+}
+
+// -----
+
+// Verify that lsir.copy from SCC to SGPR (the opposite direction) is not
+// changed.
+// CHECK-LABEL: func.func @scc_to_sgpr
+// CHECK:         lsir.copy
+func.func @scc_to_sgpr() {
+  %scc = amdgcn.alloca : !amdgcn.scc<0>
+  %sgpr = amdgcn.alloca : !amdgcn.sgpr<?>
+  amdgcn.s_cmp_eq_i32 outs(%scc) ins(%sgpr, %sgpr) : outs(!amdgcn.scc<0>) ins(!amdgcn.sgpr<?>, !amdgcn.sgpr<?>)
+  %promo = amdgcn.alloca : !amdgcn.sgpr<?>
+  lsir.copy %promo, %scc : !amdgcn.sgpr<?>, !amdgcn.scc<0>
+  amdgcn.test_inst ins %promo : (!amdgcn.sgpr<?>) -> ()
+  return
+}


### PR DESCRIPTION
Legalizes lsir.copy where the target is SCC and the source is an SGPR
into s_cmp_eq_u32 scc, sgpr, 1. The pass runs after register DCE and
before register coloring.

Co-authored-by: Cursor <cursoragent@cursor.com>
Signed-off-by: Fabian Mora <fabian.mora-cordero@amd.com>