### PR TITLE
[amdgcn] Use interface rewriter patterns for select and mov

### DIFF
--- a/lib/Dialect/AMDGCN/Transforms/LegalizeOperands.cpp
+++ b/lib/Dialect/AMDGCN/Transforms/LegalizeOperands.cpp
@@ -42,37 +42,31 @@ struct LegalizeOperands
 };
 
 //===----------------------------------------------------------------------===//
-// SelectLegalizePattern
+// VGPRSelectInstLegalizePattern
 //===----------------------------------------------------------------------===//
 
-struct SelectLegalizePattern : public OpRewritePattern<lsir::SelectOp> {
-  using OpRewritePattern::OpRewritePattern;
-  LogicalResult matchAndRewrite(lsir::SelectOp op,
+// Handles VALU select ops (non-SCC condition) where the true-value operand
+// must be materialized into a VGPR (VOP2 src1 must be VGPR, VOP3 must be
+// inline).
+struct VGPRSelectInstLegalizePattern
+    : public OpInterfaceRewritePattern<SelectInstOpInterface> {
+  using Base::Base;
+
+  LogicalResult matchAndRewrite(SelectInstOpInterface op,
                                 PatternRewriter &rewriter) const override;
 };
 
 //===----------------------------------------------------------------------===//
-// SCselectLegalizePattern
+// SGPRSelectInstLegalizePattern
 //===----------------------------------------------------------------------===//
 
-// SOP2 allows at most one literal; materialize src0 into a register.
-template <typename OpTy, int bitWidth>
-struct SCselectLegalizePattern : public OpRewritePattern<OpTy> {
-  using OpRewritePattern<OpTy>::OpRewritePattern;
-  LogicalResult matchAndRewrite(OpTy op,
-                                PatternRewriter &rewriter) const override;
-};
+// Handles SALU select ops (SCC condition) where two non-inline constants
+// require materializing the true-value operand (SOP2 at-most-one-literal rule).
+struct SGPRSelectInstLegalizePattern
+    : public OpInterfaceRewritePattern<SelectInstOpInterface> {
+  using Base::Base;
 
-using SCselectB32LegalizePattern = SCselectLegalizePattern<SCselectB32, 32>;
-using SCselectB64LegalizePattern = SCselectLegalizePattern<SCselectB64, 64>;
-
-//===----------------------------------------------------------------------===//
-// VCndmaskB32LegalizePattern
-//===----------------------------------------------------------------------===//
-
-struct VCndmaskB32LegalizePattern : public OpRewritePattern<VCndmaskB32> {
-  using OpRewritePattern::OpRewritePattern;
-  LogicalResult matchAndRewrite(VCndmaskB32 op,
+  LogicalResult matchAndRewrite(SelectInstOpInterface op,
                                 PatternRewriter &rewriter) const override;
 };
 
@@ -91,95 +85,64 @@ static std::optional<int64_t> getConstInt(Value v, int width) {
 static bool isInlineInt(int64_t val) { return val >= -16 && val <= 64; }
 
 //===----------------------------------------------------------------------===//
-// SelectLegalizePattern
+// VGPRSelectInstLegalizePattern
 //===----------------------------------------------------------------------===//
 
-LogicalResult
-SelectLegalizePattern::matchAndRewrite(lsir::SelectOp op,
-                                       PatternRewriter &rewriter) const {
+LogicalResult VGPRSelectInstLegalizePattern::matchAndRewrite(
+    SelectInstOpInterface op, PatternRewriter &rewriter) const {
+  if (isa<SCCType>(op.getConditionOperand().getType()))
+    return failure();
+  Value trueVal = op.getTrueValueOperand().getValue();
+  std::optional<int64_t> trueConst = getConstInt(trueVal, 32);
+  if (!trueConst || isInlineInt(*trueConst))
+    return failure();
   MLIRContext *ctx = rewriter.getContext();
-  Location loc = op.getLoc();
+  Location loc = op->getLoc();
+  Value out = createAllocation(rewriter, loc, getVGPR(ctx));
+  Value movResult = VMovB32::create(rewriter, loc, out, trueVal).getDst0Res();
+  rewriter.modifyOpInPlace(
+      op, [&]() { op.getTrueValueOperand().get()->set(movResult); });
+  return success();
+}
 
-  if (isa<VCCType>(op.getCondition().getType())) {
-    // VOP2 src1 must be VGPR; VOP3 requires inline. Materialize into a VGPR.
-    auto trueConst = getConstInt(op.getTrueValue(), 32);
-    if (!trueConst || isInlineInt(*trueConst))
-      return failure();
-    Value out = createAllocation(rewriter, loc, getVGPR(ctx));
-    Value movResult =
-        VMovB32::create(rewriter, loc, out, op.getTrueValue()).getDst0Res();
-    rewriter.modifyOpInPlace(
-        op, [&]() { op.getTrueValueMutable().assign(movResult); });
-    return success();
+//===----------------------------------------------------------------------===//
+// SGPRSelectInstLegalizePattern
+//===----------------------------------------------------------------------===//
+
+LogicalResult SGPRSelectInstLegalizePattern::matchAndRewrite(
+    SelectInstOpInterface op, PatternRewriter &rewriter) const {
+  if (!isa<SCCType>(op.getConditionOperand().getType()))
+    return failure();
+  Value trueVal = op.getTrueValueOperand().getValue();
+  Value falseVal = op.getFalseValueOperand().getValue();
+  // Try 32-bit first, then 64-bit.
+  std::optional<int64_t> trueConst = getConstInt(trueVal, 32);
+  std::optional<int64_t> falseConst = getConstInt(falseVal, 32);
+  int bitWidth = 32;
+  if (!trueConst && !falseConst) {
+    trueConst = getConstInt(trueVal, 64);
+    falseConst = getConstInt(falseVal, 64);
+    bitWidth = 64;
   }
-
-  // SOP2 allows at most one literal; materialize true_value into an SGPR.
-  auto trueConst = getConstInt(op.getTrueValue(), 32);
-  auto falseConst = getConstInt(op.getFalseValue(), 32);
   if (!trueConst || !falseConst || isInlineInt(*trueConst) ||
       isInlineInt(*falseConst))
     return failure();
-  Value out = createAllocation(rewriter, loc, getSGPR(ctx));
-  Value movResult =
-      SMovB32::create(rewriter, loc, getSGPR(ctx), out, op.getTrueValue())
-          .getDst0Res();
-  rewriter.modifyOpInPlace(
-      op, [&]() { op.getTrueValueMutable().assign(movResult); });
-  return success();
-}
-
-//===----------------------------------------------------------------------===//
-// SCselectLegalizePattern
-//===----------------------------------------------------------------------===//
-
-template <typename OpTy, int bitWidth>
-LogicalResult SCselectLegalizePattern<OpTy, bitWidth>::matchAndRewrite(
-    OpTy op, PatternRewriter &rewriter) const {
-  auto src0Const = getConstInt(op.getSrc0(), bitWidth);
-  auto src1Const = getConstInt(op.getSrc1(), bitWidth);
-  if (!src0Const || !src1Const || isInlineInt(*src0Const) ||
-      isInlineInt(*src1Const))
-    return failure();
-
   MLIRContext *ctx = rewriter.getContext();
-  Location loc = op.getLoc();
-  if constexpr (bitWidth == 32) {
+  Location loc = op->getLoc();
+  Value movResult;
+  if (bitWidth == 32) {
     RegisterTypeInterface sgprTy = getSGPR(ctx);
     Value out = createAllocation(rewriter, loc, sgprTy);
-    Value movResult =
-        SMovB32::create(rewriter, loc, sgprTy, out, op.getSrc0()).getDst0Res();
-    rewriter.modifyOpInPlace(op,
-                             [&]() { op.getSrc0Mutable().assign(movResult); });
-    return success();
+    movResult =
+        SMovB32::create(rewriter, loc, sgprTy, out, trueVal).getDst0Res();
+  } else {
+    RegisterTypeInterface sgprTy = getSGPR(ctx, 2);
+    Value out = createAllocation(rewriter, loc, sgprTy);
+    movResult =
+        SMovB64::create(rewriter, loc, sgprTy, out, trueVal).getDst0Res();
   }
-  RegisterTypeInterface sgprTy = getSGPR(ctx, 2);
-  Value out = createAllocation(rewriter, loc, sgprTy);
-  Value movResult =
-      SMovB64::create(rewriter, loc, sgprTy, out, op.getSrc0()).getDst0Res();
-  rewriter.modifyOpInPlace(op,
-                           [&]() { op.getSrc0Mutable().assign(movResult); });
-  return success();
-}
-
-//===----------------------------------------------------------------------===//
-// VCndmaskB32LegalizePattern
-//===----------------------------------------------------------------------===//
-
-LogicalResult
-VCndmaskB32LegalizePattern::matchAndRewrite(VCndmaskB32 op,
-                                            PatternRewriter &rewriter) const {
-  // VOP2 src1 must be VGPR; VOP3 requires inline. Materialize into a VGPR.
-  auto src1Const = getConstInt(op.getSrc1(), 32);
-  if (!src1Const || isInlineInt(*src1Const))
-    return failure();
-
-  MLIRContext *ctx = rewriter.getContext();
-  Location loc = op.getLoc();
-  Value out = createAllocation(rewriter, loc, getVGPR(ctx));
-  Value movResult =
-      VMovB32::create(rewriter, loc, out, op.getSrc1()).getDst0Res();
-  rewriter.modifyOpInPlace(op,
-                           [&]() { op.getSrc1Mutable().assign(movResult); });
+  rewriter.modifyOpInPlace(
+      op, [&]() { op.getTrueValueOperand().get()->set(movResult); });
   return success();
 }
 
@@ -189,8 +152,7 @@ VCndmaskB32LegalizePattern::matchAndRewrite(VCndmaskB32 op,
 
 void LegalizeOperands::runOnOperation() {
   RewritePatternSet patterns(&getContext());
-  patterns.add<SelectLegalizePattern, SCselectB32LegalizePattern,
-               SCselectB64LegalizePattern, VCndmaskB32LegalizePattern>(
+  patterns.add<VGPRSelectInstLegalizePattern, SGPRSelectInstLegalizePattern>(
       &getContext());
   if (failed(applyPatternsGreedily(
           getOperation(), FrozenRewritePatternSet(std::move(patterns)))))

--- a/lib/Dialect/AMDGCN/Transforms/RegisterColoring.cpp
+++ b/lib/Dialect/AMDGCN/Transforms/RegisterColoring.cpp
@@ -166,39 +166,14 @@ struct RegInterferenceOpPattern : public OpRewritePattern<RegInterferenceOp> {
 struct CopyOpPattern : public OpRewritePattern<lsir::CopyOp> {
   using Base::Base;
 
-  /// Find the max allocated VGPR register number in the enclosing function.
-  /// Returns -1 if no allocated VGPRs are found.
-  static int findMaxAllocatedVGPR(Operation *op) {
-    int maxVGPR = -1;
-    auto funcOp = op->getParentOfType<FunctionOpInterface>();
-    if (!funcOp)
-      return maxVGPR;
-    funcOp->walk([&](AllocaOp alloca) {
-      if (auto vgprTy = dyn_cast<VGPRType>(alloca.getType())) {
-        if (vgprTy.hasAllocatedSemantics()) {
-          int regNum = vgprTy.getReg().getRegister();
-          maxVGPR = std::max(maxVGPR, regNum);
-        }
-      }
-    });
-    return maxVGPR;
-  }
-
   LogicalResult matchAndRewrite(lsir::CopyOp op,
                                 PatternRewriter &rewriter) const override;
 };
 
-struct VMovB32Pattern : public OpRewritePattern<VMovB32> {
+struct MovInstOpPattern : public OpInterfaceRewritePattern<MovInstOpInterface> {
   using Base::Base;
 
-  LogicalResult matchAndRewrite(VMovB32 op,
-                                PatternRewriter &rewriter) const override;
-};
-
-struct SMovB32Pattern : public OpRewritePattern<SMovB32> {
-  using Base::Base;
-
-  LogicalResult matchAndRewrite(SMovB32 op,
+  LogicalResult matchAndRewrite(MovInstOpInterface op,
                                 PatternRewriter &rewriter) const override;
 };
 } // namespace
@@ -597,17 +572,7 @@ LogicalResult CopyOpPattern::matchAndRewrite(lsir::CopyOp op,
       return;
     }
     if (tgtTy.getRegisterKind() == RegisterKind::AGPR) {
-      // AGPR->AGPR copy: no direct instruction on CDNA3/CDNA4.
-      // Must go through VGPR intermediate: read AGPR->VGPR, write VGPR->AGPR.
-      // Allocate a scratch VGPR past all used VGPRs to avoid conflicts.
-      // TODO: evaluate whether this would be too prohibitive a use case and
-      // whether we'd prefer to fail hard and tell user to get a better
-      // schedule.
-      int scratchReg = findMaxAllocatedVGPR(op) + 1;
-      auto vtmpTy = VGPRType::get(rewriter.getContext(), Register(scratchReg));
-      auto vtmp = AllocaOp::create(rewriter, tgt.getLoc(), vtmpTy);
-      VAccvgprRead::create(rewriter, tgt.getLoc(), vtmp, src);
-      VAccvgprWrite::create(rewriter, tgt.getLoc(), tgt, vtmp);
+      VAccvgprMovB32::create(rewriter, tgt.getLoc(), tgt, src);
       return;
     }
     VMovB32::create(rewriter, tgt.getLoc(), tgt, src);
@@ -620,26 +585,17 @@ LogicalResult CopyOpPattern::matchAndRewrite(lsir::CopyOp op,
   return success();
 }
 
-LogicalResult VMovB32Pattern::matchAndRewrite(VMovB32 op,
-                                              PatternRewriter &rewriter) const {
-  RegisterTypeInterface dstTy = op.getDst0().getType();
-  auto srcTy = llvm::dyn_cast<RegisterTypeInterface>(op.getSrc0().getType());
-  if (!srcTy)
+LogicalResult
+MovInstOpPattern::matchAndRewrite(MovInstOpInterface op,
+                                  PatternRewriter &rewriter) const {
+  // CopyOpPattern handles lsir::CopyOp specifically.
+  if (isa<lsir::CopyOp>(op))
     return failure();
-  if (!srcTy.hasAllocatedSemantics() || !dstTy.hasAllocatedSemantics())
-    return failure();
-  if (srcTy != dstTy)
-    return rewriter.notifyMatchFailure(
-        op, "source and destination types do not match");
-  rewriter.eraseOp(op);
-  return success();
-}
-
-LogicalResult SMovB32Pattern::matchAndRewrite(SMovB32 op,
-                                              PatternRewriter &rewriter) const {
-  RegisterTypeInterface dstTy = op.getDst0().getType();
-  auto srcTy = llvm::dyn_cast<RegisterTypeInterface>(op.getSrc0().getType());
-  if (!srcTy)
+  RegisterTypeInterface dstTy =
+      dyn_cast<RegisterTypeInterface>(op.getDestOperand().getType());
+  RegisterTypeInterface srcTy =
+      dyn_cast<RegisterTypeInterface>(op.getSrcOperand().getType());
+  if (!srcTy || !dstTy)
     return failure();
   if (!srcTy.hasAllocatedSemantics() || !dstTy.hasAllocatedSemantics())
     return failure();
@@ -702,8 +658,12 @@ LogicalResult RegisterColoring::run(FunctionOpInterface funcOp) {
 
   RewritePatternSet patterns(&getContext());
   patterns.add<InstRewritePattern, MakeRegisterRangeOpPattern,
-               RegInterferenceOpPattern, CopyOpPattern, SMovB32Pattern,
-               VMovB32Pattern>(&getContext());
+               RegInterferenceOpPattern>(&getContext());
+  // CopyOpPattern handles lsir::CopyOp with dedicated logic. MovInstOpPattern
+  // guards against lsir::CopyOp explicitly because CopyOpPattern can return
+  // failure for it; the higher benefit ensures CopyOpPattern runs first.
+  patterns.add<CopyOpPattern>(&getContext(), /*benefit=*/2);
+  patterns.add<MovInstOpPattern>(&getContext(), /*benefit=*/1);
   FrozenRewritePatternSet frozenPatterns(std::move(patterns));
   if (failed(applyPatternsGreedily(
           funcOp, frozenPatterns,

--- a/test/Dialect/AMDGCN/Transforms/legalize-operands.mlir
+++ b/test/Dialect/AMDGCN/Transforms/legalize-operands.mlir
@@ -398,3 +398,100 @@ amdgcn.module @vcndmask_b32_inline_src1_mod target = <gfx942> {
     end_kernel
   }
 }
+
+// -----
+
+// Test: lsir.select with SGPR (non-SCC, non-VCC) condition + non-inline
+// true_value. SGPR conditions lower to v_cndmask_b32 (VALU), so the true
+// value must be materialized into a VGPR via v_mov_b32, not s_mov_b32.
+
+// CHECK-LABEL: kernel @sgpr_cond_select_non_inline_true
+// CHECK:         %{{.*}} = alloca : !amdgcn.vgpr
+// CHECK:         %[[OUT:.*]] = alloca : !amdgcn.vgpr
+// CHECK:         %[[MOV:.*]] = v_mov_b32 outs(%[[OUT]]) ins(%{{.*}}) : outs(!amdgcn.vgpr) ins(i32)
+// CHECK:         lsir.select %{{.*}}, %{{.*}}, %[[MOV]], %{{.*}} : !amdgcn.vgpr, !amdgcn.sgpr, !amdgcn.vgpr, i32
+// CHECK-NOT:     s_mov_b32
+amdgcn.module @sgpr_cond_select_non_inline_mod target = <gfx942> {
+  amdgcn.kernel @sgpr_cond_select_non_inline_true {
+    %c544 = arith.constant 544 : i32
+    %c1632 = arith.constant 1632 : i32
+    %v0 = alloca : !amdgcn.vgpr
+    %v1 = alloca : !amdgcn.vgpr
+    %s0 = alloca : !amdgcn.sgpr
+    %sel = lsir.select %v1, %s0, %c544, %c1632 : !amdgcn.vgpr, !amdgcn.sgpr, i32, i32
+    test_inst ins %sel : (!amdgcn.vgpr) -> ()
+    end_kernel
+  }
+}
+
+// -----
+
+// Test: lsir.select with SGPR condition + inline true_value -> no
+// transformation. 10 is in [-16, 64], so VOP3 can encode it directly.
+
+// CHECK-LABEL: kernel @sgpr_cond_select_inline_true
+// CHECK-NOT:     v_mov_b32
+// CHECK-NOT:     s_mov_b32
+// CHECK:         lsir.select %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : !amdgcn.vgpr, !amdgcn.sgpr, i32, i32
+amdgcn.module @sgpr_cond_select_inline_mod target = <gfx942> {
+  amdgcn.kernel @sgpr_cond_select_inline_true {
+    %c10 = arith.constant 10 : i32
+    %c200 = arith.constant 200 : i32
+    %v1 = alloca : !amdgcn.vgpr
+    %s0 = alloca : !amdgcn.sgpr
+    %sel = lsir.select %v1, %s0, %c10, %c200 : !amdgcn.vgpr, !amdgcn.sgpr, i32, i32
+    test_inst ins %sel : (!amdgcn.vgpr) -> ()
+    end_kernel
+  }
+}
+
+// -----
+
+// Test: v_cndmask_b32 with a two-SGPR condition (VOP3 mode, non-VCC) and
+// non-inline src1. The condition is not SCC, so VGPRSelectInstLegalizePattern
+// fires and materializes src1 into a VGPR via v_mov_b32.
+
+// CHECK-LABEL: kernel @vcndmask_twosgpr_cond_non_inline_src1
+// CHECK:         %{{.*}} = alloca : !amdgcn.vgpr
+// CHECK:         %[[OUT:.*]] = alloca : !amdgcn.vgpr
+// CHECK:         %[[MOV:.*]] = v_mov_b32 outs(%[[OUT]]) ins(%{{.*}}) : outs(!amdgcn.vgpr) ins(i32)
+// CHECK:         v_cndmask_b32 outs(%{{.*}}) ins(%{{.*}}, %[[MOV]], %{{.*}}) : outs(!amdgcn.vgpr) ins(i32, !amdgcn.vgpr, !amdgcn.sgpr<[? + 2]>)
+amdgcn.module @vcndmask_twosgpr_cond_mod target = <gfx942> {
+  amdgcn.kernel @vcndmask_twosgpr_cond_non_inline_src1 {
+    %c544 = arith.constant 544 : i32
+    %c1632 = arith.constant 1632 : i32
+    %v0 = alloca : !amdgcn.vgpr
+    %v1 = alloca : !amdgcn.vgpr
+    %s0 = alloca : !amdgcn.sgpr
+    %s1 = alloca : !amdgcn.sgpr
+    %cond = make_register_range %s0, %s1 : !amdgcn.sgpr, !amdgcn.sgpr
+    test_inst ins %cond : (!amdgcn.sgpr<[? + 2]>) -> ()
+    %sel = amdgcn.v_cndmask_b32 outs(%v1) ins(%c1632, %c544, %cond) : outs(!amdgcn.vgpr) ins(i32, i32, !amdgcn.sgpr<[? + 2]>)
+    test_inst ins %sel : (!amdgcn.vgpr) -> ()
+    end_kernel
+  }
+}
+
+// -----
+
+// Test: v_cndmask_b32 with a two-SGPR condition + inline src1 -> no
+// transformation. 10 is in [-16, 64], so VOP3 can encode it directly.
+
+// CHECK-LABEL: kernel @vcndmask_twosgpr_cond_inline_src1
+// CHECK-NOT:     v_mov_b32
+// CHECK:         v_cndmask_b32 outs(%{{.*}}) ins(%{{.*}}, %{{.*}}, %{{.*}}) : outs(!amdgcn.vgpr) ins(i32, i32, !amdgcn.sgpr<[? + 2]>)
+amdgcn.module @vcndmask_twosgpr_cond_inline_mod target = <gfx942> {
+  amdgcn.kernel @vcndmask_twosgpr_cond_inline_src1 {
+    %c10 = arith.constant 10 : i32
+    %c200 = arith.constant 200 : i32
+    %v0 = alloca : !amdgcn.vgpr
+    %v1 = alloca : !amdgcn.vgpr
+    %s0 = alloca : !amdgcn.sgpr
+    %s1 = alloca : !amdgcn.sgpr
+    %cond = make_register_range %s0, %s1 : !amdgcn.sgpr, !amdgcn.sgpr
+    test_inst ins %cond : (!amdgcn.sgpr<[? + 2]>) -> ()
+    %sel = amdgcn.v_cndmask_b32 outs(%v1) ins(%c200, %c10, %cond) : outs(!amdgcn.vgpr) ins(i32, i32, !amdgcn.sgpr<[? + 2]>)
+    test_inst ins %sel : (!amdgcn.vgpr) -> ()
+    end_kernel
+  }
+}

--- a/test/Dialect/AMDGCN/Transforms/register-coloring-agpr.mlir
+++ b/test/Dialect/AMDGCN/Transforms/register-coloring-agpr.mlir
@@ -56,14 +56,11 @@ amdgcn.kernel @agpr_range_allocation {
 
 // -----
 
-// No other VGPRs allocated, so scratch is v0.
 // CHECK-LABEL: amdgcn.kernel @agpr_copy {
 // CHECK-DAG:     %[[A0:.*]] = alloca : !amdgcn.agpr<0>
 // CHECK-DAG:     %[[A1:.*]] = alloca : !amdgcn.agpr<1>
 // CHECK:         test_inst outs %[[A0]] : (!amdgcn.agpr<0>) -> ()
-// CHECK:         %[[VTMP:.*]] = alloca : !amdgcn.vgpr<0>
-// CHECK:         v_accvgpr_read outs(%[[VTMP]]) ins(%[[A1]])
-// CHECK:         v_accvgpr_write outs(%[[A0]]) ins(%[[VTMP]])
+// CHECK:         v_accvgpr_mov_b32 outs(%[[A0]]) ins(%[[A1]])
 // CHECK:         test_inst ins %[[A1]] : (!amdgcn.agpr<1>) -> ()
 // CHECK:         end_kernel
 amdgcn.kernel @agpr_copy {
@@ -77,16 +74,13 @@ amdgcn.kernel @agpr_copy {
 
 // -----
 
-// With VGPRs v0..v2 in use, the scratch should be v3.
 // CHECK-LABEL: amdgcn.kernel @agpr_copy_with_vgprs {
 // CHECK-DAG:     %[[V0:.*]] = alloca : !amdgcn.vgpr<0>
 // CHECK-DAG:     %[[V1:.*]] = alloca : !amdgcn.vgpr<1>
 // CHECK-DAG:     %[[V2:.*]] = alloca : !amdgcn.vgpr<2>
 // CHECK-DAG:     %[[A0:.*]] = alloca : !amdgcn.agpr<0>
 // CHECK-DAG:     %[[A1:.*]] = alloca : !amdgcn.agpr<1>
-// CHECK:         %[[VTMP:.*]] = alloca : !amdgcn.vgpr<3>
-// CHECK:         v_accvgpr_read outs(%[[VTMP]]) ins(%[[A1]])
-// CHECK:         v_accvgpr_write outs(%[[A0]]) ins(%[[VTMP]])
+// CHECK:         v_accvgpr_mov_b32 outs(%[[A0]]) ins(%[[A1]])
 // CHECK:         end_kernel
 amdgcn.kernel @agpr_copy_with_vgprs {
   %v0 = alloca : !amdgcn.vgpr<?>
@@ -208,4 +202,20 @@ amdgcn.kernel @agpr_to_vgpr_copy_rejected {
   lsir.copy %a, %v : !amdgcn.agpr<?>, !amdgcn.vgpr<?>
   test_inst ins %v : (!amdgcn.vgpr<?>) -> ()
   end_kernel
+}
+
+// -----
+
+// Test: v_accvgpr_mov_b32 with non-interfering src and dst AGPRs -> both are
+// allocated to the same AGPR and the mov is erased by MovInstOpPattern.
+
+// CHECK-LABEL: kernel @redundant_v_accvgpr_mov {
+// CHECK-NOT:     v_accvgpr_mov_b32
+amdgcn.module @redundant_v_accvgpr_mov_mod target = <gfx942> {
+  amdgcn.kernel @redundant_v_accvgpr_mov {
+    %a0 = alloca : !amdgcn.agpr<?>
+    %a1 = alloca : !amdgcn.agpr<?>
+    amdgcn.v_accvgpr_mov_b32 outs(%a1) ins(%a0) : outs(!amdgcn.agpr<?>) ins(!amdgcn.agpr<?>)
+    end_kernel
+  }
 }

--- a/test/Dialect/AMDGCN/Transforms/register-coloring.mlir
+++ b/test/Dialect/AMDGCN/Transforms/register-coloring.mlir
@@ -1112,3 +1112,21 @@ func.func @range_interference() {
   amdgcn.reg_interference %0, %5 : !amdgcn.vgpr<?>, !amdgcn.vgpr<2>
   return
 }
+
+// -----
+
+// Test: s_mov_b64 with non-interfering src and dst ranges -> both are allocated
+// to the same two SGPRs and the mov is erased by MovInstOpPattern.
+
+// CHECK-LABEL:   func.func @redundant_s_mov_b64() {
+// CHECK-NOT:       s_mov_b64
+func.func @redundant_s_mov_b64() {
+  %s0 = amdgcn.alloca : !amdgcn.sgpr<?>
+  %s1 = amdgcn.alloca : !amdgcn.sgpr<?>
+  %s2 = amdgcn.alloca : !amdgcn.sgpr<?>
+  %s3 = amdgcn.alloca : !amdgcn.sgpr<?>
+  %r0 = amdgcn.make_register_range %s0, %s1 : !amdgcn.sgpr<?>, !amdgcn.sgpr<?>
+  %r1 = amdgcn.make_register_range %s2, %s3 : !amdgcn.sgpr<?>, !amdgcn.sgpr<?>
+  amdgcn.s_mov_b64 outs(%r1) ins(%r0) : outs(!amdgcn.sgpr<[? : ? + 2]>) ins(!amdgcn.sgpr<[? : ? + 2]>)
+  return
+}


### PR DESCRIPTION
Replace the concrete-op patterns VMovB32Pattern/SMovB32Pattern in
RegisterColoring and SelectLegalizePattern/SCselectLegalizePattern/
VCndmaskB32LegalizePattern in LegalizeOperands with interface-based
patterns using MovInstOpInterface and SelectInstOpInterface.

RegisterColoring: MovInstOpPattern handles all mov ops via the
interface; CopyOpPattern retains higher benefit (2 vs 1) so it
continues to take precedence for lsir::CopyOp.

LegalizeOperands: VGPRSelectInstLegalizePattern handles VCC-condition
select ops (VOP2 src1-must-be-VGPR rule); SGPRSelectInstLegalizePattern
handles SCC-condition ops (SOP2 at-most-one-literal rule), detecting
32 vs 64-bit width automatically.

Co-Authored-By: Claude Sonnet 4 <noreply@anthropic.com>
Signed-off-by: Fabian Mora <fabian.mora-cordero@amd.com>