### PR TITLE
[interfaces] Add SelectInstOpInterface and MovInstOpInterface

### DIFF
--- a/include/aster/Dialect/AMDGCN/IR/AMDGCNInstBase.td
+++ b/include/aster/Dialect/AMDGCN/IR/AMDGCNInstBase.td
@@ -18,6 +18,7 @@
 include "aster/Dialect/AMDGCN/IR/AMDGCNDialect.td"
 include "aster/Dialect/AMDGCN/IR/AMDGCNTypeConstraints.td"
 include "aster/IR/Inst.td"
+include "aster/Interfaces/InstOpInterfaces.td"
 
 //===----------------------------------------------------------------------===//
 // Base instruction class for AMDGCN instructions.

--- a/include/aster/Dialect/AMDGCN/IR/AMDGCNOps.h
+++ b/include/aster/Dialect/AMDGCN/IR/AMDGCNOps.h
@@ -26,6 +26,7 @@
 #include "aster/Interfaces/AllocaOpInterface.h"
 #include "aster/Interfaces/DependentOpInterface.h"
 #include "aster/Interfaces/GPUFuncInterface.h"
+#include "aster/Interfaces/InstOpInterfaces.h"
 #include "aster/Interfaces/LivenessOpInterface.h"
 #include "aster/Interfaces/ModuleOpInterface.h"
 #include "aster/Interfaces/OperandBundleOpInterface.h"

--- a/include/aster/Dialect/AMDGCN/IR/Instructions/SOP.td
+++ b/include/aster/Dialect/AMDGCN/IR/Instructions/SOP.td
@@ -660,7 +660,7 @@ def SMulI32 : SOP2Out1In2Inst<"s_mul_i32"> {
 
 #ifndef SOP2OUT1IN3INST_DEF
 #define SOP2OUT1IN3INST_DEF
-class SOP2Out1In3Inst<string mnemonic, list<Type> dst0Type, list<Type> src0Type, list<Type> src1Type> : AMDISAInstruction<mnemonic> {
+class SOP2Out1In3Inst<string mnemonic, list<Type> dst0Type, list<Type> src0Type, list<Type> src1Type, list<Trait> opTraits = []> : AMDISAInstruction<mnemonic, opTraits> {
   let props = [IsSALU, IsSOP2];
   let archs = [CDNA3Isa, CDNA4Isa];
   let outputs = (ins
@@ -683,13 +683,21 @@ class SOP2Out1In3Inst<string mnemonic, list<Type> dst0Type, list<Type> src0Type,
 def SCselectB32 : SOP2Out1In3Inst<"s_cselect_b32",
     /*dst0=*/[OneSGPROrSRegType],
     /*src0=*/[OneSGPROrSRegOrLitConstOf<InlineLitFP<[F32]>, InlineLitInt<[IntType<32>]>, F32, IntType<32>>],
-    /*src1=*/[OneSGPROrSRegOrLitConstOf<InlineLitFP<[F32]>, InlineLitInt<[IntType<32>]>, F32, IntType<32>>]
+    /*src1=*/[OneSGPROrSRegOrLitConstOf<InlineLitFP<[F32]>, InlineLitInt<[IntType<32>]>, F32, IntType<32>>],
+    /*opTraits=*/[SelectInstOpInterface]
   > {
   let description = [{
     Select the first input if SCC is true otherwise select the second input,
     then store the selected input into a scalar register.
   }];
   let encodings = [InstEnc<[ENC_SOP2_CDNA3, ENC_SOP2_CDNA4], 0b0001010>];
+  let instExtraClassDeclaration = [{
+    ::mlir::aster::Operand getDestOperand() { return getDst0Mutable(); }
+    ::mlir::Value getDestResult() { return getDst0Res(); }
+    ::mlir::aster::Operand getConditionOperand() { return getSccSrcMutable(); }
+    ::mlir::aster::Operand getTrueValueOperand() { return getSrc0Mutable(); }
+    ::mlir::aster::Operand getFalseValueOperand() { return getSrc1Mutable(); }
+  }];
 }
 #endif // SCSELECTB32_DEF
 
@@ -698,19 +706,27 @@ def SCselectB32 : SOP2Out1In3Inst<"s_cselect_b32",
 def SCselectB64 : SOP2Out1In3Inst<"s_cselect_b64",
     /*dst0=*/[TwoSGPROrSRegType],
     /*src0=*/[TwoSGPROrSRegOrConstType],
-    /*src1=*/[TwoSGPROrSRegOrConstType]
+    /*src1=*/[TwoSGPROrSRegOrConstType],
+    /*opTraits=*/[SelectInstOpInterface]
   > {
   let description = [{
     Select the first input if SCC is true otherwise select the second input,
     then store the selected input into a scalar register.
   }];
   let encodings = [InstEnc<[ENC_SOP2_CDNA3, ENC_SOP2_CDNA4], 0b0001011>];
+  let instExtraClassDeclaration = [{
+    ::mlir::aster::Operand getDestOperand() { return getDst0Mutable(); }
+    ::mlir::Value getDestResult() { return getDst0Res(); }
+    ::mlir::aster::Operand getConditionOperand() { return getSccSrcMutable(); }
+    ::mlir::aster::Operand getTrueValueOperand() { return getSrc0Mutable(); }
+    ::mlir::aster::Operand getFalseValueOperand() { return getSrc1Mutable(); }
+  }];
 }
 #endif // SCSELECTB64_DEF
 
 #ifndef SOP1OUT1IN1INST_DEF
 #define SOP1OUT1IN1INST_DEF
-class SOP1Out1In1Inst<string mnemonic, list<Type> dst0Type, list<Type> src0Type> : AMDISAInstruction<mnemonic> {
+class SOP1Out1In1Inst<string mnemonic, list<Type> dst0Type, list<Type> src0Type, list<Trait> opTraits = []> : AMDISAInstruction<mnemonic, opTraits> {
   let props = [IsSALU, IsSOP1];
   let archs = [CDNA3Isa, CDNA4Isa];
   let outputs = (ins
@@ -730,12 +746,18 @@ class SOP1Out1In1Inst<string mnemonic, list<Type> dst0Type, list<Type> src0Type>
 #define SMOVB32_DEF
 def SMovB32 : SOP1Out1In1Inst<"s_mov_b32",
     /*dst0=*/[OneSGPROrSRegType],
-    /*src0=*/[OneSGPROrSRegOrLitConstOf<InlineLitFP<[F32]>, InlineLitInt<[IntType<32>]>, F32, IntType<32>>]
+    /*src0=*/[OneSGPROrSRegOrLitConstOf<InlineLitFP<[F32]>, InlineLitInt<[IntType<32>]>, F32, IntType<32>>],
+    /*opTraits=*/[MovInstOpInterface]
   > {
   let description = [{
     Move scalar input into a scalar register.
   }];
   let encodings = [InstEnc<[ENC_SOP1_CDNA3, ENC_SOP1_CDNA4], 0b00000000>];
+  let instExtraClassDeclaration = [{
+    ::mlir::aster::Operand getDestOperand() { return getDst0Mutable(); }
+    ::mlir::Value getDestResult() { return getDst0Res(); }
+    ::mlir::aster::Operand getSrcOperand() { return getSrc0Mutable(); }
+  }];
 }
 #endif // SMOVB32_DEF
 
@@ -743,12 +765,18 @@ def SMovB32 : SOP1Out1In1Inst<"s_mov_b32",
 #define SMOVB64_DEF
 def SMovB64 : SOP1Out1In1Inst<"s_mov_b64",
     /*dst0=*/[TwoSGPROrSRegType],
-    /*src0=*/[TwoSGPROrSRegOrConstType]
+    /*src0=*/[TwoSGPROrSRegOrConstType],
+    /*opTraits=*/[MovInstOpInterface]
   > {
   let description = [{
     Move scalar input into a scalar register.
   }];
   let encodings = [InstEnc<[ENC_SOP1_CDNA3, ENC_SOP1_CDNA4], 0b00000001>];
+  let instExtraClassDeclaration = [{
+    ::mlir::aster::Operand getDestOperand() { return getDst0Mutable(); }
+    ::mlir::Value getDestResult() { return getDst0Res(); }
+    ::mlir::aster::Operand getSrcOperand() { return getSrc0Mutable(); }
+  }];
 }
 #endif // SMOVB64_DEF
 

--- a/include/aster/Dialect/AMDGCN/IR/Instructions/VOP.td
+++ b/include/aster/Dialect/AMDGCN/IR/Instructions/VOP.td
@@ -1384,7 +1384,7 @@ def VCmpNeI32 : VCmpInst<"v_cmp_ne_i32"> {
 
 #ifndef VCNDMASKB32_DEF
 #define VCNDMASKB32_DEF
-def VCndmaskB32 : AMDISAInstruction<"v_cndmask_b32"> {
+def VCndmaskB32 : AMDISAInstruction<"v_cndmask_b32", [SelectInstOpInterface]> {
   let props = [IsVALU];
   let archs = [CDNA3Isa, CDNA4Isa];
   let description = [{
@@ -1416,12 +1416,19 @@ def VCndmaskB32 : AMDISAInstruction<"v_cndmask_b32"> {
     ASMString<[ENC_VOP2_CDNA3, ENC_VOP2_CDNA4], "${mnemonic} $dst0, $src0, $src1, $src2">,
     ASMString<[ENC_VOP3_CDNA3], "${mnemonic}_e64 $dst0, $src0, $src1, $src2">
   ];
+  let instExtraClassDeclaration = [{
+    ::mlir::aster::Operand getDestOperand() { return getDst0Mutable(); }
+    ::mlir::Value getDestResult() { return getDst0Res(); }
+    ::mlir::aster::Operand getConditionOperand() { return getSrc2Mutable(); }
+    ::mlir::aster::Operand getTrueValueOperand() { return getSrc1Mutable(); }
+    ::mlir::aster::Operand getFalseValueOperand() { return getSrc0Mutable(); }
+  }];
 }
 #endif // VCNDMASKB32_DEF
 
 #ifndef VOP1OUT1IN1INST_DEF
 #define VOP1OUT1IN1INST_DEF
-class VOP1Out1In1Inst<string mnemonic, list<Type> dst0Type, list<Type> src0Type> : AMDISAInstruction<mnemonic> {
+class VOP1Out1In1Inst<string mnemonic, list<Type> dst0Type, list<Type> src0Type, list<Trait> opTraits = []> : AMDISAInstruction<mnemonic, opTraits> {
   let props = [IsVALU];
   let archs = [CDNA3Isa, CDNA4Isa];
   let outputs = (ins
@@ -1575,7 +1582,8 @@ def VCvtU32F32 : VOP1Out1In1Inst<"v_cvt_u32_f32",
 def VMovB32 : VOP1Out1In1Inst<"v_mov_b32",
     /*dst0=*/[VGPROf<1>],
     /*src0=*/[OneGPROrSRegOrConstType,
-             OneGPROrSRegOrConstOf<InlineLitFP<[F32]>, InlineLitInt<[IntType<32>]>>]
+             OneGPROrSRegOrConstOf<InlineLitFP<[F32]>, InlineLitInt<[IntType<32>]>>],
+    /*opTraits=*/[MovInstOpInterface]
   > {
   let description = [{
     Move 32-bit data from a vector input into a vector register.
@@ -1588,6 +1596,11 @@ def VMovB32 : VOP1Out1In1Inst<"v_mov_b32",
       OneGPROrSRegOrConstOf<InlineLitFP<[F32]>, InlineLitInt<[IntType<32>]>>:$src0
     )>
   ];
+  let instExtraClassDeclaration = [{
+    ::mlir::aster::Operand getDestOperand() { return getDst0Mutable(); }
+    ::mlir::Value getDestResult() { return getDst0Res(); }
+    ::mlir::aster::Operand getSrcOperand() { return getSrc0Mutable(); }
+  }];
 }
 #endif // VMOVB32_DEF
 

--- a/include/aster/Dialect/LSIR/IR/LSIROps.h
+++ b/include/aster/Dialect/LSIR/IR/LSIROps.h
@@ -20,6 +20,7 @@
 #include "aster/IR/InstImpl.h"
 #include "aster/Interfaces/AllocaOpInterface.h"
 #include "aster/Interfaces/InstOpInterface.h"
+#include "aster/Interfaces/InstOpInterfaces.h"
 #include "aster/Interfaces/RegisterType.h"
 #include "mlir/Bytecode/BytecodeOpInterface.h"
 #include "mlir/Dialect/Ptr/IR/MemorySpaceInterfaces.h"

--- a/include/aster/Dialect/LSIR/IR/LSIROps.td
+++ b/include/aster/Dialect/LSIR/IR/LSIROps.td
@@ -19,6 +19,7 @@ include "aster/Dialect/LSIR/IR/LSIRDialect.td"
 include "aster/Dialect/LSIR/IR/LSIRAttrs.td"
 include "aster/Dialect/LSIR/IR/LSIRTypes.td"
 include "aster/Interfaces/AllocaOpInterface.td"
+include "aster/Interfaces/InstOpInterfaces.td"
 include "mlir/Dialect/Arith/IR/ArithBase.td"
 include "mlir/Dialect/Ptr/IR/MemorySpaceInterfaces.td"
 include "mlir/Interfaces/ControlFlowInterfaces.td"
@@ -311,7 +312,8 @@ def LSIR_CmpIOp : LSIR_InstOp<"cmpi", [InstInferType, PureInst]> {
 // CopyOp
 //===----------------------------------------------------------------------===//
 
-def LSIR_CopyOp : LSIR_InstOp<"copy", [InstInferType, PureInst]> {
+def LSIR_CopyOp : LSIR_InstOp<"copy", [InstInferType, MovInstOpInterface,
+    PureInst]> {
   let summary = "Copy operation";
   let description = [{
     The `lsir.copy` operation copies a value from a source register to a target
@@ -328,6 +330,11 @@ def LSIR_CopyOp : LSIR_InstOp<"copy", [InstInferType, PureInst]> {
     $target `,` $source attr-dict `:` type($target) `,` type($source)
   }];
   let hasCanonicalizeMethod = 1;
+  let extraClassDeclaration = [{
+    ::mlir::aster::Operand getDestOperand() { return getTargetMutable(); }
+    ::mlir::Value getDestResult() { return getTargetRes(); }
+    ::mlir::aster::Operand getSrcOperand() { return getSourceMutable(); }
+  }];
 }
 
 //===----------------------------------------------------------------------===//
@@ -610,7 +617,7 @@ def LSIR_MinimumFOp : BinaryFOp<"minimumf"> {
 //===----------------------------------------------------------------------===//
 
 def LSIR_MovOp : LSIR_InstOp<"mov", [
-    PureInst, InstInferType
+    InstInferType, MovInstOpInterface, PureInst
   ]> {
   let summary = "Move operation";
   let description = [{
@@ -625,6 +632,11 @@ def LSIR_MovOp : LSIR_InstOp<"mov", [
   let inputs = (ins IntFloatOrRegType:$value);
   let assemblyFormat = [{
     $dst `,` $value attr-dict `:` type($dst) `,` type($value)
+  }];
+  let extraClassDeclaration = [{
+    ::mlir::aster::Operand getDestOperand() { return getDstMutable(); }
+    ::mlir::Value getDestResult() { return getDstRes(); }
+    ::mlir::aster::Operand getSrcOperand() { return getValueMutable(); }
   }];
 }
 
@@ -795,7 +807,9 @@ def LSIR_RemUIOp : BinaryIOp<"remui"> {
 // SelectOp
 //===----------------------------------------------------------------------===//
 
-def LSIR_SelectOp : LSIR_InstOp<"select", [PureInst, InstInferType]> {
+def LSIR_SelectOp : LSIR_InstOp<"select", [
+    InstInferType, PureInst, SelectInstOpInterface
+  ]> {
   let summary = "Select operation";
   let description = [{
     The `lsir.select` operation selects between two values based on a register
@@ -816,6 +830,13 @@ def LSIR_SelectOp : LSIR_InstOp<"select", [PureInst, InstInferType]> {
   let assemblyFormat = [{
     $dst `,` $condition `,` $true_value `,` $false_value attr-dict
     `:` type($dst) `,` type($condition) `,` type($true_value) `,` type($false_value)
+  }];
+  let extraClassDeclaration = [{
+    ::mlir::aster::Operand getDestOperand() { return getDstMutable(); }
+    ::mlir::Value getDestResult() { return getDstRes(); }
+    ::mlir::aster::Operand getConditionOperand() { return getConditionMutable(); }
+    ::mlir::aster::Operand getTrueValueOperand() { return getTrueValueMutable(); }
+    ::mlir::aster::Operand getFalseValueOperand() { return getFalseValueMutable(); }
   }];
 }
 

--- a/include/aster/Interfaces/CMakeLists.txt
+++ b/include/aster/Interfaces/CMakeLists.txt
@@ -15,6 +15,11 @@ mlir_tablegen(InstOpInterface.h.inc -gen-op-interface-decls)
 mlir_tablegen(InstOpInterface.cpp.inc -gen-op-interface-defs)
 add_public_tablegen_target(InstOpInterfaceIncGen)
 
+set(LLVM_TARGET_DEFINITIONS InstOpInterfaces.td)
+mlir_tablegen(InstOpInterfaces.h.inc -gen-op-interface-decls)
+mlir_tablegen(InstOpInterfaces.cpp.inc -gen-op-interface-defs)
+add_public_tablegen_target(AsterInstOpInterfacesIncGen)
+
 set(LLVM_TARGET_DEFINITIONS MemorySpaceConstraints.td)
 mlir_tablegen(MemorySpaceConstraints.h.inc -gen-attr-interface-decls)
 mlir_tablegen(MemorySpaceConstraints.cpp.inc -gen-attr-interface-defs)

--- a/include/aster/Interfaces/InstOpInterfaces.h
+++ b/include/aster/Interfaces/InstOpInterfaces.h
@@ -1,0 +1,23 @@
+//===- InstOpInterfaces.h - Inst Op Interfaces ------------------*- C++ -*-===//
+//
+// Copyright 2026 The ASTER Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines shared instruction operation interfaces for Aster.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ASTER_INTERFACES_INSTOPINTERFACES_H
+#define ASTER_INTERFACES_INSTOPINTERFACES_H
+
+#include "aster/IR/Operand.h"
+#include "aster/Interfaces/InstOpInterface.h"
+
+#include "aster/Interfaces/InstOpInterfaces.h.inc"
+
+#endif // ASTER_INTERFACES_INSTOPINTERFACES_H

--- a/include/aster/Interfaces/InstOpInterfaces.td
+++ b/include/aster/Interfaces/InstOpInterfaces.td
@@ -1,0 +1,66 @@
+//===- InstOpInterfaces.td - Inst Op Interfaces ------------*- tablegen -*-===//
+//
+// Copyright 2026 The ASTER Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines shared instruction operation interfaces for Aster.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ASTER_INTERFACES_INSTOPINTERFACES_TD
+#define ASTER_INTERFACES_INSTOPINTERFACES_TD
+
+include "mlir/IR/OpBase.td"
+include "aster/Interfaces/InstOpInterface.td"
+
+//===----------------------------------------------------------------------===//
+// Select instruction interface
+//===----------------------------------------------------------------------===//
+
+def SelectInstOpInterface : OpInterface<"SelectInstOpInterface",
+    [InstOpInterface]> {
+  let cppNamespace = "::mlir::aster";
+  let description = [{
+    Interface for select-like instructions that choose between two values
+    based on a condition.
+  }];
+  let methods = [
+    InterfaceMethod<"Get the destination operand.",
+      "::mlir::aster::Operand", "getDestOperand">,
+    InterfaceMethod<"Get the destination result.",
+      "::mlir::Value", "getDestResult">,
+    InterfaceMethod<"Get the condition operand.",
+      "::mlir::aster::Operand", "getConditionOperand">,
+    InterfaceMethod<"Get the true-value operand.",
+      "::mlir::aster::Operand", "getTrueValueOperand">,
+    InterfaceMethod<"Get the false-value operand.",
+      "::mlir::aster::Operand", "getFalseValueOperand">
+  ];
+}
+
+//===----------------------------------------------------------------------===//
+// Mov instruction interface
+//===----------------------------------------------------------------------===//
+
+def MovInstOpInterface : OpInterface<"MovInstOpInterface", [InstOpInterface]> {
+  let cppNamespace = "::mlir::aster";
+  let description = [{
+    Interface for move/copy-like instructions that transfer a value from one
+    register to another without any computation.
+  }];
+  let methods = [
+    InterfaceMethod<"Get the destination operand.",
+      "::mlir::aster::Operand", "getDestOperand">,
+    InterfaceMethod<"Get the destination result.",
+      "::mlir::Value", "getDestResult">,
+    InterfaceMethod<"Get the source operand.",
+      "::mlir::aster::Operand", "getSrcOperand">
+  ];
+}
+
+#endif // ASTER_INTERFACES_INSTOPINTERFACES_TD

--- a/lib/Interfaces/CMakeLists.txt
+++ b/lib/Interfaces/CMakeLists.txt
@@ -3,6 +3,7 @@ set(LLVM_OPTIONAL_SOURCES
   DependentOpInterface.cpp
   GPUFuncInterface.cpp
   InstOpInterface.cpp
+  InstOpInterfaces.cpp
   LivenessOpInterface.cpp
   MemorySpaceConstraints.cpp
   ModuleOpInterface.cpp
@@ -20,6 +21,7 @@ add_mlir_library(AsterInterfaces
   DependentOpInterface.cpp
   GPUFuncInterface.cpp
   InstOpInterface.cpp
+  InstOpInterfaces.cpp
   LivenessOpInterface.cpp
   MemorySpaceConstraints.cpp
   ModuleOpInterface.cpp
@@ -32,6 +34,7 @@ add_mlir_library(AsterInterfaces
 
   DEPENDS
   AllocaOpInterfaceIncGen
+  AsterInstOpInterfacesIncGen
   AsterInterfacesIncGen
   GPUFuncInterfaceIncGen
   InstOpInterfaceIncGen

--- a/lib/Interfaces/InstOpInterfaces.cpp
+++ b/lib/Interfaces/InstOpInterfaces.cpp
@@ -1,0 +1,16 @@
+//===- InstOpInterfaces.cpp - Inst Op Interfaces ----------------*- C++ -*-===//
+//
+// Copyright 2026 The ASTER Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "aster/Interfaces/InstOpInterfaces.h"
+
+using namespace mlir;
+using namespace mlir::aster;
+
+#include "aster/Interfaces/InstOpInterfaces.cpp.inc"


### PR DESCRIPTION
Add two dialect-neutral interfaces in aster/Interfaces that derive from
InstOpInterface:
- SelectInstOpInterface: dest operand, result, condition, true/false values.
- MovInstOpInterface: dest operand, result, source operand.

Attach SelectInstOpInterface to lsir::select, amdgcn::VCndmaskB32,
amdgcn::SCselectB32, and amdgcn::SCselectB64.

Attach MovInstOpInterface to lsir::copy, lsir::mov, amdgcn::VMovB32,
amdgcn::SMovB32, and amdgcn::SMovB64.

Also add opTraits forwarding parameters to the SOP2Out1In3Inst,
SOP1Out1In1Inst, and VOP1Out1In1Inst base classes to allow per-def
interface attachment.

Co-Authored-By: Claude Sonnet 4 <noreply@anthropic.com>
Signed-off-by: Fabian Mora <fabian.mora-cordero@amd.com>