### PR TITLE
Extract lsir.copy expansion into PostRegAllocLegalization pass.

### DIFF
--- a/include/aster/Dialect/AMDGCN/Transforms/AMDGCNPasses.td
+++ b/include/aster/Dialect/AMDGCN/Transforms/AMDGCNPasses.td
@@ -70,8 +70,7 @@ def AMDGCNBufferization : Pass<"aster-amdgcn-bufferization"> {
   }];
   let dependentDialects = [
     "mlir::aster::amdgcn::AMDGCNDialect",
-    "mlir::aster::lsir::LSIRDialect",
-    "mlir::cf::ControlFlowDialect"
+    "mlir::aster::lsir::LSIRDialect"
   ];
 }
 
@@ -111,6 +110,22 @@ def PreColoringLegalization : Pass<"amdgcn-pre-coloring-legalization"> {
   let dependentDialects = [
     "mlir::aster::amdgcn::AMDGCNDialect",
     "mlir::arith::ArithDialect"
+  ];
+}
+
+def PostRegAllocLegalization : Pass<"amdgcn-post-reg-alloc-legalization"> {
+  let summary = "Legalize operations after register allocation";
+  let description = [{
+    This pass performs post-register-allocation legalization. It expands
+    lsir.copy operations into the appropriate hardware mov instructions
+    (s_mov_b32, v_mov_b32, v_accvgpr_mov_b32) and erases redundant mov
+    instructions whose source and destination are the same physical register.
+
+    Pre-condition: #amdgcn.all_registers_allocated
+  }];
+  let dependentDialects = [
+    "mlir::aster::amdgcn::AMDGCNDialect",
+    "mlir::aster::lsir::LSIRDialect"
   ];
 }
 

--- a/include/aster/Interfaces/InstOpInterfaces.h
+++ b/include/aster/Interfaces/InstOpInterfaces.h
@@ -19,5 +19,13 @@
 #include "aster/Interfaces/InstOpInterface.h"
 
 #include "aster/Interfaces/InstOpInterfaces.h.inc"
+#include "mlir/IR/PatternMatch.h"
+
+namespace mlir::aster::detail {
+/// Canonicalization pattern for MovInstOpInterface, if the source and
+/// destination are the same register, the instruction can be removed.
+LogicalResult canonicalizeMovInstImpl(MovInstOpInterface mov,
+                                      RewriterBase &rewriter);
+} // namespace mlir::aster::detail
 
 #endif // ASTER_INTERFACES_INSTOPINTERFACES_H

--- a/lib/Dialect/AMDGCN/Transforms/AMDGCNBufferization.cpp
+++ b/lib/Dialect/AMDGCN/Transforms/AMDGCNBufferization.cpp
@@ -20,7 +20,6 @@
 #include "aster/Interfaces/RegisterType.h"
 #include "mlir/Analysis/DataFlow/Utils.h"
 #include "mlir/Analysis/DataFlowFramework.h"
-#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/IR/Dominance.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Interfaces/ControlFlowInterfaces.h"

--- a/lib/Dialect/AMDGCN/Transforms/CMakeLists.txt
+++ b/lib/Dialect/AMDGCN/Transforms/CMakeLists.txt
@@ -15,6 +15,7 @@ add_mlir_library(AMDGCNTransforms
   OptimizeAMDGCN.cpp
   OptimizeInterferenceGraph.cpp
   Pipelines.cpp
+  PostRegAllocLegalization.cpp
   PreColoringLegalization.cpp
   PreloadLibrary.cpp
   RegisterColoring.cpp

--- a/lib/Dialect/AMDGCN/Transforms/Pipelines.cpp
+++ b/lib/Dialect/AMDGCN/Transforms/Pipelines.cpp
@@ -64,10 +64,13 @@ struct RegAllocPipelineOptions
 /// This pipeline performs register allocation for AMDGCN kernels by running
 /// the following passes in sequence:
 /// 1. Bufferization - inserts copies to remove potentially clobbered values,
-/// and removes phi-nodes arguments with register value semantics.
+///    and removes phi-node arguments with register value semantics.
 /// 2. ToRegisterSemantics - converts value allocas to unallocated register
-///    semantics
-/// 3. RegisterAlloc - performs the actual register allocation
+///    semantics.
+/// 3. RegisterColoring - performs the actual register allocation.
+/// 4. PostRegAllocLegalization - expands lsir.copy to hardware mov instructions
+///    and erases redundant movs whose source and destination are the same
+///    physical register.
 static void buildRegAllocPassPipeline(OpPassManager &pm,
                                       const RegAllocPipelineOptions &options) {
   if (options.hoistIterArgWaits) {
@@ -95,6 +98,7 @@ static void buildRegAllocPassPipeline(OpPassManager &pm,
   coloringOpts.numVGPRs = options.numVGPRs;
   coloringOpts.numAGPRs = options.numAGPRs;
   pm.addPass(createRegisterColoring(coloringOpts));
+  pm.addPass(createPostRegAllocLegalization());
   pm.addPass(createHoistOps());
   pm.addPass(createCFGSimplification());
 }

--- a/lib/Dialect/AMDGCN/Transforms/PostRegAllocLegalization.cpp
+++ b/lib/Dialect/AMDGCN/Transforms/PostRegAllocLegalization.cpp
@@ -1,0 +1,183 @@
+//===- PostRegAllocLegalization.cpp - Legalize ops after register alloc ===//
+//
+// Copyright 2025 The ASTER Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "aster/Dialect/AMDGCN/IR/AMDGCNOps.h"
+#include "aster/Dialect/AMDGCN/Transforms/Passes.h"
+#include "aster/Dialect/LSIR/IR/LSIRDialect.h"
+#include "aster/Dialect/LSIR/IR/LSIROps.h"
+#include "aster/Interfaces/InstOpInterfaces.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#define DEBUG_TYPE "amdgcn-post-reg-alloc-legalization"
+
+namespace mlir::aster {
+namespace amdgcn {
+#define GEN_PASS_DEF_POSTREGALLOCLEGALIZATION
+#include "aster/Dialect/AMDGCN/Transforms/Passes.h.inc"
+} // namespace amdgcn
+} // namespace mlir::aster
+
+using namespace mlir;
+using namespace mlir::aster;
+using namespace mlir::aster::amdgcn;
+
+namespace {
+//===----------------------------------------------------------------------===//
+// PostRegAllocLegalization pass
+//===----------------------------------------------------------------------===//
+struct PostRegAllocLegalization
+    : public amdgcn::impl::PostRegAllocLegalizationBase<
+          PostRegAllocLegalization> {
+  using Base::Base;
+  void runOnOperation() override;
+};
+
+//===----------------------------------------------------------------------===//
+// Rewrite patterns
+//===----------------------------------------------------------------------===//
+
+struct CopyExpansionPattern : public OpRewritePattern<lsir::CopyOp> {
+  using Base::Base;
+
+  LogicalResult matchAndRewrite(lsir::CopyOp op,
+                                PatternRewriter &rewriter) const override;
+};
+
+struct MovInstOpPattern : public OpInterfaceRewritePattern<MovInstOpInterface> {
+  using Base::Base;
+
+  LogicalResult matchAndRewrite(MovInstOpInterface op,
+                                PatternRewriter &rewriter) const override;
+};
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// Helpers
+//===----------------------------------------------------------------------===//
+
+// Returns true if the value needs allocation (i.e. is not yet an allocated
+// physical register). Also defined in RegisterColoring.cpp; kept local to
+// avoid coupling the two passes.
+static bool needsAllocation(Value node) {
+  auto regTy = dyn_cast<AMDGCNRegisterTypeInterface>(node.getType());
+  return regTy && !regTy.hasAllocatedSemantics();
+}
+
+//===----------------------------------------------------------------------===//
+// CopyExpansionPattern
+//===----------------------------------------------------------------------===//
+
+LogicalResult
+CopyExpansionPattern::matchAndRewrite(lsir::CopyOp op,
+                                      PatternRewriter &rewriter) const {
+  // Self-copies were already removed by RegisterColoring. Remaining copies
+  // with fully allocated operands are expanded to hardware mov instructions.
+
+  // Value-semantics copies with live results must have been eliminated by
+  // ToRegisterSemantics before register coloring runs.
+  if (op.getTargetRes() && !op.getTargetRes().use_empty())
+    return failure();
+
+  // Get the source allocas. Bail out if the allocas are missing or need
+  // allocation.
+  FailureOr<ValueRange> srcAlloc = getAllocasOrFailure(op.getSource());
+  if (failed(srcAlloc) ||
+      llvm::any_of(*srcAlloc, [](Value v) { return needsAllocation(v); }))
+    return failure();
+
+  // Get the target allocas. Bail out if the allocas are missing or need
+  // allocation.
+  FailureOr<ValueRange> tgtAlloc = getAllocasOrFailure(op.getTarget());
+  if (failed(tgtAlloc) ||
+      llvm::any_of(*tgtAlloc, [](Value v) { return needsAllocation(v); }))
+    return failure();
+
+  assert(srcAlloc->size() == tgtAlloc->size() &&
+         "source and target allocas must have the same size");
+  assert(srcAlloc->size() > 0 &&
+         "source and target allocas must have at least one alloca");
+
+  auto srcTy = dyn_cast<AMDGCNRegisterTypeInterface>(op.getSource().getType());
+  auto tgtTy = dyn_cast<AMDGCNRegisterTypeInterface>(op.getTarget().getType());
+
+  // Bail if the source or target is not an AMDGCN register type.
+  if (!srcTy || !tgtTy)
+    return failure();
+
+  // Bail if the copy cannot be performed.
+  if (srcTy.getRegisterKind() != RegisterKind::SGPR &&
+      tgtTy.getRegisterKind() == RegisterKind::SGPR) {
+    return rewriter.notifyMatchFailure(
+        op, "cannot copy between non-sgpr type to an sgpr type");
+  }
+  if (!llvm::is_contained(
+          {RegisterKind::SGPR, RegisterKind::VGPR, RegisterKind::AGPR},
+          srcTy.getRegisterKind()) ||
+      !llvm::is_contained(
+          {RegisterKind::SGPR, RegisterKind::VGPR, RegisterKind::AGPR},
+          tgtTy.getRegisterKind())) {
+    return rewriter.notifyMatchFailure(
+        op, "cannot copy if data type is not SGPR, VGPR, or AGPR");
+  }
+  // AGPR copies: only AGPR->AGPR is supported (via v_accvgpr_mov_b32).
+  if (tgtTy.getRegisterKind() == RegisterKind::AGPR &&
+      srcTy.getRegisterKind() != RegisterKind::AGPR) {
+    return rewriter.notifyMatchFailure(
+        op,
+        "cannot copy non-AGPR to AGPR (use v_accvgpr_write_b32 explicitly)");
+  }
+  if (srcTy.getRegisterKind() == RegisterKind::AGPR &&
+      tgtTy.getRegisterKind() != RegisterKind::AGPR) {
+    return rewriter.notifyMatchFailure(
+        op, "cannot copy AGPR to non-AGPR (use v_accvgpr_read_b32 explicitly)");
+  }
+
+  auto copyReg = [&](Value src, Value tgt) {
+    if (tgtTy.getRegisterKind() == RegisterKind::SGPR) {
+      SMovB32::create(rewriter, tgt.getLoc(), tgt, src);
+      return;
+    }
+    if (tgtTy.getRegisterKind() == RegisterKind::AGPR) {
+      VAccvgprMovB32::create(rewriter, tgt.getLoc(), tgt, src);
+      return;
+    }
+    VMovB32::create(rewriter, tgt.getLoc(), tgt, src);
+  };
+
+  // Emit one hardware mov per register pair.
+  for (auto [src, tgt] : llvm::zip_equal(*srcAlloc, *tgtAlloc))
+    copyReg(src, tgt);
+  rewriter.eraseOp(op);
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// MovInstOpPattern
+//===----------------------------------------------------------------------===//
+
+LogicalResult
+MovInstOpPattern::matchAndRewrite(MovInstOpInterface op,
+                                  PatternRewriter &rewriter) const {
+  return aster::detail::canonicalizeMovInstImpl(op, rewriter);
+}
+
+//===----------------------------------------------------------------------===//
+// PostRegAllocLegalization pass
+//===----------------------------------------------------------------------===//
+
+void PostRegAllocLegalization::runOnOperation() {
+  RewritePatternSet patterns(&getContext());
+  patterns.add<CopyExpansionPattern>(&getContext(), /*benefit=*/1);
+  patterns.add<MovInstOpPattern>(&getContext(), /*benefit=*/2);
+  FrozenRewritePatternSet frozenPatterns(std::move(patterns));
+  if (failed(applyPatternsGreedily(getOperation(), frozenPatterns)))
+    return signalPassFailure();
+}

--- a/lib/Dialect/AMDGCN/Transforms/RegisterColoring.cpp
+++ b/lib/Dialect/AMDGCN/Transforms/RegisterColoring.cpp
@@ -16,8 +16,6 @@
 #include "aster/Dialect/AMDGCN/Transforms/Transforms.h"
 #include "aster/Dialect/LSIR/IR/LSIROps.h"
 #include "mlir/Analysis/DataFlowFramework.h"
-#include "mlir/IR/Builders.h"
-#include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "llvm/ADT/EquivalenceClasses.h"
 #include "llvm/ADT/STLExtras.h"
@@ -160,20 +158,6 @@ struct RegInterferenceOpPattern : public OpRewritePattern<RegInterferenceOp> {
   using Base::Base;
 
   LogicalResult matchAndRewrite(RegInterferenceOp op,
-                                PatternRewriter &rewriter) const override;
-};
-
-struct CopyOpPattern : public OpRewritePattern<lsir::CopyOp> {
-  using Base::Base;
-
-  LogicalResult matchAndRewrite(lsir::CopyOp op,
-                                PatternRewriter &rewriter) const override;
-};
-
-struct MovInstOpPattern : public OpInterfaceRewritePattern<MovInstOpInterface> {
-  using Base::Base;
-
-  LogicalResult matchAndRewrite(MovInstOpInterface op,
                                 PatternRewriter &rewriter) const override;
 };
 } // namespace
@@ -501,111 +485,6 @@ RegInterferenceOpPattern::matchAndRewrite(RegInterferenceOp op,
   return success();
 }
 
-LogicalResult CopyOpPattern::matchAndRewrite(lsir::CopyOp op,
-                                             PatternRewriter &rewriter) const {
-  // Try to canonicalize the operation.
-  if (succeeded(op.canonicalize(op, rewriter)))
-    return success();
-
-  // If the result is used, bail out.
-  if (op.getTargetRes() && !op.getTargetRes().use_empty())
-    return failure();
-
-  // Get the source allocas. Bail out if the allocas are missing or need
-  // allocation.
-  FailureOr<ValueRange> srcAlloc = getAllocasOrFailure(op.getSource());
-  if (failed(srcAlloc) ||
-      llvm::any_of(*srcAlloc, [](Value v) { return needsAllocation(v); }))
-    return failure();
-
-  // Get the target allocas. Bail out if the allocas are missing or need
-  // allocation.
-  FailureOr<ValueRange> tgtAlloc = getAllocasOrFailure(op.getTarget());
-  if (failed(tgtAlloc) ||
-      llvm::any_of(*tgtAlloc, [](Value v) { return needsAllocation(v); }))
-    return failure();
-
-  assert(srcAlloc->size() == tgtAlloc->size() &&
-         "source and target allocas must have the same size");
-
-  assert(srcAlloc->size() > 0 &&
-         "source and target allocas must have at least one alloca");
-
-  auto srcTy = dyn_cast<AMDGCNRegisterTypeInterface>(op.getSource().getType());
-  auto tgtTy = dyn_cast<AMDGCNRegisterTypeInterface>(op.getTarget().getType());
-
-  // Bail if the source or target is not an AMDGCN register type.
-  if (!srcTy || !tgtTy)
-    return failure();
-
-  // Bail if the copy cannot be performed.
-  if (srcTy.getRegisterKind() != RegisterKind::SGPR &&
-      tgtTy.getRegisterKind() == RegisterKind::SGPR) {
-    return rewriter.notifyMatchFailure(
-        op, "cannot copy between non-sgpr type to an sgpr type");
-  }
-  if (!llvm::is_contained(
-          {RegisterKind::SGPR, RegisterKind::VGPR, RegisterKind::AGPR},
-          srcTy.getRegisterKind()) ||
-      !llvm::is_contained(
-          {RegisterKind::SGPR, RegisterKind::VGPR, RegisterKind::AGPR},
-          tgtTy.getRegisterKind())) {
-    return rewriter.notifyMatchFailure(
-        op, "cannot copy if data type is not SGPR, VGPR, or AGPR");
-  }
-  // AGPR copies: only AGPR->AGPR is supported (via v_accvgpr_write_b32).
-  if (tgtTy.getRegisterKind() == RegisterKind::AGPR &&
-      srcTy.getRegisterKind() != RegisterKind::AGPR) {
-    return rewriter.notifyMatchFailure(
-        op,
-        "cannot copy non-AGPR to AGPR (use v_accvgpr_write_b32 explicitly)");
-  }
-  if (srcTy.getRegisterKind() == RegisterKind::AGPR &&
-      tgtTy.getRegisterKind() != RegisterKind::AGPR) {
-    return rewriter.notifyMatchFailure(
-        op, "cannot copy AGPR to non-AGPR (use v_accvgpr_read_b32 explicitly)");
-  }
-
-  auto copyReg = [&](Value src, Value tgt) {
-    if (tgtTy.getRegisterKind() == RegisterKind::SGPR) {
-      SMovB32::create(rewriter, tgt.getLoc(), tgt, src);
-      return;
-    }
-    if (tgtTy.getRegisterKind() == RegisterKind::AGPR) {
-      VAccvgprMovB32::create(rewriter, tgt.getLoc(), tgt, src);
-      return;
-    }
-    VMovB32::create(rewriter, tgt.getLoc(), tgt, src);
-  };
-
-  // Create the copy operations.
-  for (auto [src, tgt] : llvm::zip_equal(*srcAlloc, *tgtAlloc))
-    copyReg(src, tgt);
-  rewriter.eraseOp(op);
-  return success();
-}
-
-LogicalResult
-MovInstOpPattern::matchAndRewrite(MovInstOpInterface op,
-                                  PatternRewriter &rewriter) const {
-  // CopyOpPattern handles lsir::CopyOp specifically.
-  if (isa<lsir::CopyOp>(op))
-    return failure();
-  RegisterTypeInterface dstTy =
-      dyn_cast<RegisterTypeInterface>(op.getDestOperand().getType());
-  RegisterTypeInterface srcTy =
-      dyn_cast<RegisterTypeInterface>(op.getSrcOperand().getType());
-  if (!srcTy || !dstTy)
-    return failure();
-  if (!srcTy.hasAllocatedSemantics() || !dstTy.hasAllocatedSemantics())
-    return failure();
-  if (srcTy != dstTy)
-    return rewriter.notifyMatchFailure(
-        op, "source and destination types do not match");
-  rewriter.eraseOp(op);
-  return success();
-}
-
 //===----------------------------------------------------------------------===//
 // RegisterColoring pass
 //===----------------------------------------------------------------------===//
@@ -659,11 +538,6 @@ LogicalResult RegisterColoring::run(FunctionOpInterface funcOp) {
   RewritePatternSet patterns(&getContext());
   patterns.add<InstRewritePattern, MakeRegisterRangeOpPattern,
                RegInterferenceOpPattern>(&getContext());
-  // CopyOpPattern handles lsir::CopyOp with dedicated logic. MovInstOpPattern
-  // guards against lsir::CopyOp explicitly because CopyOpPattern can return
-  // failure for it; the higher benefit ensures CopyOpPattern runs first.
-  patterns.add<CopyOpPattern>(&getContext(), /*benefit=*/2);
-  patterns.add<MovInstOpPattern>(&getContext(), /*benefit=*/1);
   FrozenRewritePatternSet frozenPatterns(std::move(patterns));
   if (failed(applyPatternsGreedily(
           funcOp, frozenPatterns,

--- a/lib/Interfaces/InstOpInterfaces.cpp
+++ b/lib/Interfaces/InstOpInterfaces.cpp
@@ -9,8 +9,55 @@
 //===----------------------------------------------------------------------===//
 
 #include "aster/Interfaces/InstOpInterfaces.h"
+#include "aster/Interfaces/RegisterType.h"
 
 using namespace mlir;
 using namespace mlir::aster;
 
 #include "aster/Interfaces/InstOpInterfaces.cpp.inc"
+
+LogicalResult
+mlir::aster::detail::canonicalizeMovInstImpl(MovInstOpInterface mov,
+                                             RewriterBase &rewriter) {
+  RegisterTypeInterface dstTy =
+      dyn_cast<RegisterTypeInterface>(mov.getDestOperand().getType());
+  RegisterTypeInterface srcTy =
+      dyn_cast<RegisterTypeInterface>(mov.getSrcOperand().getType());
+
+  // Bail if either source or destination is not a register type.
+  if (!srcTy || !dstTy)
+    return failure();
+
+  RegisterSemantics semantics = srcTy.getSemantics();
+  // Bail if source and destination have different semantics.
+  if (semantics != dstTy.getSemantics())
+    return rewriter.notifyMatchFailure(
+        mov, "source and destination have different register semantics");
+
+  // We can remove the mov if the source and destination are the same register.
+  // There are 2 cases:
+  // 1. If allocated, it suffices to check if the types are the same.
+  // 2. If unallocated or value, we need to check if the values are the same.
+
+  if (semantics == RegisterSemantics::Allocated) {
+    if (srcTy != dstTy) {
+      return rewriter.notifyMatchFailure(
+          mov,
+          "source and destination have different allocated register types");
+    }
+    rewriter.eraseOp(mov);
+    return success();
+  }
+
+  if (mov.getDestOperand().getValue() != mov.getSrcOperand().getValue()) {
+    return rewriter.notifyMatchFailure(
+        mov, "source and destination have different register values");
+  }
+
+  if (semantics == RegisterSemantics::Unallocated)
+    rewriter.eraseOp(mov);
+  else
+    rewriter.replaceOp(mov, mov.getSrcOperand().getValue());
+
+  return success();
+}

--- a/test/Dialect/AMDGCN/Transforms/chained-select-dps-violation.mlir
+++ b/test/Dialect/AMDGCN/Transforms/chained-select-dps-violation.mlir
@@ -11,7 +11,7 @@
 // 4. Chained selects and loop counter advance all get concrete registers.
 //
 // CHECK-LABEL: kernel @chained_select_loop_3_way_buffer_mux {
-// CHECK:   lsir.br ^bb1
+// CHECK:   cf.br ^bb1
 // CHECK: ^bb1:
 // CHECK:   lsir.select %{{[0-9]+}},
 // CHECK:   lsir.select %{{[0-9]+}},

--- a/test/Dialect/AMDGCN/Transforms/post-reg-alloc-legalization.mlir
+++ b/test/Dialect/AMDGCN/Transforms/post-reg-alloc-legalization.mlir
@@ -1,0 +1,215 @@
+// RUN: aster-opt %s --amdgcn-post-reg-alloc-legalization --split-input-file | FileCheck %s
+
+// Positive case: SGPR->SGPR copy (lsir.copy target, source) expands to
+// s_mov_b32. The first operand is the destination (target), the second is
+// the source in DPS style.
+
+// CHECK-LABEL: amdgcn.kernel @sgpr_copy_expands {
+// CHECK-DAG:     %[[S0:.*]] = alloca : !amdgcn.sgpr<0>
+// CHECK-DAG:     %[[S1:.*]] = alloca : !amdgcn.sgpr<1>
+// CHECK:         s_mov_b32 outs(%[[S0]]) ins(%[[S1]]) : outs(!amdgcn.sgpr<0>) ins(!amdgcn.sgpr<1>)
+// CHECK:         test_inst ins %[[S0]] : (!amdgcn.sgpr<0>) -> ()
+// CHECK:         end_kernel
+amdgcn.kernel @sgpr_copy_expands {
+  %tgt = alloca : !amdgcn.sgpr<0>
+  %src = alloca : !amdgcn.sgpr<1>
+  test_inst outs %src : (!amdgcn.sgpr<1>) -> ()
+  // lsir.copy target, source — tgt is the destination register.
+  lsir.copy %tgt, %src : !amdgcn.sgpr<0>, !amdgcn.sgpr<1>
+  test_inst ins %tgt : (!amdgcn.sgpr<0>) -> ()
+  end_kernel
+}
+
+// -----
+
+// Positive case: VGPR->VGPR copy expands to v_mov_b32.
+
+// CHECK-LABEL: amdgcn.kernel @vgpr_copy_expands {
+// CHECK-DAG:     %[[V0:.*]] = alloca : !amdgcn.vgpr<0>
+// CHECK-DAG:     %[[V1:.*]] = alloca : !amdgcn.vgpr<1>
+// CHECK:         v_mov_b32 outs(%[[V0]]) ins(%[[V1]]) : outs(!amdgcn.vgpr<0>) ins(!amdgcn.vgpr<1>)
+// CHECK:         test_inst ins %[[V0]] : (!amdgcn.vgpr<0>) -> ()
+// CHECK:         end_kernel
+amdgcn.kernel @vgpr_copy_expands {
+  %tgt = alloca : !amdgcn.vgpr<0>
+  %src = alloca : !amdgcn.vgpr<1>
+  test_inst outs %src : (!amdgcn.vgpr<1>) -> ()
+  lsir.copy %tgt, %src : !amdgcn.vgpr<0>, !amdgcn.vgpr<1>
+  test_inst ins %tgt : (!amdgcn.vgpr<0>) -> ()
+  end_kernel
+}
+
+// -----
+
+// Positive case: AGPR->AGPR copy expands to v_accvgpr_mov_b32.
+
+// CHECK-LABEL: amdgcn.kernel @agpr_copy_expands {
+// CHECK-DAG:     %[[A0:.*]] = alloca : !amdgcn.agpr<0>
+// CHECK-DAG:     %[[A1:.*]] = alloca : !amdgcn.agpr<1>
+// CHECK:         v_accvgpr_mov_b32 outs(%[[A0]]) ins(%[[A1]]) : outs(!amdgcn.agpr<0>) ins(!amdgcn.agpr<1>)
+// CHECK:         test_inst ins %[[A0]] : (!amdgcn.agpr<0>) -> ()
+// CHECK:         end_kernel
+amdgcn.kernel @agpr_copy_expands {
+  %tgt = alloca : !amdgcn.agpr<0>
+  %src = alloca : !amdgcn.agpr<1>
+  test_inst outs %src : (!amdgcn.agpr<1>) -> ()
+  lsir.copy %tgt, %src : !amdgcn.agpr<0>, !amdgcn.agpr<1>
+  test_inst ins %tgt : (!amdgcn.agpr<0>) -> ()
+  end_kernel
+}
+
+// -----
+
+// Negative case: redundant v_mov_b32 (src == dst physical reg) is erased.
+// CHECK-LABEL: kernel @redundant_v_mov_erased {
+// CHECK-NOT:     v_mov_b32
+amdgcn.module @redundant_v_mov_erased_mod target = <gfx942> {
+  amdgcn.kernel @redundant_v_mov_erased {
+    %v0 = alloca : !amdgcn.vgpr<0>
+    amdgcn.v_mov_b32 outs(%v0) ins(%v0) : outs(!amdgcn.vgpr<0>) ins(!amdgcn.vgpr<0>)
+    end_kernel
+  }
+}
+
+// -----
+
+// Negative case: redundant s_mov_b32 (src == dst physical reg) is erased.
+// CHECK-LABEL: kernel @redundant_s_mov_erased {
+// CHECK-NOT:     s_mov_b32
+amdgcn.module @redundant_s_mov_erased_mod target = <gfx942> {
+  amdgcn.kernel @redundant_s_mov_erased {
+    %s0 = alloca : !amdgcn.sgpr<0>
+    amdgcn.s_mov_b32 outs(%s0) ins(%s0) : outs(!amdgcn.sgpr<0>) ins(!amdgcn.sgpr<0>)
+    end_kernel
+  }
+}
+
+// -----
+
+// Negative case: redundant v_accvgpr_mov_b32 (src == dst) is erased.
+// CHECK-LABEL: kernel @redundant_v_accvgpr_mov_erased {
+// CHECK-NOT:     v_accvgpr_mov_b32
+amdgcn.module @redundant_v_accvgpr_mov_erased_mod target = <gfx942> {
+  amdgcn.kernel @redundant_v_accvgpr_mov_erased {
+    %a0 = alloca : !amdgcn.agpr<0>
+    amdgcn.v_accvgpr_mov_b32 outs(%a0) ins(%a0) : outs(!amdgcn.agpr<0>) ins(!amdgcn.agpr<0>)
+    end_kernel
+  }
+}
+
+// -----
+
+// Negative case: lsir.copy with unallocated operands is not expanded because
+// the operands still need register allocation.
+
+// CHECK-LABEL: amdgcn.kernel @unallocated_copy_not_expanded {
+// CHECK-DAG:     %[[TGT:.*]] = alloca : !amdgcn.vgpr<?>
+// CHECK-DAG:     %[[SRC:.*]] = alloca : !amdgcn.vgpr<?>
+// CHECK:         lsir.copy %[[TGT]], %[[SRC]] : !amdgcn.vgpr<?>, !amdgcn.vgpr<?>
+// CHECK:         end_kernel
+amdgcn.kernel @unallocated_copy_not_expanded {
+  %tgt = alloca : !amdgcn.vgpr<?>
+  %src = alloca : !amdgcn.vgpr<?>
+  lsir.copy %tgt, %src : !amdgcn.vgpr<?>, !amdgcn.vgpr<?>
+  end_kernel
+}
+
+// -----
+
+// Negative case: VGPR->SGPR cross-class copy is not expanded because hardware
+// cannot perform this move directly.
+
+// CHECK-LABEL: amdgcn.kernel @vgpr_to_sgpr_copy_not_expanded {
+// CHECK-DAG:     %[[DST:.*]] = alloca : !amdgcn.sgpr<0>
+// CHECK-DAG:     %[[SRC:.*]] = alloca : !amdgcn.vgpr<0>
+// CHECK:         lsir.copy %[[DST]], %[[SRC]] : !amdgcn.sgpr<0>, !amdgcn.vgpr<0>
+// CHECK:         end_kernel
+amdgcn.kernel @vgpr_to_sgpr_copy_not_expanded {
+  %dst = alloca : !amdgcn.sgpr<0>
+  %src = alloca : !amdgcn.vgpr<0>
+  lsir.copy %dst, %src : !amdgcn.sgpr<0>, !amdgcn.vgpr<0>
+  end_kernel
+}
+
+// -----
+
+// Positive case: lsir.copy of a two-register VGPR range expands to two
+// v_mov_b32 instructions, one per register pair.
+
+// CHECK-LABEL: amdgcn.kernel @vgpr_range_copy_expands {
+// CHECK-DAG:     %[[T0:.*]] = alloca : !amdgcn.vgpr<2>
+// CHECK-DAG:     %[[T1:.*]] = alloca : !amdgcn.vgpr<3>
+// CHECK-DAG:     %[[S0:.*]] = alloca : !amdgcn.vgpr<0>
+// CHECK-DAG:     %[[S1:.*]] = alloca : !amdgcn.vgpr<1>
+// CHECK:         v_mov_b32 outs(%[[T0]]) ins(%[[S0]]) : outs(!amdgcn.vgpr<2>) ins(!amdgcn.vgpr<0>)
+// CHECK:         v_mov_b32 outs(%[[T1]]) ins(%[[S1]]) : outs(!amdgcn.vgpr<3>) ins(!amdgcn.vgpr<1>)
+// CHECK:         test_inst ins %[[T0]], %[[T1]] : (!amdgcn.vgpr<2>, !amdgcn.vgpr<3>) -> ()
+// CHECK:         end_kernel
+amdgcn.kernel @vgpr_range_copy_expands {
+  %tgt0 = alloca : !amdgcn.vgpr<2>
+  %tgt1 = alloca : !amdgcn.vgpr<3>
+  %src0 = alloca : !amdgcn.vgpr<0>
+  %src1 = alloca : !amdgcn.vgpr<1>
+  test_inst outs %src0, %src1 : (!amdgcn.vgpr<0>, !amdgcn.vgpr<1>) -> ()
+  %tgt = make_register_range %tgt0, %tgt1 : !amdgcn.vgpr<2>, !amdgcn.vgpr<3>
+  %src = make_register_range %src0, %src1 : !amdgcn.vgpr<0>, !amdgcn.vgpr<1>
+  lsir.copy %tgt, %src : !amdgcn.vgpr<[2 : 4]>, !amdgcn.vgpr<[0 : 2]>
+  test_inst ins %tgt0, %tgt1 : (!amdgcn.vgpr<2>, !amdgcn.vgpr<3>) -> ()
+  end_kernel
+}
+
+// -----
+
+// Positive case: SGPR-source to VGPR-target copy expands to v_mov_b32.
+// Hardware supports reading an SGPR as the source of a VGPR write.
+
+// CHECK-LABEL: amdgcn.kernel @sgpr_to_vgpr_copy_expands {
+// CHECK-DAG:     %[[V0:.*]] = alloca : !amdgcn.vgpr<0>
+// CHECK-DAG:     %[[S0:.*]] = alloca : !amdgcn.sgpr<0>
+// CHECK:         v_mov_b32 outs(%[[V0]]) ins(%[[S0]]) : outs(!amdgcn.vgpr<0>) ins(!amdgcn.sgpr<0>)
+// CHECK:         test_inst ins %[[V0]] : (!amdgcn.vgpr<0>) -> ()
+// CHECK:         end_kernel
+amdgcn.kernel @sgpr_to_vgpr_copy_expands {
+  %tgt = alloca : !amdgcn.vgpr<0>
+  %src = alloca : !amdgcn.sgpr<0>
+  test_inst outs %src : (!amdgcn.sgpr<0>) -> ()
+  lsir.copy %tgt, %src : !amdgcn.vgpr<0>, !amdgcn.sgpr<0>
+  test_inst ins %tgt : (!amdgcn.vgpr<0>) -> ()
+  end_kernel
+}
+
+// -----
+
+// Negative case: VGPR-to-AGPR copy is not expanded because hardware requires
+// an explicit v_accvgpr_write_b32 for this transfer.
+
+// CHECK-LABEL: amdgcn.kernel @vgpr_to_agpr_copy_not_expanded {
+// CHECK-DAG:     %[[A0:.*]] = alloca : !amdgcn.agpr<0>
+// CHECK-DAG:     %[[V0:.*]] = alloca : !amdgcn.vgpr<0>
+// CHECK:         lsir.copy %[[A0]], %[[V0]] : !amdgcn.agpr<0>, !amdgcn.vgpr<0>
+// CHECK:         end_kernel
+amdgcn.kernel @vgpr_to_agpr_copy_not_expanded {
+  %tgt = alloca : !amdgcn.agpr<0>
+  %src = alloca : !amdgcn.vgpr<0>
+  test_inst outs %src : (!amdgcn.vgpr<0>) -> ()
+  lsir.copy %tgt, %src : !amdgcn.agpr<0>, !amdgcn.vgpr<0>
+  end_kernel
+}
+
+// -----
+
+// Negative case: AGPR-to-VGPR copy is not expanded because hardware requires
+// an explicit v_accvgpr_read_b32 for this transfer.
+
+// CHECK-LABEL: amdgcn.kernel @agpr_to_vgpr_copy_not_expanded {
+// CHECK-DAG:     %[[V0:.*]] = alloca : !amdgcn.vgpr<0>
+// CHECK-DAG:     %[[A0:.*]] = alloca : !amdgcn.agpr<0>
+// CHECK:         lsir.copy %[[V0]], %[[A0]] : !amdgcn.vgpr<0>, !amdgcn.agpr<0>
+// CHECK:         end_kernel
+amdgcn.kernel @agpr_to_vgpr_copy_not_expanded {
+  %tgt = alloca : !amdgcn.vgpr<0>
+  %src = alloca : !amdgcn.agpr<0>
+  test_inst outs %src : (!amdgcn.agpr<0>) -> ()
+  lsir.copy %tgt, %src : !amdgcn.vgpr<0>, !amdgcn.agpr<0>
+  end_kernel
+}

--- a/test/Dialect/AMDGCN/Transforms/register-coloring-agpr.mlir
+++ b/test/Dialect/AMDGCN/Transforms/register-coloring-agpr.mlir
@@ -1,4 +1,4 @@
-// RUN: aster-opt %s --amdgcn-register-coloring --cse --split-input-file | FileCheck %s
+// RUN: aster-opt %s --amdgcn-register-coloring --amdgcn-post-reg-alloc-legalization --cse --split-input-file | FileCheck %s
 
 // CHECK-LABEL: amdgcn.kernel @agpr_no_interference {
 // CHECK:         %[[A0:.*]] = alloca : !amdgcn.agpr<0>

--- a/test/Dialect/AMDGCN/Transforms/register-coloring-pipelined.mlir
+++ b/test/Dialect/AMDGCN/Transforms/register-coloring-pipelined.mlir
@@ -1,4 +1,4 @@
-// RUN: aster-opt --amdgcn-register-coloring --cse --split-input-file %s | FileCheck %s
+// RUN: aster-opt --amdgcn-register-coloring --amdgcn-post-reg-alloc-legalization --cse --split-input-file %s | FileCheck %s
 
 func.func private @rand() -> i1
 // CHECK-LABEL:   func.func @two_stage_load_basic() {

--- a/test/Dialect/AMDGCN/Transforms/register-coloring.mlir
+++ b/test/Dialect/AMDGCN/Transforms/register-coloring.mlir
@@ -1,4 +1,4 @@
-// RUN: aster-opt %s --amdgcn-register-coloring --cse --split-input-file | FileCheck %s
+// RUN: aster-opt %s --amdgcn-register-coloring --amdgcn-post-reg-alloc-legalization --cse --split-input-file | FileCheck %s
 
 // CHECK-LABEL:   amdgcn.kernel @range_allocations {
 // CHECK-DAG:       %[[VAL_0:.*]] = alloca : !amdgcn.vgpr<0>


### PR DESCRIPTION
Moves copy-to-mov expansion and redundant-mov elimination out of
RegisterColoring into a new PostRegAllocLegalization pass, run after
coloring in the reg-alloc pipeline. In PostRegAllocLegalization,
MovInstOpPattern (benefit=2) eliminates self-copies before
CopyExpansionPattern (benefit=1) expands the remaining copies to
hardware mov instructions.