### PR TITLE
[amdgcn] Refactor register coloring to make it more modular

### DIFF
--- a/include/aster/Dialect/AMDGCN/Transforms/AMDGCNPasses.td
+++ b/include/aster/Dialect/AMDGCN/Transforms/AMDGCNPasses.td
@@ -91,12 +91,12 @@ def RegisterColoring : Pass<"amdgcn-register-coloring"> {
   let options = [
     Option<"buildMode", "mode", "std::string", "\"minimal\"",
            "Graph build mode: \"minimal\" (default) or \"full\"">,
-    Option<"optimize", "optimize", "bool", "true",
-           "If true, run optimizeGraph to coalesce non-interfering nodes">,
     Option<"numVGPRs", "num-vgprs", "int32_t", "256",
            "Maximum number of VGPRs available for allocation (default 256)">,
     Option<"numAGPRs", "num-agprs", "int32_t", "256",
            "Maximum number of AGPRs available for allocation (default 256)">,
+    Option<"numSGPRs", "num-sgprs", "int32_t", "102",
+           "Maximum number of SGPRs available for allocation (default 102)">,
   ];
 }
 

--- a/include/aster/Dialect/AMDGCN/Transforms/Transforms.h
+++ b/include/aster/Dialect/AMDGCN/Transforms/Transforms.h
@@ -13,10 +13,9 @@
 #define ASTER_DIALECT_AMDGCN_TRANSFORMS_TRANSFORMS_H
 
 #include "aster/Dialect/AMDGCN/Analysis/RegisterInterferenceGraph.h"
-#include "llvm/ADT/EquivalenceClasses.h"
-#include "llvm/ADT/IntEqClasses.h"
-
-#include <optional>
+#include "aster/Support/Graph.h"
+#include "mlir/Support/LogicalResult.h"
+#include "llvm/ADT/SmallVector.h"
 
 namespace mlir {
 class Operation;
@@ -28,35 +27,30 @@ namespace amdgcn {
 /// run before calling this function.
 void registerDCE(Operation *op, DataFlowSolver &solver);
 
-/// Class holding coalescing information for register coloring.
+/// The interference graph remapped through equivalence classes, with
+/// coalescing information for register coloring.
 struct CoalescingInfo {
-  /// Optimize the register interference graph and return equivalence classes
-  /// (e.g. for coalescing). Returns std::nullopt if optimization does not
-  /// apply or fails. The dataflow solver is expected to be loaded with the
-  /// reaching definitions analysis tracking only loads.
-  static std::optional<CoalescingInfo>
-  optimizeGraph(Operation *op, RegisterInterferenceGraph &graph,
-                DataFlowSolver &solver);
+  /// Optimize the register interference graph by coalescing non-interfering
+  /// registers connected by move operations, and return the resulting quotient
+  /// graph. Returns failure if move analysis encounters an unexpected register
+  /// form.
+  static FailureOr<CoalescingInfo>
+  optimizeGraph(Operation *op, RegisterInterferenceGraph &graph);
 
-  /// Get the range information for a node ID. For any node returns the leader
-  /// node ID, and the range constraint.
-  std::pair<int32_t, RangeConstraint *>
-  getRangeInfo(RegisterInterferenceGraph &graph, int32_t nodeId) {
-    return graph.getRangeInfo(nodeClasses.findLeader(nodeId));
-  }
-
-  /// Get the leader of the equivalence class for the given node ID.
-  int32_t getLeader(int32_t nodeId) const {
-    return nodeClasses.findLeader(nodeId);
-  }
-
-  /// Equivalence classes for coalescing.
-  llvm::EquivalenceClasses<int32_t> eqClasses;
-
-private:
-  /// This contains the same equivalence classes as eqClasses, but it has the
-  /// guarantee that the leader of each class is the smallest member.
-  llvm::IntEqClasses nodeClasses;
+  /// The interference graph remapped through equivalence classes (undirected).
+  Graph graph{/*directed=*/false};
+  /// Representative value for each quotient node.
+  SmallVector<Value> values;
+  /// Range constraint for each quotient node (nullptr if singleton).
+  SmallVector<RangeConstraint *> constraints;
+  /// Flat storage of original node IDs grouped by quotient class, in
+  /// ascending order within each class. Class qid occupies
+  /// memberData[memberOffsets[qid] .. memberOffsets[qid+1]).
+  /// memberData[memberOffsets[qid]] is the minimum (representative) of qid.
+  SmallVector<int32_t> memberData;
+  SmallVector<int32_t> memberOffsets;
+  /// nodeClass[origId] is the quotient class ID of original node origId.
+  SmallVector<int32_t> nodeClass;
 };
 } // namespace amdgcn
 } // namespace aster

--- a/lib/Dialect/AMDGCN/Transforms/CMakeLists.txt
+++ b/lib/Dialect/AMDGCN/Transforms/CMakeLists.txt
@@ -4,6 +4,7 @@ add_mlir_library(AMDGCNTransforms
   ConvertLDSBuffers.cpp
   ConvertWaits.cpp
   ExpandMetadataOps.cpp
+  GraphColoring.cpp
   HoistIterArgWaits.cpp
   HoistOps.cpp
   InstructionSchedulingAutoschedulePass.cpp

--- a/lib/Dialect/AMDGCN/Transforms/GraphColoring.cpp
+++ b/lib/Dialect/AMDGCN/Transforms/GraphColoring.cpp
@@ -1,0 +1,281 @@
+//===- GraphColoring.cpp - Graph coloring for register allocation ---------===//
+//
+// Copyright 2025 The ASTER Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "GraphColoring.h"
+#include "aster/Dialect/AMDGCN/IR/AMDGCNEnums.h"
+#include "aster/Interfaces/RegisterType.h"
+#include "aster/Support/Graph.h"
+#include "mlir/IR/Diagnostics.h"
+#include "mlir/IR/Location.h"
+#include "mlir/Support/LLVM.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/DebugLog.h"
+#include <set>
+
+#define DEBUG_TYPE "amdgcn-register-coloring"
+
+using namespace mlir;
+using namespace mlir::aster;
+using namespace mlir::aster::amdgcn;
+
+namespace {
+
+//===----------------------------------------------------------------------===//
+// Allocation
+//===----------------------------------------------------------------------===//
+
+/// A physical register allocation: a contiguous range [begin, begin+size) of a
+/// particular register kind.
+struct Allocation {
+  int16_t begin;
+  int16_t size;
+  RegisterKind kind;
+
+  Allocation(int16_t begin, int16_t size, RegisterKind kind)
+      : begin(begin), size(size), kind(kind) {}
+
+  Allocation(AMDGCNRegisterTypeInterface regTy, int64_t numRegs)
+      : begin(regTy.getAsRange().begin().getRegister()),
+        size(static_cast<int16_t>(numRegs)), kind(regTy.getRegisterKind()) {}
+
+  Register getBegin() const { return Register(begin); }
+  Register getEnd() const { return Register(begin + size); }
+  RegisterRange getRange() const { return RegisterRange(getBegin(), size, 1); }
+  int16_t end() const { return begin + size; }
+
+  bool operator<(const Allocation &other) const {
+    return std::make_tuple(kind, begin) <
+           std::make_tuple(other.kind, other.begin);
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// AllocConstraints
+//===----------------------------------------------------------------------===//
+
+/// Physical register occupancy tracker. Finds the first free physical range
+/// satisfying the given size and alignment.
+///
+/// numSGPR defaults to 102 — the fixed SGPR limit per wavefront on AMD GCN
+/// architectures.
+struct AllocConstraints {
+  AllocConstraints(int32_t numVGPR = 256, int32_t numAGPR = 256,
+                   int32_t numSGPR = 102)
+      : numSGPR(numSGPR), numVGPR(numVGPR), numAGPR(numAGPR) {}
+
+  /// Insert a given allocation.
+  void insert(Allocation alloc);
+
+  /// Allocate registers for a node. Returns failure if no suitable range could
+  /// be found.
+  FailureOr<Allocation> alloc(AMDGCNRegisterTypeInterface regTy,
+                              int16_t numRegs, int16_t alignment);
+
+  /// Clear all allocations.
+  void clear();
+
+  /// Print the allocation constraints.
+  void print(raw_ostream &os) const;
+
+private:
+  /// The number of SGPRs per wavefront.
+  const int32_t numSGPR;
+  /// The number of VGPRs.
+  const int32_t numVGPR;
+  /// The number of AGPRs.
+  const int32_t numAGPR;
+  /// The allocation constraints. std::set is used here because the allocator
+  /// requires ordered iteration by (kind, begin) to scan for gaps efficiently.
+  std::set<Allocation> constraints;
+};
+
+//===----------------------------------------------------------------------===//
+// GraphColoringImpl
+//===----------------------------------------------------------------------===//
+
+/// Pure graph coloring implementation. Holds no Value, no Op, no IRRewriter,
+/// no RegisterInterferenceGraph, and no CoalescingInfo.
+struct GraphColoringImpl {
+  GraphColoringImpl(const aster::Graph &graph,
+                    ArrayRef<NodeConstraint> nodeConstraints,
+                    MutableArrayRef<AMDGCNRegisterTypeInterface> types,
+                    Location loc, int32_t numVGPRs, int32_t numAGPRs,
+                    int32_t numSGPRs)
+      : graph(graph), nodeConstraints(nodeConstraints), types(types), loc(loc),
+        allocConstraints(numVGPRs, numAGPRs, numSGPRs) {}
+
+  /// Run graph coloring. Returns failure if any node cannot be colored.
+  LogicalResult run();
+
+private:
+  /// Collect interference constraints from already-colored neighbors of nodeId.
+  /// For range leaders, also collects from the neighbors of consecutive
+  /// positions [nodeId+1, nodeId+numRegs).
+  void collectConstraints(int32_t nodeId);
+
+  /// Assign a physical register to nodeId (and all consecutive range positions
+  /// if nodeConstraints[nodeId].numRegs > 1).
+  LogicalResult colorNode(int32_t nodeId);
+
+  const aster::Graph &graph;
+  ArrayRef<NodeConstraint> nodeConstraints;
+  MutableArrayRef<AMDGCNRegisterTypeInterface> types;
+  Location loc;
+  AllocConstraints allocConstraints;
+  llvm::DenseSet<int32_t> visited;
+};
+
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// AllocConstraints implementation
+//===----------------------------------------------------------------------===//
+
+void AllocConstraints::insert(Allocation alloc) { constraints.insert(alloc); }
+
+FailureOr<Allocation> AllocConstraints::alloc(AMDGCNRegisterTypeInterface regTy,
+                                              int16_t numRegs,
+                                              int16_t alignment) {
+  LDBG() << "  Allocating " << numRegs << " registers of kind "
+         << regTy.getRegisterKind() << " with alignment " << alignment;
+
+  int16_t maxRegs = 0;
+  switch (regTy.getRegisterKind()) {
+  case RegisterKind::SGPR:
+    maxRegs = numSGPR;
+    break;
+  case RegisterKind::VGPR:
+    maxRegs = numVGPR;
+    break;
+  case RegisterKind::AGPR:
+    maxRegs = numAGPR;
+    break;
+  default:
+    maxRegs = 1;
+  }
+
+  auto lb = constraints.lower_bound({0, 1, regTy.getRegisterKind()});
+  auto ub = constraints.upper_bound({maxRegs, 1, regTy.getRegisterKind()});
+
+  auto getStartAligned = [alignment](int64_t addr) {
+    return static_cast<int16_t>(((addr + alignment - 1) / alignment) *
+                                alignment);
+  };
+
+  int16_t start = 0;
+  for (const Allocation &occupied : llvm::make_range(lb, ub)) {
+    if (start + numRegs <= occupied.begin) {
+      Allocation result = {start, numRegs, occupied.kind};
+      constraints.insert(result);
+      return result;
+    }
+    start = getStartAligned(occupied.end());
+  }
+
+  // Check if we can fit at the end.
+  if (start + numRegs <= maxRegs) {
+    Allocation result = {start, numRegs, regTy.getRegisterKind()};
+    constraints.insert(result);
+    return result;
+  }
+
+  return failure();
+}
+
+void AllocConstraints::clear() { constraints.clear(); }
+
+void AllocConstraints::print(raw_ostream &os) const {
+  os << "{";
+  llvm::interleaveComma(constraints, os, [&](const Allocation &a) {
+    os << a.getRange() << " : " << stringifyRegisterKind(a.kind);
+  });
+  os << "}";
+}
+
+//===----------------------------------------------------------------------===//
+// GraphColoringImpl implementation
+//===----------------------------------------------------------------------===//
+
+void GraphColoringImpl::collectConstraints(int32_t nodeId) {
+  LDBG() << " Collecting constraints for node[" << nodeId << "]";
+
+  NodeConstraint nc = nodeConstraints[nodeId];
+  int32_t numPositions = nc.numRegs;
+
+  for (int32_t pos = 0; pos < numPositions; ++pos) {
+    int32_t posId = nodeId + pos;
+    for (auto [src, tgt] : graph.edges(posId)) {
+      LDBG() << "  Inspecting neighbor[" << tgt << "]";
+      AMDGCNRegisterTypeInterface regTy = types[tgt];
+      if (!regTy.hasAllocatedSemantics())
+        continue;
+      assert(regTy.getAsRange().size() == 1 && "expected single register");
+      allocConstraints.insert(Allocation(regTy, 1));
+    }
+  }
+}
+
+LogicalResult GraphColoringImpl::colorNode(int32_t nodeId) {
+  NodeConstraint nc = nodeConstraints[nodeId];
+
+  // Non-leader range positions are pre-marked visited by the leader's colorNode
+  // loop and skipped by run() before colorNode is ever called on them.
+  assert(nc.numRegs > 0 &&
+         "colorNode must not be called on non-leader positions");
+
+  AMDGCNRegisterTypeInterface regTy = types[nodeId];
+  int16_t numRegs = static_cast<int16_t>(nc.numRegs);
+  int16_t alignment = static_cast<int16_t>(nc.alignment);
+
+  LDBG() << "Allocating node[" << nodeId << "] with " << numRegs
+         << " regs, alignment " << alignment;
+
+  FailureOr<Allocation> alloc =
+      allocConstraints.alloc(regTy, numRegs, alignment);
+  if (failed(alloc))
+    return emitError(loc) << "failed to allocate the registers";
+
+  // Write the allocated type for each consecutive range position.
+  for (int32_t i = 0; i < numRegs; ++i) {
+    Register reg = alloc->getBegin().getWithOffset(static_cast<int16_t>(i));
+    types[nodeId + i] =
+        cast<AMDGCNRegisterTypeInterface>(regTy.cloneRegisterType(reg));
+    visited.insert(nodeId + i);
+  }
+  return success();
+}
+
+LogicalResult GraphColoringImpl::run() {
+  for (auto [i, regTy] : llvm::enumerate(types)) {
+    if (!visited.insert(static_cast<int32_t>(i)).second)
+      continue;
+    if (regTy.hasAllocatedSemantics())
+      continue;
+    allocConstraints.clear();
+    collectConstraints(static_cast<int32_t>(i));
+    if (failed(colorNode(static_cast<int32_t>(i))))
+      return failure();
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// colorGraph entry point
+//===----------------------------------------------------------------------===//
+
+LogicalResult mlir::aster::amdgcn::colorGraph(
+    const aster::Graph &graph, ArrayRef<NodeConstraint> constraints,
+    MutableArrayRef<AMDGCNRegisterTypeInterface> types, Location loc,
+    int32_t numVGPRs, int32_t numAGPRs, int32_t numSGPRs) {
+  return GraphColoringImpl(graph, constraints, types, loc, numVGPRs, numAGPRs,
+                           numSGPRs)
+      .run();
+}

--- a/lib/Dialect/AMDGCN/Transforms/GraphColoring.h
+++ b/lib/Dialect/AMDGCN/Transforms/GraphColoring.h
@@ -1,0 +1,67 @@
+//===- GraphColoring.h - Graph coloring for register allocation ---*- C++
+//-*-===//
+//
+// Copyright 2025 The ASTER Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ASTER_LIB_DIALECT_AMDGCN_TRANSFORMS_GRAPHCOLORING_H
+#define ASTER_LIB_DIALECT_AMDGCN_TRANSFORMS_GRAPHCOLORING_H
+
+#include "aster/Dialect/AMDGCN/IR/Interfaces/AMDGCNRegisterTypeInterface.h"
+#include "aster/Support/Graph.h"
+#include "mlir/IR/Location.h"
+#include "mlir/Support/LLVM.h"
+#include "llvm/ADT/ArrayRef.h"
+
+namespace mlir::aster::amdgcn {
+
+/// Per-node constraint carrying only integer data. The caller
+/// (RegisterColoring) extracts these values from RangeConstraint before calling
+/// colorGraph, so that GraphColoring has no dependency on mlir::Value or
+/// RangeConstraint.
+///
+/// numRegs == 1 means singleton (no range constraint).
+/// numRegs > 1 means this is the range leader for a multi-register allocation.
+/// numRegs == 0 marks a non-leader range position; run() skips these via the
+/// visited set, which the leader's colorNode call populates.
+struct NodeConstraint {
+  int32_t numRegs = 1;
+  int32_t alignment = 1;
+};
+
+/// Assign physical register types to every unallocated node in the graph.
+///
+/// graph       — the already-materialized quotient graph (or original
+///               interference graph cast to Graph) built by the caller.
+/// constraints — one NodeConstraint per node in graph; the caller populates
+///               this from RangeConstraint or quotientGraph.constraints.
+///               Entries with numRegs == 0 are non-leader range positions
+///               and are skipped.
+/// types       — one AMDGCNRegisterTypeInterface per node; on entry holds the
+///               node's current (unallocated) type; on exit holds the
+///               allocated type for colored nodes; unchanged for
+///               already-allocated nodes. The caller must ensure no entry has
+///               value semantics (verified before calling).
+/// loc         — diagnostic location used when allocation fails (typically the
+///               enclosing function's loc).
+/// numVGPRs    — number of available VGPRs (default 256).
+/// numAGPRs    — number of available AGPRs (default 256).
+/// numSGPRs    — number of available SGPRs (default 102). AMD GCN architectures
+///               impose a fixed limit of 102 SGPRs per wavefront.
+///
+/// Returns failure if any node cannot be allocated (register pressure
+/// exceeded).
+LogicalResult colorGraph(const aster::Graph &graph,
+                         ArrayRef<NodeConstraint> constraints,
+                         MutableArrayRef<AMDGCNRegisterTypeInterface> types,
+                         Location loc, int32_t numVGPRs = 256,
+                         int32_t numAGPRs = 256, int32_t numSGPRs = 102);
+
+} // namespace mlir::aster::amdgcn
+
+#endif // ASTER_LIB_DIALECT_AMDGCN_TRANSFORMS_GRAPHCOLORING_H

--- a/lib/Dialect/AMDGCN/Transforms/OptimizeInterferenceGraph.cpp
+++ b/lib/Dialect/AMDGCN/Transforms/OptimizeInterferenceGraph.cpp
@@ -19,6 +19,8 @@
 #include "llvm/ADT/IntEqClasses.h"
 #include "llvm/Support/DebugLog.h"
 
+#include <limits>
+
 #define DEBUG_TYPE "amdgcn-interference-opt"
 
 using namespace mlir;
@@ -41,13 +43,12 @@ struct MovDesc {
 };
 
 struct OptimizeGraphImpl {
-  OptimizeGraphImpl(RegisterInterferenceGraph &graph, DataFlowSolver &solver,
-                    EqClasses &eqClasses, llvm::IntEqClasses &nodeClasses)
-      : graph(graph), solver(solver), eqClasses(eqClasses),
-        nodeClasses(nodeClasses) {}
+  OptimizeGraphImpl(RegisterInterferenceGraph &graph, EqClasses &eqClasses,
+                    llvm::IntEqClasses &nodeClasses)
+      : graph(graph), eqClasses(eqClasses), nodeClasses(nodeClasses) {}
 
   /// Build equivalence classes for the interference graph.
-  bool run(Operation *root);
+  LogicalResult run(Operation *root);
 
   /// Collect a move operation: resolve its allocas and assign a coalescing
   /// priority (0 = load-sourced, preferred; 1 = default).
@@ -57,7 +58,6 @@ struct OptimizeGraphImpl {
   void optimizeGraph();
 
   RegisterInterferenceGraph &graph;
-  DataFlowSolver &solver;
   EqClasses &eqClasses;
   llvm::IntEqClasses &nodeClasses;
   SmallVector<MovDesc> movOps;
@@ -254,7 +254,7 @@ void OptimizeGraphImpl::optimizeGraph() {
   }
 }
 
-bool OptimizeGraphImpl::run(Operation *root) {
+LogicalResult OptimizeGraphImpl::run(Operation *root) {
   WalkResult result = root->walk([&](Operation *op) -> WalkResult {
     FailureOr<std::pair<Value, Value>> moveInfo = getMoveInfo(op);
     if (failed(moveInfo))
@@ -277,7 +277,7 @@ bool OptimizeGraphImpl::run(Operation *root) {
     return WalkResult::advance();
   });
   if (result.wasInterrupted())
-    return false;
+    return failure();
 
   // Sort the moves by priority. Stable sort is used to preserve the order of
   // moves with the same priority.
@@ -291,24 +291,77 @@ bool OptimizeGraphImpl::run(Operation *root) {
   for (int32_t i = 0; i < numNodes; ++i)
     eqClasses.insert(i);
   optimizeGraph();
-  if (eqClasses.getNumClasses() == static_cast<unsigned>(numNodes))
-    return false;
-
-  // Compress and uncompress the leader classes for faster lookup. Note that we
-  // can't use a compress class as it would point to a class rather than a node.
   nodeClasses.compress();
-  nodeClasses.uncompress();
-  return true;
+  return success();
 }
 
-std::optional<CoalescingInfo>
-CoalescingInfo::optimizeGraph(Operation *op, RegisterInterferenceGraph &graph,
-                              DataFlowSolver &solver) {
-  if (!graph.isCompressed())
-    return std::nullopt;
+/// Build a CoalescingInfo from the interference graph and equivalence classes.
+/// nodeClasses must already be compressed. For each quotient node the
+/// representative is the minimum-ID original node in that class, which is
+/// always the range leader because ranges have consecutive IDs by construction.
+static CoalescingInfo buildCoalescingInfo(RegisterInterferenceGraph &graph,
+                                          llvm::IntEqClasses &nodeClasses) {
+  int32_t numQuotient = static_cast<int32_t>(nodeClasses.getNumClasses());
+  int32_t numNodes = graph.sizeNodes();
   CoalescingInfo info;
-  OptimizeGraphImpl impl(graph, solver, info.eqClasses, info.nodeClasses);
-  if (!impl.run(op))
-    return std::nullopt;
+
+  // Build the forward map (nodeClass) and count class sizes for the CSR
+  // offset array.
+  info.nodeClass.resize(numNodes);
+  info.memberOffsets.resize(numQuotient + 1, 0);
+  for (int32_t i = 0; i < numNodes; ++i) {
+    int32_t qid = static_cast<int32_t>(nodeClasses[i]);
+    info.nodeClass[i] = qid;
+    ++info.memberOffsets[qid + 1];
+  }
+  // Prefix-sum the sizes to get offsets.
+  for (int32_t qid = 0; qid < numQuotient; ++qid)
+    info.memberOffsets[qid + 1] += info.memberOffsets[qid];
+
+  // Fill memberData in one pass. Nodes are visited in ascending order so each
+  // class's slice is already sorted and its first element is the
+  // representative.
+  info.memberData.resize(numNodes);
+  SmallVector<int32_t> cursor(info.memberOffsets.begin(),
+                              info.memberOffsets.begin() + numQuotient);
+  for (int32_t i = 0; i < numNodes; ++i) {
+    int32_t qid = info.nodeClass[i];
+    info.memberData[cursor[qid]++] = i;
+  }
+
+  // Populate values and constraints using the minimum member of each class as
+  // the representative.
+  info.values.resize(numQuotient);
+  info.constraints.resize(numQuotient);
+  for (int32_t qid = 0; qid < numQuotient; ++qid) {
+    int32_t leader = info.memberData[info.memberOffsets[qid]];
+    info.values[qid] = graph.getValue(leader);
+    auto [rangeId, constraint] = graph.getRangeInfo(leader);
+    // Only store the constraint when the leader is also the range leader so
+    // that allocation iterates the range exactly once per quotient node.
+    info.constraints[qid] = (rangeId == leader) ? constraint : nullptr;
+  }
+
+  // Build the quotient graph by remapping edges directly, without copying the
+  // original edge set into an intermediate graph first.
+  info.graph = Graph(/*directed=*/false);
+  info.graph.setNumNodes(numQuotient);
+  for (auto [src, tgt] : graph.edges()) {
+    int32_t s = static_cast<int32_t>(nodeClasses[src]);
+    int32_t t = static_cast<int32_t>(nodeClasses[tgt]);
+    if (s != t)
+      info.graph.addEdge(s, t);
+  }
+  info.graph.compress();
   return info;
+}
+
+FailureOr<CoalescingInfo>
+CoalescingInfo::optimizeGraph(Operation *op, RegisterInterferenceGraph &graph) {
+  assert(graph.isCompressed() && "graph must be compressed");
+  EqClasses eqClasses;
+  llvm::IntEqClasses nodeClasses;
+  if (failed(OptimizeGraphImpl(graph, eqClasses, nodeClasses).run(op)))
+    return failure();
+  return buildCoalescingInfo(graph, nodeClasses);
 }

--- a/lib/Dialect/AMDGCN/Transforms/Pipelines.cpp
+++ b/lib/Dialect/AMDGCN/Transforms/Pipelines.cpp
@@ -36,10 +36,6 @@ struct RegAllocPipelineOptions
       *this, "mode",
       llvm::cl::desc("Graph build mode: \"minimal\" (default) or \"full\""),
       llvm::cl::init("minimal")};
-  mlir::detail::PassOptions::Option<bool> optimize{
-      *this, "optimize",
-      llvm::cl::desc("Run optimizeGraph to coalesce non-interfering nodes"),
-      llvm::cl::init(true)};
   mlir::detail::PassOptions::Option<int32_t> numVGPRs{
       *this, "num-vgprs",
       llvm::cl::desc("Maximum VGPRs for allocation (default 256)"),
@@ -48,6 +44,10 @@ struct RegAllocPipelineOptions
       *this, "num-agprs",
       llvm::cl::desc("Maximum AGPRs for allocation (default 256)"),
       llvm::cl::init(256)};
+  mlir::detail::PassOptions::Option<int32_t> numSGPRs{
+      *this, "num-sgprs",
+      llvm::cl::desc("Maximum SGPRs for allocation (default 102)"),
+      llvm::cl::init(102)};
   mlir::detail::PassOptions::Option<bool> hoistIterArgWaits{
       *this, "hoist-iter-arg-waits",
       llvm::cl::desc("Hoist iter_arg-dependent waits to loop head"),
@@ -94,9 +94,9 @@ static void buildRegAllocPassPipeline(OpPassManager &pm,
   pm.addPass(createPreColoringLegalization());
   RegisterColoringOptions coloringOpts;
   coloringOpts.buildMode = options.buildMode;
-  coloringOpts.optimize = options.optimize;
   coloringOpts.numVGPRs = options.numVGPRs;
   coloringOpts.numAGPRs = options.numAGPRs;
+  coloringOpts.numSGPRs = options.numSGPRs;
   pm.addPass(createRegisterColoring(coloringOpts));
   pm.addPass(createPostRegAllocLegalization());
   pm.addPass(createHoistOps());

--- a/lib/Dialect/AMDGCN/Transforms/RegisterColoring.cpp
+++ b/lib/Dialect/AMDGCN/Transforms/RegisterColoring.cpp
@@ -8,6 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "GraphColoring.h"
 #include "aster/Dialect/AMDGCN/Analysis/RangeConstraintAnalysis.h"
 #include "aster/Dialect/AMDGCN/Analysis/RegisterInterferenceGraph.h"
 #include "aster/Dialect/AMDGCN/IR/AMDGCNAttrs.h"
@@ -17,8 +18,7 @@
 #include "aster/Dialect/LSIR/IR/LSIROps.h"
 #include "mlir/Analysis/DataFlowFramework.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
-#include "llvm/ADT/EquivalenceClasses.h"
-#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallBitVector.h"
 #include "llvm/Support/DebugLog.h"
 
 #define DEBUG_TYPE "amdgcn-register-coloring"
@@ -35,7 +35,6 @@ using namespace mlir::aster;
 using namespace mlir::aster::amdgcn;
 
 namespace {
-using EqClasses = llvm::EquivalenceClasses<int32_t>;
 static constexpr std::string_view kCastOpTag = "__amdgcn_register_coloring__";
 //===----------------------------------------------------------------------===//
 // RegisterColoring pass
@@ -48,92 +47,6 @@ public:
 
   /// Run the transformation on the given function.
   LogicalResult run(FunctionOpInterface funcOp);
-};
-
-//===----------------------------------------------------------------------===//
-// RegisterAllocator
-//===----------------------------------------------------------------------===//
-/// A memory allocation.
-struct Allocation {
-  int16_t begin;
-  int16_t size;
-  RegisterKind kind;
-
-  Allocation(int16_t begin, int16_t size, RegisterKind kind)
-      : begin(begin), size(size), kind(kind) {}
-
-  Allocation(AMDGCNRegisterTypeInterface regTy, int64_t numRegs)
-      : begin(regTy.getAsRange().begin().getRegister()), size(numRegs),
-        kind(regTy.getRegisterKind()) {}
-
-  Register getBegin() const { return Register(begin); }
-  Register getEnd() const { return Register(begin + size); }
-  RegisterRange getRange() const { return RegisterRange(getBegin(), size, 1); }
-  int16_t end() const { return begin + size; }
-
-  bool operator<(const Allocation &other) const {
-    return std::make_tuple(kind, begin) <
-           std::make_tuple(other.kind, other.begin);
-  }
-};
-
-/// The allocation constraints.
-struct AllocConstraints {
-  AllocConstraints(int32_t numVGPR = 256, int32_t numAGPR = 256)
-      : numVGPR(numVGPR), numAGPR(numAGPR) {}
-
-  /// Insert a given allocation.
-  void insert(Allocation alloc);
-
-  /// Allocate memory for a given node, returns failure if no suitable region
-  /// could be found.
-  FailureOr<Allocation> alloc(AMDGCNRegisterTypeInterface regTy,
-                              int16_t numRegs, int16_t alignment);
-
-  /// Clear all allocations.
-  void clear();
-
-  /// Print the allocation constraints.
-  void print(raw_ostream &os) const;
-
-private:
-  /// The number of SGPRs.
-  const int32_t numSGPR = 102;
-  /// The number of VGPRs.
-  const int32_t numVGPR;
-  /// The number of AGPRs.
-  const int32_t numAGPR;
-  /// The allocation constraints.
-  std::set<Allocation> constraints;
-};
-
-/// A greedy allocator for registers based on the interference graph.
-/// The allocator traverses nodes in breadth-first order and assigns registers.
-struct RegisterAllocator {
-  RegisterAllocator(RegisterInterferenceGraph &graph,
-                    std::optional<CoalescingInfo> &&coalescingInfo,
-                    MLIRContext *ctx, int32_t numVGPRs = 256,
-                    int32_t numAGPRs = 256)
-      : graph(graph), constraints(numVGPRs, numAGPRs),
-        coalescingInfo(coalescingInfo), rewriter(ctx) {}
-
-  /// Run the allocator on all nodes, returns failure if an allocation request
-  /// cannot be satisfied.
-  LogicalResult run(FunctionOpInterface op);
-
-private:
-  /// Collect the allocation constraints for the given node.
-  LogicalResult collectConstraints(int32_t nodeId, ArrayRef<Value> nodes);
-  /// Allocate memory for a register node.
-  LogicalResult alloc(int32_t nodeId, Value alloca);
-
-  RegisterInterferenceGraph &graph;
-  AllocConstraints constraints;
-  std::optional<CoalescingInfo> coalescingInfo;
-  IRRewriter rewriter;
-  llvm::DenseSet<int32_t> visited;
-  /// Insertion point, updated as allocations are inserted.
-  OpBuilder::InsertPoint ip;
 };
 
 //===----------------------------------------------------------------------===//
@@ -163,266 +76,16 @@ struct RegInterferenceOpPattern : public OpRewritePattern<RegInterferenceOp> {
 } // namespace
 
 //===----------------------------------------------------------------------===//
-// AllocConstraints
-//===----------------------------------------------------------------------===//
-
-void AllocConstraints::insert(Allocation alloc) { constraints.insert(alloc); }
-
-FailureOr<Allocation> AllocConstraints::alloc(AMDGCNRegisterTypeInterface regTy,
-                                              int16_t numRegs,
-                                              int16_t alignment) {
-  LDBG() << "  Allocating " << numRegs << " registers of kind "
-         << regTy.getRegisterKind() << " with alignment " << alignment;
-  int16_t start = 0;
-  auto getStartAligned = [&](int64_t addr) {
-    return ((addr + alignment - 1) / alignment) * alignment;
-  };
-
-  int16_t maxRegs = 0;
-  switch (regTy.getRegisterKind()) {
-  case RegisterKind::SGPR:
-    maxRegs = numSGPR;
-    break;
-  case RegisterKind::VGPR:
-    maxRegs = numVGPR;
-    break;
-  case RegisterKind::AGPR:
-    maxRegs = numAGPR;
-    break;
-  default:
-    maxRegs = 1;
-  }
-
-  auto lb = constraints.lower_bound({0, 1, regTy.getRegisterKind()});
-  auto ub = constraints.upper_bound({maxRegs, 1, regTy.getRegisterKind()});
-
-  for (const Allocation &alloc : llvm::make_range(lb, ub)) {
-    // Check if we can fit before this allocation.
-    if (start + numRegs <= alloc.begin) {
-      Allocation result = {start, numRegs, alloc.kind};
-      constraints.insert(result);
-      return result;
-    }
-    start = getStartAligned(alloc.end());
-  }
-
-  // Check if we can fit at the end.
-  if (start + numRegs <= maxRegs) {
-    Allocation result = {start, numRegs, regTy.getRegisterKind()};
-    constraints.insert(result);
-    return result;
-  }
-
-  return failure();
-}
-
-void AllocConstraints::clear() { constraints.clear(); }
-
-void AllocConstraints::print(raw_ostream &os) const {
-  os << "{";
-  llvm::interleaveComma(constraints, os, [&](const Allocation &alloc) {
-    os << alloc.getRange() << " : " << stringifyRegisterKind(alloc.kind);
-  });
-  os << "}";
-}
-
-//===----------------------------------------------------------------------===//
-// RegisterAllocator
-//===----------------------------------------------------------------------===//
-
-LogicalResult RegisterAllocator::collectConstraints(int32_t nodeId,
-                                                    ArrayRef<Value> nodes) {
-  LDBG() << " Collecting constraints for node[" << nodeId
-         << "]: " << nodes[nodeId];
-
-  auto addConstraints = [&](int32_t node) -> LogicalResult {
-    for (auto [src, tgt] : graph.edges(node)) {
-      LDBG() << "  Inspecting neighbor[" << tgt << "]: " << nodes[tgt];
-      Value tgtNode = nodes[tgt];
-      AMDGCNRegisterTypeInterface regTy =
-          dyn_cast<AMDGCNRegisterTypeInterface>(tgtNode.getType());
-      // Skip if the node is not a register type.
-      if (!regTy)
-        continue;
-
-      // Error if the node is a value register.
-      if (regTy.hasValueSemantics())
-        return emitError(tgtNode.getLoc()) << "found unexpected value register";
-
-      // Skip if the node is not an allocated register.
-      if (!regTy.hasAllocatedSemantics())
-        continue;
-
-      assert(regTy.getAsRange().size() == 1 && "expected single register");
-      constraints.insert(Allocation(regTy, 1));
-    }
-    return success();
-  };
-
-  auto [rangeId, constraint] = coalescingInfo
-                                   ? coalescingInfo->getRangeInfo(graph, nodeId)
-                                   : graph.getRangeInfo(nodeId);
-
-  for (int32_t
-           nodeId = rangeId,
-           end = rangeId + (constraint ? constraint->allocations.size() : 1);
-       nodeId < end; ++nodeId) {
-    // If there are no coalescing classes, just add the constraints for the
-    // node.
-    if (!coalescingInfo) {
-      if (failed(addConstraints(nodeId)))
-        return failure();
-      continue;
-    }
-
-    // Otherwise, add the constraints for all members of the coalescing class.
-    for (int32_t member : coalescingInfo->eqClasses.members(nodeId)) {
-      if (failed(addConstraints(member)))
-        return failure();
-    }
-  }
-  return success();
-}
-
-LogicalResult RegisterAllocator::alloc(int32_t nodeId, Value alloca) {
-  auto regTy = dyn_cast<AMDGCNRegisterTypeInterface>(alloca.getType());
-  int64_t numRegs = 1;
-  int64_t alignment = 1;
-  ValueRange allocas = alloca;
-  // If the alloca has a range constraint, use the constraint to allocate the
-  // register.
-  auto [rangeId, constraint] = coalescingInfo
-                                   ? coalescingInfo->getRangeInfo(graph, nodeId)
-                                   : graph.getRangeInfo(nodeId);
-  if (constraint) {
-    numRegs = constraint->allocations.size();
-    alignment = constraint->alignment;
-    allocas = constraint->allocations;
-  }
-
-  OpBuilder::InsertionGuard guard(rewriter);
-
-  // Try to allocate the registers.
-  FailureOr<Allocation> alloc = constraints.alloc(regTy, numRegs, alignment);
-  if (failed(alloc))
-    return emitError(alloca.getLoc()) << "failed to allocate the registers";
-
-  // Helper to update the IR, and allocator after allocation.
-  auto updateAllocator = [&](int32_t node, Value castValue, Value alloca) {
-    // Update the graph with the new value.
-    Value oldAlloca = std::exchange(graph.getValues()[node], alloca);
-
-    // Replace all uses of the old alloca with the new alloca.
-    rewriter.replaceAllUsesWith(oldAlloca, castValue);
-
-    // Make sure we mark the node as visited since we have already allocated it.
-    visited.insert(node);
-  };
-
-  // Replace the alloca with the new alloca.
-  for (auto [i, alloca] : llvm::enumerate(allocas)) {
-    // Get the node ID for the alloca, this is the range leader + the index
-    // of the alloca in the range by construction.
-    int32_t node = rangeId + i;
-
-    // Get the alloca and set the insertion point.
-    auto allocaOp = cast<AllocaOp>(alloca.getDefiningOp());
-
-    // Set the insertion point to the last saved position.
-    assert(ip.isSet() && "insertion point is not set");
-    rewriter.restoreInsertionPoint(ip);
-
-    // Create the new alloca.
-    Register reg = alloc->getBegin().getWithOffset(i);
-    AllocaOp newAlloca = AllocaOp::create(rewriter, allocaOp.getLoc(),
-                                          regTy.cloneRegisterType(reg));
-
-    // Cast back to the original type.
-    auto cOp = UnrealizedConversionCastOp::create(rewriter, allocaOp.getLoc(),
-                                                  regTy, newAlloca.getResult());
-    cOp->setAttr(kCastOpTag, rewriter.getUnitAttr());
-
-    // Update the insertion point to the new alloca.
-    // NOTE: This checkpoint has to happen after the creation of the cast
-    // operation so that the iteration is never invalid.
-    rewriter.setInsertionPointAfter(newAlloca.getOperation());
-    ip = rewriter.saveInsertionPoint();
-
-    // Update the IR and the allocator.
-    if (!coalescingInfo) {
-      updateAllocator(node, cOp.getResult(0), newAlloca);
-      continue;
-    }
-    for (int32_t member : coalescingInfo->eqClasses.members(node))
-      updateAllocator(member, cOp.getResult(0), newAlloca);
-  }
-  return success();
-}
-
-static bool needsAllocation(Value node) {
-  auto regTy = dyn_cast<AMDGCNRegisterTypeInterface>(node.getType());
-  return regTy && !regTy.hasAllocatedSemantics();
-}
-
-LogicalResult RegisterAllocator::run(FunctionOpInterface op) {
-  Region &body = op.getFunctionBody();
-  if (body.empty())
-    return success();
-
-  // Set the insertion point to the start of the entry block. This is used to
-  // insert the allocas at the correct position and in the order they are
-  // allocated.
-  Block *entryBlock = &body.front();
-  rewriter.setInsertionPointToStart(entryBlock);
-  ip = rewriter.saveInsertionPoint();
-
-  ArrayRef<Value> nodes = graph.getValues();
-  for (auto [i, node] : llvm::enumerate(nodes)) {
-    // Skip already visited or allocated nodes.
-    if (!visited.insert(i).second || !needsAllocation(node))
-      continue;
-
-    LDBG() << "Allocating node[" << i << "]: " << node;
-
-    // Collect the neighbors constraints.
-    constraints.clear();
-    if (failed(collectConstraints(i, nodes)))
-      return failure();
-
-    LDBG_OS([&](raw_ostream &os) {
-      os << " Initial constraints: ";
-      constraints.print(os);
-    });
-
-    // Allocate the node.
-    if (failed(alloc(i, node)))
-      return failure();
-
-    LDBG_OS([&](raw_ostream &os) {
-      os << " Final constraints: ";
-      constraints.print(os);
-    });
-  }
-  return success();
-}
-
-//===----------------------------------------------------------------------===//
 // Rewrite patterns
 //===----------------------------------------------------------------------===//
 
 LogicalResult
 InstRewritePattern::matchAndRewrite(InstOpInterface op,
                                     PatternRewriter &rewriter) const {
-  bool mutatedIns = false;
-  bool mutatedOuts = false;
-
-  // Bail out if the instruction has results.
-  if (!op.getInstResults().empty()) {
+  if (!op.getInstResults().empty())
     return rewriter.notifyMatchFailure(
         op, "expected instruction with register semantics");
-  }
 
-  // Helper to handle an operand.
   auto handleOperand = [&](Value operand) -> Value {
     auto cOp =
         dyn_cast_or_null<UnrealizedConversionCastOp>(operand.getDefiningOp());
@@ -431,28 +94,24 @@ InstRewritePattern::matchAndRewrite(InstOpInterface op,
     return cOp.getInputs().front();
   };
 
-  // Check if any operand or result needs to be updated.
-  SmallVector<Value> newIns = llvm::to_vector(op.getInstIns());
+  bool mutated = false;
   SmallVector<Value> newOuts = llvm::to_vector(op.getInstOuts());
-  for (Value &operand : newOuts) {
-    Value nV = handleOperand(operand);
-    mutatedOuts |= (nV != nullptr);
-    if (nV)
-      operand = nV;
-  }
-  for (Value &operand : newIns) {
-    Value nV = handleOperand(operand);
-    mutatedIns |= (nV != nullptr);
-    if (nV)
-      operand = nV;
-  }
-
-  // Early exit if nothing changed.
-  if (!mutatedIns && !mutatedOuts)
+  SmallVector<Value> newIns = llvm::to_vector(op.getInstIns());
+  for (Value &v : newOuts)
+    if (Value nV = handleOperand(v)) {
+      v = nV;
+      mutated = true;
+    }
+  for (Value &v : newIns)
+    if (Value nV = handleOperand(v)) {
+      v = nV;
+      mutated = true;
+    }
+  if (!mutated)
     return failure();
 
   // Create the new instruction.
-  auto newInst = op.cloneInst(rewriter, newOuts, newIns);
+  InstOpInterface newInst = op.cloneInst(rewriter, newOuts, newIns);
   if (!newInst)
     return failure();
 
@@ -486,6 +145,85 @@ RegInterferenceOpPattern::matchAndRewrite(RegInterferenceOp op,
 }
 
 //===----------------------------------------------------------------------===//
+// Phase 2 helpers
+//===----------------------------------------------------------------------===//
+
+/// Emit one AllocaOp and a tagged cast for value, using allocatedType as the
+/// physical register type, then replace all uses of value with the cast result.
+/// Advances ip past the new AllocaOp so subsequent calls insert in IR order.
+static void emitAllocAndReplace(Value value,
+                                AMDGCNRegisterTypeInterface allocatedType,
+                                IRRewriter &rewriter,
+                                OpBuilder::InsertPoint &ip) {
+  assert(value.getDefiningOp() && isa<AllocaOp>(value.getDefiningOp()) &&
+         "expected alloca op for coalescing class member");
+  auto allocaOp = cast<AllocaOp>(value.getDefiningOp());
+  OpBuilder::InsertionGuard guard(rewriter);
+  rewriter.restoreInsertionPoint(ip);
+
+  AllocaOp newAlloca =
+      AllocaOp::create(rewriter, allocaOp.getLoc(), allocatedType);
+
+  // Cast back to the original unallocated type so existing uses remain valid
+  // until the downstream rewrite patterns peel the cast.
+  auto cOp = UnrealizedConversionCastOp::create(
+      rewriter, allocaOp.getLoc(), value.getType(), newAlloca.getResult());
+  cOp->setDiscardableAttr(kCastOpTag, rewriter.getUnitAttr());
+
+  // Advance ip past the new AllocaOp so subsequent allocas are inserted in
+  // textual IR order.
+  rewriter.setInsertionPointAfter(newAlloca.getOperation());
+  ip = rewriter.saveInsertionPoint();
+
+  rewriter.replaceAllUsesWith(value, cOp.getResult(0));
+}
+
+/// Derive the allocated type for range position pos relative to the leader
+/// type. The leader type carries physical register begin; position pos uses
+/// begin+pos.
+static AMDGCNRegisterTypeInterface
+getOffsetType(AMDGCNRegisterTypeInterface leaderType, int32_t pos) {
+  if (pos == 0)
+    return leaderType;
+  Register reg =
+      leaderType.getAsRange().begin().getWithOffset(static_cast<int16_t>(pos));
+  return cast<AMDGCNRegisterTypeInterface>(leaderType.cloneRegisterType(reg));
+}
+
+/// Coalescing fan-out: expand each changed quotient node to all members of its
+/// equivalence classes in the original interference graph.
+static void rewriteCoalescing(RegisterInterferenceGraph &graph,
+                              CoalescingInfo &coalescingInfo,
+                              ArrayRef<NodeConstraint> nodeConsts,
+                              ArrayRef<AMDGCNRegisterTypeInterface> types,
+                              const llvm::SmallBitVector &wasUnallocated,
+                              IRRewriter &rewriter,
+                              OpBuilder::InsertPoint &ip) {
+  int32_t m = static_cast<int32_t>(types.size());
+  for (int32_t i = 0; i < m; ++i) {
+    if (!wasUnallocated[static_cast<unsigned>(i)])
+      continue;
+    int32_t numRegs = nodeConsts[i].numRegs;
+    // Non-leader range positions in the quotient graph (numRegs == 0) are
+    // handled by their leader's fan-out loop; skip them here.
+    if (numRegs == 0)
+      continue;
+
+    for (int32_t pos = 0; pos < numRegs; ++pos) {
+      // Members for quotient slot i+pos are stored in memberData at the
+      // slice [memberOffsets[i+pos], memberOffsets[i+pos+1]).
+      int32_t qid = i + pos;
+      AMDGCNRegisterTypeInterface allocatedType = getOffsetType(types[i], pos);
+      for (int32_t j = coalescingInfo.memberOffsets[qid],
+                   end = coalescingInfo.memberOffsets[qid + 1];
+           j < end; ++j)
+        emitAllocAndReplace(graph.getValue(coalescingInfo.memberData[j]),
+                            allocatedType, rewriter, ip);
+    }
+  }
+}
+
+//===----------------------------------------------------------------------===//
 // RegisterColoring pass
 //===----------------------------------------------------------------------===//
 
@@ -510,7 +248,7 @@ LogicalResult RegisterColoring::run(FunctionOpInterface funcOp) {
 
   // Create the dataflow solver but don't run an analysis.
   // The coalescing-priority query in OptimizeInterferenceGraph::collectMov is
-  // answered on demand via/ hasReachingLoadDefinition (per-MOV backwards walk),
+  // answered on demand via hasReachingLoadDefinition (per-MOV backwards walk),
   // eliminating the global dataflow fixpoint that previously dominated compile
   // time.
   SymbolTableCollection symbolTable;
@@ -520,20 +258,83 @@ LogicalResult RegisterColoring::run(FunctionOpInterface funcOp) {
   FailureOr<RegisterInterferenceGraph> graph =
       RegisterInterferenceGraph::create(funcOp, solver, symbolTable,
                                         *rangeAnalysis, buildMode);
-  if (failed(graph)) {
+  if (failed(graph))
     return funcOp.emitError() << "failed to create register interference graph";
+
+  // Optimize the graph and get the coalescing classes.
+  FailureOr<CoalescingInfo> coalescingInfo =
+      CoalescingInfo::optimizeGraph(funcOp, *graph);
+  if (failed(coalescingInfo))
+    return funcOp.emitError() << "failed to optimize interference graph";
+
+  //===--------------------------------------------------------------------===//
+  // Phase 1: Materialize constraints and types; run colorGraph.
+  //===--------------------------------------------------------------------===//
+
+  ArrayRef<RangeConstraint *> qConsts = coalescingInfo->constraints;
+  int32_t m = static_cast<int32_t>(qConsts.size());
+
+  SmallVector<NodeConstraint> nodeConsts;
+  SmallVector<AMDGCNRegisterTypeInterface> types;
+  nodeConsts.reserve(m);
+  types.reserve(m);
+  llvm::SmallBitVector wasUnallocated(static_cast<unsigned>(m));
+
+  // Track the end of the active range so that non-leader positions (those
+  // falling inside a preceding leader's range) are marked with numRegs == 0.
+  //
+  // This relies on the invariant that, after compress(), the quotient IDs for
+  // the non-leader positions of a range are consecutive and immediately
+  // follow the leader's quotient ID. The invariant holds because:
+  //  1. Ranges are constructed with consecutive original node IDs.
+  //  2. Coalescing always merges the smaller range into the larger (or equal)
+  //     one, so the larger range's original IDs are always smaller and
+  //     IntEqClasses::join makes them the leader.
+  //  3. compress() scans original IDs in ascending order, so the leading
+  //     range's positions receive consecutive quotient IDs.
+  int32_t rangeEnd = 0;
+  for (int32_t i = 0; i < m; ++i) {
+    RangeConstraint *c = qConsts[i];
+    if (c != nullptr) {
+      nodeConsts.push_back(
+          {static_cast<int32_t>(c->allocations.size()), c->alignment});
+      rangeEnd = i + static_cast<int32_t>(c->allocations.size());
+    } else if (i < rangeEnd) {
+      // Non-leader position within an active range; the leader's colorNode
+      // call will write types[i] and mark this node visited.
+      nodeConsts.push_back({0, 1});
+    } else {
+      nodeConsts.push_back({1, 1});
+    }
+    Value v = coalescingInfo->values[i];
+    auto regTy = cast<AMDGCNRegisterTypeInterface>(v.getType());
+    if (regTy.hasValueSemantics()) {
+      emitError(v.getLoc()) << "found unexpected value register";
+      return funcOp.emitError() << "failed to run register allocator";
+    }
+    types.push_back(regTy);
+    if (!regTy.hasAllocatedSemantics())
+      wasUnallocated.set(static_cast<unsigned>(i));
   }
 
-  // Optionally optimize the graph and get the coalescing classes.
-  std::optional<CoalescingInfo> coalescingInfo;
-  if (optimize)
-    coalescingInfo = CoalescingInfo::optimizeGraph(funcOp, *graph, solver);
-
-  // Create and run the register allocator.
-  RegisterAllocator allocator(*graph, std::move(coalescingInfo),
-                              funcOp->getContext(), numVGPRs, numAGPRs);
-  if (failed(allocator.run(funcOp)))
+  if (failed(colorGraph(coalescingInfo->graph, nodeConsts, types,
+                        funcOp.getLoc(), numVGPRs, numAGPRs, numSGPRs)))
     return funcOp.emitError() << "failed to run register allocator";
+
+  //===--------------------------------------------------------------------===//
+  // Phase 2: IR rewrite.
+  //===--------------------------------------------------------------------===//
+
+  Region &body = funcOp.getFunctionBody();
+  if (!body.empty()) {
+    IRRewriter rewriter(funcOp->getContext());
+    Block *entryBlock = &body.front();
+    rewriter.setInsertionPointToStart(entryBlock);
+    OpBuilder::InsertPoint ip = rewriter.saveInsertionPoint();
+
+    rewriteCoalescing(*graph, *coalescingInfo, nodeConsts, types,
+                      wasUnallocated, rewriter, ip);
+  }
 
   RewritePatternSet patterns(&getContext());
   patterns.add<InstRewritePattern, MakeRegisterRangeOpPattern,

--- a/lib/Support/Graph.cpp
+++ b/lib/Support/Graph.cpp
@@ -112,6 +112,8 @@ LogicalResult Graph::computeQuotient(const llvm::IntEqClasses &eqClasses) {
   for (const Edge &e : edgeSet) {
     int32_t srcClass = static_cast<int32_t>(eqClasses[e.first]);
     int32_t tgtClass = static_cast<int32_t>(eqClasses[e.second]);
+    if (srcClass == tgtClass)
+      continue; // intra-class edges collapse in the quotient
     newEdgeSet.insert({srcClass, tgtClass});
   }
 

--- a/test/Dialect/AMDGCN/Transforms/reg-alloc.mlir
+++ b/test/Dialect/AMDGCN/Transforms/reg-alloc.mlir
@@ -1,14 +1,10 @@
 // RUN: aster-opt %s --amdgcn-reg-alloc | FileCheck %s
-// RUN: aster-opt %s --amdgcn-reg-alloc="mode=full optimize=false" | FileCheck %s --check-prefix=CHECK-FULL
 
 amdgcn.module @reg_alloc target = <gfx942> {
   // CHECK-LABEL: reg_alloc
-  // CHECK-FULL-LABEL: reg_alloc
   func.func private @rand() -> i1
   // CHECK-NOT: alloca : !amdgcn.vgpr<1>
   // CHECK: alloca : !amdgcn.vgpr<0>
-  // CHECK-FULL-DAG: alloca : !amdgcn.vgpr<1>
-  // CHECK-FULL-DAG: alloca : !amdgcn.vgpr<0>
   kernel @reg_alloc {
     %0 = func.call @rand() : () -> i1
     %1 = alloca : !amdgcn.vgpr

--- a/test/Dialect/AMDGCN/Transforms/register-coloring-exhaustion-nf.mlir
+++ b/test/Dialect/AMDGCN/Transforms/register-coloring-exhaustion-nf.mlir
@@ -1,0 +1,19 @@
+// RUN: aster-opt --amdgcn-register-coloring="num-vgprs=2" --verify-diagnostics %s
+
+// Verify that the register allocator rejects a kernel whose VGPR demand
+// exceeds the configured limit. Three mutually-live VGPRs cannot fit in two
+// slots; each alloca is written before the final consumer makes all three live
+// simultaneously.
+
+// expected-error @below {{failed to allocate the registers}}
+// expected-error @below {{failed to run register allocator}}
+amdgcn.kernel @vgpr_exhaustion {
+  %a = amdgcn.alloca : !amdgcn.vgpr<?>
+  %b = amdgcn.alloca : !amdgcn.vgpr<?>
+  %c = amdgcn.alloca : !amdgcn.vgpr<?>
+  amdgcn.test_inst outs %a : (!amdgcn.vgpr<?>) -> ()
+  amdgcn.test_inst outs %b : (!amdgcn.vgpr<?>) -> ()
+  amdgcn.test_inst outs %c : (!amdgcn.vgpr<?>) -> ()
+  amdgcn.test_inst ins %a, %b, %c : (!amdgcn.vgpr<?>, !amdgcn.vgpr<?>, !amdgcn.vgpr<?>) -> ()
+  amdgcn.end_kernel
+}

--- a/test/Dialect/AMDGCN/Transforms/register-coloring-pipelined.mlir
+++ b/test/Dialect/AMDGCN/Transforms/register-coloring-pipelined.mlir
@@ -443,3 +443,25 @@ func.func @two_loads_to_compute() {
   amdgcn.test_inst outs %7 ins %4, %6 : (!amdgcn.vgpr<?>, !amdgcn.vgpr<?>, !amdgcn.vgpr<?>) -> ()
   return
 }
+
+// -----
+// Verify that B and C, coalesced via lsir.copy, are assigned a register
+// other than 2 because pre-allocated neighbour A occupies vgpr<2> in the
+// quotient graph. The allocator must honour A's constraint when collecting
+// interference for the {B, C} quotient node.
+// CHECK-LABEL: func.func @coalescing_preallocated_neighbor() {
+// CHECK:         %[[BC:.*]] = amdgcn.alloca : !amdgcn.vgpr<0>
+// CHECK:         %[[A:.*]] = amdgcn.alloca : !amdgcn.vgpr<2>
+// CHECK:         amdgcn.test_inst outs %[[BC]] : (!amdgcn.vgpr<0>) -> ()
+// CHECK:         amdgcn.test_inst ins %[[A]], %[[BC]] : (!amdgcn.vgpr<2>, !amdgcn.vgpr<0>) -> ()
+// CHECK:         return
+// CHECK:       }
+func.func @coalescing_preallocated_neighbor() {
+  %a = amdgcn.alloca : !amdgcn.vgpr<2>
+  %b = amdgcn.alloca : !amdgcn.vgpr<?>
+  %c = amdgcn.alloca : !amdgcn.vgpr<?>
+  amdgcn.test_inst outs %b : (!amdgcn.vgpr<?>) -> ()
+  lsir.copy %c, %b : !amdgcn.vgpr<?>, !amdgcn.vgpr<?>
+  amdgcn.test_inst ins %a, %c : (!amdgcn.vgpr<2>, !amdgcn.vgpr<?>) -> ()
+  return
+}

--- a/test/Dialect/AMDGCN/Transforms/register-coloring-value-semantics-nf.mlir
+++ b/test/Dialect/AMDGCN/Transforms/register-coloring-value-semantics-nf.mlir
@@ -1,0 +1,19 @@
+// RUN: aster-opt --amdgcn-register-coloring --verify-diagnostics %s
+
+// Verify that the register allocator rejects a quotient graph node with value
+// semantics. The kernel below coalesces B and C (no interference between them)
+// and then creates an interference edge between the coalesced class and A (a
+// value-semantics alloca). The allocator detects A's value semantics during the
+// pre-check in RegisterColoring::run and emits the expected diagnostic.
+
+// expected-error @below {{failed to run register allocator}}
+amdgcn.kernel @coalescing_value_semantics_neighbor {
+  %b = amdgcn.alloca : !amdgcn.vgpr<?>
+  %c = amdgcn.alloca : !amdgcn.vgpr<?>
+  // expected-error @below {{found unexpected value register}}
+  %a = amdgcn.alloca : !amdgcn.vgpr
+  amdgcn.test_inst outs %b : (!amdgcn.vgpr<?>) -> ()
+  lsir.copy %c, %b : !amdgcn.vgpr<?>, !amdgcn.vgpr<?>
+  amdgcn.test_inst ins %a, %c : (!amdgcn.vgpr, !amdgcn.vgpr<?>) -> ()
+  amdgcn.end_kernel
+}

--- a/test/Dialect/AMDGCN/Transforms/register-coloring.mlir
+++ b/test/Dialect/AMDGCN/Transforms/register-coloring.mlir
@@ -1130,3 +1130,35 @@ func.func @redundant_s_mov_b64() {
   amdgcn.s_mov_b64 outs(%r1) ins(%r0) : outs(!amdgcn.sgpr<[? : ? + 2]>) ins(!amdgcn.sgpr<[? : ? + 2]>)
   return
 }
+
+// -----
+
+// Verify that a 4-register range with alignment=4 (the default for size=4)
+// skips past a pre-allocated neighbour at register 1 and lands at the next
+// aligned slot (4). Without alignment the allocator would greedily try 0, find
+// that register 1 is blocked by the live neighbour, advance start to 2, and
+// then, because alignment rounds 2 up to 4, land at [4:8).
+//
+// CHECK-LABEL:   func.func @alignment_skip() {
+// CHECK:           %[[A0:.*]] = amdgcn.alloca : !amdgcn.vgpr<4>
+// CHECK:           %[[A1:.*]] = amdgcn.alloca : !amdgcn.vgpr<5>
+// CHECK:           %[[A2:.*]] = amdgcn.alloca : !amdgcn.vgpr<6>
+// CHECK:           %[[A3:.*]] = amdgcn.alloca : !amdgcn.vgpr<7>
+// CHECK:           %[[RANGE:.*]] = amdgcn.make_register_range %[[A0]], %[[A1]], %[[A2]], %[[A3]] : !amdgcn.vgpr<4>, !amdgcn.vgpr<5>, !amdgcn.vgpr<6>, !amdgcn.vgpr<7>
+// CHECK:           amdgcn.test_inst ins %[[RANGE]] : (!amdgcn.vgpr<[4 : 8]>) -> ()
+// CHECK:           return
+// CHECK:         }
+func.func @alignment_skip() {
+  %0 = amdgcn.alloca : !amdgcn.vgpr<?>
+  %1 = amdgcn.alloca : !amdgcn.vgpr<?>
+  %2 = amdgcn.alloca : !amdgcn.vgpr<?>
+  %3 = amdgcn.alloca : !amdgcn.vgpr<?>
+  // Pre-allocated neighbour at register 1; live simultaneously with the range,
+  // blocking slots [0:4) from being chosen (start=0 fails, rounds up to 4).
+  %nbr = amdgcn.alloca : !amdgcn.vgpr<1>
+  %r = amdgcn.make_register_range %0, %1, %2, %3
+      : !amdgcn.vgpr<?>, !amdgcn.vgpr<?>, !amdgcn.vgpr<?>, !amdgcn.vgpr<?>
+  amdgcn.test_inst ins %r : (!amdgcn.vgpr<[? : ? + 4]>) -> ()
+  amdgcn.reg_interference %0, %nbr : !amdgcn.vgpr<?>, !amdgcn.vgpr<1>
+  return
+}

--- a/test/lib/Pass/TestAMDGCNInterferenceAnalysis.cpp
+++ b/test/lib/Pass/TestAMDGCNInterferenceAnalysis.cpp
@@ -24,6 +24,7 @@
 #include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Pass/Pass.h"
 #include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/EquivalenceClasses.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/raw_ostream.h"
@@ -90,10 +91,21 @@ struct TestAMDGCNInterferenceAnalysis
       }
 
       // Print the interference graph (and optionally the quotient after
-      // running optimizeGraph).
+      // running optimizeGraph). Only print the quotient when coalescing
+      // actually merged at least two original nodes; otherwise the quotient
+      // is isomorphic to the original and printing it would be noise.
       std::optional<CoalescingInfo> coalescingInfo;
-      if (optimize)
-        coalescingInfo = CoalescingInfo::optimizeGraph(kernel, *graph, solver);
+      if (optimize) {
+        FailureOr<CoalescingInfo> info =
+            CoalescingInfo::optimizeGraph(kernel, *graph);
+        if (failed(info)) {
+          kernel.emitError("failed to optimize interference graph");
+          return signalPassFailure();
+        }
+        int64_t numQuotient = static_cast<int64_t>(info->values.size());
+        if (numQuotient > 0 && numQuotient < graph->sizeNodes())
+          coalescingInfo = std::move(*info);
+      }
       if (coalescingInfo) {
         graph->print(os);
         os << "\nRange constraints:";
@@ -106,31 +118,52 @@ struct TestAMDGCNInterferenceAnalysis
              << "] alignment = " << range.alignment;
         }
         os << "\n";
-        // Print equivalence classes sorted by smallest member.
-        int64_t numNodes = graph->sizeNodes();
-        DenseSet<int32_t> printed;
+        // Print equivalence classes sorted by smallest member. Each class is
+        // stored as a sorted slice in memberData;
+        // memberData[memberOffsets[qid]] is the minimum member.
+        int32_t numQuotient =
+            static_cast<int32_t>(coalescingInfo->memberOffsets.size()) - 1;
+
+        // Returns the minimum original node ID in the quotient class of node.
+        auto getMinMember = [&](int32_t node) {
+          return coalescingInfo->memberData
+              [coalescingInfo->memberOffsets[coalescingInfo->nodeClass[node]]];
+        };
+
         os << "EquivalenceClasses {\n";
-        for (int32_t i = 0; i < numNodes; ++i) {
-          int32_t leader = coalescingInfo->eqClasses.getLeaderValue(i);
-          if (!printed.insert(leader).second)
-            continue;
-          SmallVector<int32_t> members(coalescingInfo->eqClasses.members(i));
-          llvm::sort(members);
+        for (int32_t qid = 0; qid < numQuotient; ++qid) {
           os << "  [";
-          llvm::interleave(members, os, [&](int32_t m) { os << m; }, ", ");
+          llvm::interleave(
+              llvm::ArrayRef(coalescingInfo->memberData)
+                  .slice(coalescingInfo->memberOffsets[qid],
+                         coalescingInfo->memberOffsets[qid + 1] -
+                             coalescingInfo->memberOffsets[qid]),
+              os, [&](int32_t m) { os << m; }, ", ");
           os << "]\n";
         }
         os << "}\n";
-        graph->print(os, coalescingInfo->eqClasses);
+
+        // Reconstruct an EquivalenceClasses for graph->print, which requires
+        // it for colouring nodes by class.
+        llvm::EquivalenceClasses<int32_t> eqForPrint;
+        for (int32_t qid = 0; qid < numQuotient; ++qid) {
+          int32_t rep =
+              coalescingInfo->memberData[coalescingInfo->memberOffsets[qid]];
+          for (int32_t j = coalescingInfo->memberOffsets[qid],
+                       end = coalescingInfo->memberOffsets[qid + 1];
+               j < end; ++j)
+            eqForPrint.unionSets(rep, coalescingInfo->memberData[j]);
+        }
+        graph->print(os, eqForPrint);
         os << "\nPost range constraints:";
-        printed.clear();
+        DenseSet<int32_t> printed;
         for (const RangeConstraint &range : rangeAnalysis->getRanges()) {
-          int32_t startId = coalescingInfo->getLeader(
-              graph->getNodeId(range.allocations.front()));
+          int32_t startId =
+              getMinMember(graph->getNodeId(range.allocations.front()));
           if (!printed.insert(startId).second)
             continue;
-          int32_t endId = coalescingInfo->getLeader(
-              graph->getNodeId(range.allocations.back()));
+          int32_t endId =
+              getMinMember(graph->getNodeId(range.allocations.back()));
           os << "\n  [" << startId << "-" << endId
              << "] alignment = " << range.alignment;
         }

--- a/unittests/Support/GraphTest.cpp
+++ b/unittests/Support/GraphTest.cpp
@@ -151,9 +151,8 @@ TEST(GraphTest, ComputeQuotientAllNodesInOneClass) {
 
   EXPECT_TRUE(succeeded(g.computeQuotient(eqClasses)));
   EXPECT_EQ(g.sizeNodes(), 1);
-  EXPECT_EQ(g.sizeEdges(), 1);
-  // All edges collapse to self-loop 0->0
-  EXPECT_TRUE(g.hasEdge(0, 0));
+  // Intra-class edges are dropped; the quotient has no edges.
+  EXPECT_EQ(g.sizeEdges(), 0);
 }
 
 } // namespace


### PR DESCRIPTION
Extract AllocConstraints (physical register occupancy tracker) and
GraphColoringImpl (pure graph coloring) from RegisterColoring.cpp into a
dedicated GraphColoring.cpp/h. This isolates all physical allocation
logic and makes each piece independently testable.

Replace the EquivalenceClasses/IntEqClasses-based CoalescingInfo with a
flat representation: a quotient Graph, parallel value/constraint arrays,
and CSR-style memberData/memberOffsets/nodeClass arrays. The new layout
gives O(1) class lookups and avoids repeated leader searches.

Add num-sgprs as a configurable pass option (replacing the hard-coded
102), and remove the optimize option (coalescing is now always run).
Fix Graph::computeQuotient to drop intra-class edges instead of
collapsing them to self-loops.

Add negative-form tests for register exhaustion and value-semantics
violations, and extend register-coloring.mlir with alignment-skip and
coalescing-with-pre-allocated-neighbor cases.