### PR TITLE
Fix CMake build type, gitignore, and dangling ref in InstAsmPrinterGen.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@
 /examples/trace_*
 /examples/*zip
 /llvm/llvm-project/
+.claude/
+plan/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,6 @@
 cmake_minimum_required(VERSION 3.23)
 project(aster VERSION 1.0)
 
-# TODO: Remove this once we are on production
-set(CMAKE_BUILD_TYPE DEBUG)
-
 # Set CXX requirements
 set(CMAKE_CXX_STANDARD 17)
 

--- a/tools/amdgcn-tblgen/InstAsmPrinterGen.cpp
+++ b/tools/amdgcn-tblgen/InstAsmPrinterGen.cpp
@@ -114,7 +114,8 @@ ASMPrinterHandler::ASMPrinterHandler(const llvm::Record *rec) : instOp(rec) {
     }
   }
   // Collect block operands from successors.
-  for (auto [i, arg] : llvm::enumerate(instOp.getSuccessors().getAsRange())) {
+  Dag successors = instOp.getSuccessors();
+  for (auto [i, arg] : llvm::enumerate(successors.getAsRange())) {
     if (!ASMArgFormat::isa(arg.getAsRecord()))
       continue;
     arguments[arg.getName()] = {arg, ASMArgFormat(arg.getAsRecord())};


### PR DESCRIPTION
Remove hardcoded DEBUG build type from CMakeLists.txt, ignore .claude/
and plan/ directories, and extract getSuccessors() result to a named
variable to avoid a dangling reference in the range loop.

Co-Authored-By: Claude Sonnet 4 <noreply@anthropic.com>
