### PR TITLE
Add gfx1250 (GFX12_50) target skeleton + s_setprio_inc_wg

### DIFF
--- a/include/aster/Dialect/AMDGCN/IR/AMDGCN.td
+++ b/include/aster/Dialect/AMDGCN/IR/AMDGCN.td
@@ -49,9 +49,16 @@ def CDNA4 : ISAVersion<"cdna4"> { let description = "CDNA 4 ISA version"; }
 
 def RDNA4 : ISAVersion<"rdna4"> { let description = "RDNA 4 ISA version"; }
 
+// TODO: Ideally call this CDNA5 / RDNA5 or UDNA ...
+// don't know what the right teminology is here but this sits at the same level
+// as CDNA4/CDNA4/RDNA4 and should not conflict with
+// GFX940/GFX950/GFX1201/GFX1250/GFX1251 terminology.
+def GFX12_50 : ISAVersion<"gfx12_50"> { let description = "GFX12.5 ISA version (gfx1250/gfx1251)"; }
+
 def IsaVersions
     : AutoI32EnumCases<"ISAVersion",
-                       "AMDGCN ISA Versions", [InvalidCase, CDNA3, CDNA4, RDNA4]> {
+                       "AMDGCN ISA Versions",
+                       [InvalidCase, CDNA3, CDNA4, RDNA4, GFX12_50]> {
   let cppNamespace = "::mlir::aster::amdgcn";
 }
 
@@ -69,9 +76,14 @@ def GFX950 : Target<"gfx950", CDNA4> { let description = "GFX950 target"; }
 
 def GFX1201 : Target<"gfx1201", RDNA4> { let description = "GFX1201 target"; }
 
+def GFX1250 : Target<"gfx1250", GFX12_50> { let description = "GFX1250 target (gfx1250)"; }
+
+def GFX1251 : Target<"gfx1251", GFX12_50> { let description = "GFX1251 target (gfx1251)"; }
+
 def AMDGCNTargets
     : AutoI32EnumCases<
-          "Target", "AMDGCN Targets", [InvalidCase, GFX940, GFX942, GFX950, GFX1201]> {
+          "Target", "AMDGCN Targets",
+          [InvalidCase, GFX940, GFX942, GFX950, GFX1201, GFX1250, GFX1251]> {
   let cppNamespace = "::mlir::aster::amdgcn";
 }
 

--- a/include/aster/Dialect/AMDGCN/IR/AMDGCNInstBase.td
+++ b/include/aster/Dialect/AMDGCN/IR/AMDGCNInstBase.td
@@ -102,6 +102,7 @@ class AMDISAInstruction<string mnemonic, list<Trait> opTraits = []>
 
 def CDNA3Isa : Arch<"CDNA3">;
 def CDNA4Isa : Arch<"CDNA4">;
+def GFX12_50Isa : Arch<"GFX12_50">;
 
 //===----------------------------------------------------------------------===//
 // Encoding name records
@@ -146,6 +147,7 @@ def ENC_SOPK_CDNA3 : EncodedArch<ENC_SOPK, CDNA3Isa>;
 def ENC_SOPK_CDNA4 : EncodedArch<ENC_SOPK, CDNA4Isa>;
 def ENC_SOPP_CDNA3 : EncodedArch<ENC_SOPP, CDNA3Isa>;
 def ENC_SOPP_CDNA4 : EncodedArch<ENC_SOPP, CDNA4Isa>;
+def ENC_SOPP_GFX12_50 : EncodedArch<ENC_SOPP, GFX12_50Isa>;
 def ENC_VOP1_CDNA3 : EncodedArch<ENC_VOP1, CDNA3Isa>;
 def ENC_VOP1_CDNA4 : EncodedArch<ENC_VOP1, CDNA4Isa>;
 def ENC_VOP2_CDNA3 : EncodedArch<ENC_VOP2, CDNA3Isa>;

--- a/include/aster/Dialect/AMDGCN/IR/Instructions/ControlFlow.td
+++ b/include/aster/Dialect/AMDGCN/IR/Instructions/ControlFlow.td
@@ -25,14 +25,18 @@ def EndKernelOp : AMDISAInstruction<"end_kernel", [
     Terminator, ReturnLike, HasParent<"KernelOp">
   ]> {
   let props = [IsControlFlow, IsSOPP];
-  let archs = [CDNA3Isa, CDNA4Isa];
+  let archs = [CDNA3Isa, CDNA4Isa, GFX12_50Isa];
   let description = [{
     End of program; terminate wavefront.
   }];
   let asm_mnemonic = "s_endpgm";
-  let encodings = [InstEnc<[ENC_SOPP_CDNA3, ENC_SOPP_CDNA4], 0b0000001>];
+  let encodings = [
+    InstEnc<[ENC_SOPP_CDNA3, ENC_SOPP_CDNA4], 0b0000001>,
+    InstEnc<[ENC_SOPP_GFX12_50], 0b0110000>
+  ];
   let asm_syntax = [
-    ASMString<[ENC_SOPP_CDNA3, ENC_SOPP_CDNA4], "${mnemonic}">
+    ASMString<[ENC_SOPP_CDNA3, ENC_SOPP_CDNA4], "${mnemonic}">,
+    ASMString<[ENC_SOPP_GFX12_50], "${mnemonic}">
   ];
 }
 #endif // SENDPGM_DEF

--- a/include/aster/Dialect/AMDGCN/IR/Instructions/SOP.td
+++ b/include/aster/Dialect/AMDGCN/IR/Instructions/SOP.td
@@ -813,6 +813,32 @@ def SSetprio : AMDISAInstruction<"s_setprio"> {
 }
 #endif // SSETPRIO_DEF
 
+#ifndef SSETPRIO_INC_WG_DEF
+#define SSETPRIO_INC_WG_DEF
+def SSetprioIncWg : AMDISAInstruction<"s_setprio_inc_wg"> {
+  let props = [IsSALU, IsSOPP];
+  let archs = [GFX12_50Isa];
+  let description = [{
+    Change wave user priority and increment the workgroup priority counter.
+    Available in gfx1250/gfx1251 (GFX12.5) only atm.
+  }];
+  // tmp SoT: LLVM defm S_SETPRIO_INC_WG : SOPP_Real_32_gfx12_gfx13<0x03e>;
+  let encodings = [InstEnc<[ENC_SOPP_GFX12_50], 0b0111110>];
+  let outputs = (ins);
+  let inputs = (ins);
+  let trailingArgs = (ins
+    Imm16Attr:$imm
+  );
+  let genInstAssemblyFormat = 0;
+  let assemblyFormat = [{
+    $imm attr-dict
+  }];
+  let asm_syntax = [
+    ASMString<[ENC_SOPP_GFX12_50], "${mnemonic} $imm">
+  ];
+}
+#endif // SSETPRIO_INC_WG_DEF
+
 
 #ifndef SSLEEP_DEF
 #define SSLEEP_DEF

--- a/lib/Dialect/AMDGCN/IR/AMDGCNAttrs.cpp
+++ b/lib/Dialect/AMDGCN/IR/AMDGCNAttrs.cpp
@@ -577,6 +577,10 @@ mlir::aster::TargetFamily TargetAttr::getTargetFamily() const {
   case amdgcn::Target::GFX1201:
     isa = ISAVersion::RDNA4;
     break;
+  case amdgcn::Target::GFX1250:
+  case amdgcn::Target::GFX1251:
+    isa = ISAVersion::GFX12_50;
+    break;
   case amdgcn::Target::Invalid:
     llvm_unreachable("invalid target");
   }

--- a/lib/Dialect/AMDGCN/IR/Utils.cpp
+++ b/lib/Dialect/AMDGCN/IR/Utils.cpp
@@ -144,6 +144,9 @@ ISAVersion mlir::aster::amdgcn::getIsaForTarget(Target target) {
     return ISAVersion::CDNA4;
   case Target::GFX1201:
     return ISAVersion::RDNA4;
+  case Target::GFX1250:
+  case Target::GFX1251:
+    return ISAVersion::GFX12_50;
   case Target::Invalid:
     return ISAVersion::Invalid;
   }
@@ -159,6 +162,9 @@ int64_t mlir::aster::amdgcn::getLdsBytesPerCU(Target target) {
     return 160 * 1024; // 160 KB on CDNA4 (MI350), 64 banks x 4 bytes.
   case Target::GFX1201:
     return 128 * 1024; // 128 KB on RDNA4.
+  case Target::GFX1250:
+  case Target::GFX1251:
+    return 320 * 1024; // 320 KB on GFX12.5 (gfx1250/gfx1251).
   case Target::Invalid:
     return 64 * 1024; // Conservative fallback.
   }
@@ -170,6 +176,7 @@ bool mlir::aster::amdgcn::hasPackedTID(ISAVersion isa) {
   case ISAVersion::CDNA3:
   case ISAVersion::CDNA4:
   case ISAVersion::RDNA4:
+  case ISAVersion::GFX12_50:
     return true;
   case ISAVersion::Invalid:
     return false;

--- a/lib/Dialect/AMDGCN/Scheduler/SchedulerCostModel.cpp
+++ b/lib/Dialect/AMDGCN/Scheduler/SchedulerCostModel.cpp
@@ -140,8 +140,8 @@ QueueType classifyOp(Operation *op) {
 ///   1 = mfma-hiding default
 ///   2..N = future presets (add a new struct above + a new case here).
 CDNA3Latencies latencies(ISAVersion isa, int preset) {
-  if (isa == ISAVersion::CDNA4)
-    return CDNA4Latencies();
+  if (isa == ISAVersion::CDNA4 || isa == ISAVersion::GFX12_50)
+    return CDNA4Latencies(); // GFX12.5: CDNA4 placeholder until profiled.
   switch (preset) {
   case 1:
     return CDNA3PresetMfmaHiding();

--- a/lib/Target/ASM/TranslateModule.cpp
+++ b/lib/Target/ASM/TranslateModule.cpp
@@ -90,6 +90,8 @@ static TargetHWInfo getTargetHWInfo(Target target) {
     return {/*vgprAllocGranule=*/8, /*sgprEncodingGranule=*/8,
             /*hasAccVGPR=*/true};
   case Target::GFX1201:
+  case Target::GFX1250:
+  case Target::GFX1251:
     return {/*vgprAllocGranule=*/8, /*sgprEncodingGranule=*/8,
             /*hasAccVGPR=*/false};
   default:

--- a/test/Dialect/AMDGCN/IR/sopp-setprio-sleep-wakeup.mlir
+++ b/test/Dialect/AMDGCN/IR/sopp-setprio-sleep-wakeup.mlir
@@ -19,3 +19,15 @@ amdgcn.module @setprio_test target = #amdgcn.target<gfx942> {
     amdgcn.end_kernel
   }
 }
+
+// CHECK-LABEL: amdgcn.module @setprio_inc_wg_test
+amdgcn.module @setprio_inc_wg_test target = #amdgcn.target<gfx1250> {
+  // CHECK:      kernel @test_setprio_inc_wg
+  amdgcn.kernel @test_setprio_inc_wg {
+    // CHECK:    s_setprio_inc_wg 3
+    s_setprio_inc_wg 3
+    // CHECK:    s_setprio_inc_wg 0
+    s_setprio_inc_wg 0
+    amdgcn.end_kernel
+  }
+}

--- a/test/Dialect/AMDGCN/Transforms/lds-alloc-limits-per-arch.mlir
+++ b/test/Dialect/AMDGCN/Transforms/lds-alloc-limits-per-arch.mlir
@@ -1,0 +1,39 @@
+// RUN: aster-opt --amdgcn-lds-alloc --split-input-file --verify-diagnostics %s
+
+// gfx1250 has 320 KB LDS.
+amdgcn.module @gfx1250_fits target = #amdgcn.target<gfx1250> {
+  amdgcn.kernel @k {
+    %0 = amdgcn.alloc_lds 300000
+    amdgcn.end_kernel
+  }
+}
+
+// -----
+
+amdgcn.module @gfx1251_fits target = #amdgcn.target<gfx1251> {
+  amdgcn.kernel @k {
+    %0 = amdgcn.alloc_lds 300000
+    amdgcn.end_kernel
+  }
+}
+
+// -----
+
+amdgcn.module @gfx1250_overflow target = #amdgcn.target<gfx1250> {
+  amdgcn.kernel @k {
+    // expected-error@+1 {{failed to allocate LDS buffer of size 400000 with alignment 16; would exceed 327680 bytes}}
+    %0 = amdgcn.alloc_lds 400000
+    amdgcn.end_kernel
+  }
+}
+
+// -----
+
+// gfx940 has 64 KB LDS.
+amdgcn.module @cdna3_gfx940_overflow target = #amdgcn.target<gfx940> {
+  amdgcn.kernel @k {
+    // expected-error@+1 {{failed to allocate LDS buffer of size 300000 with alignment 16; would exceed 65536 bytes}}
+    %0 = amdgcn.alloc_lds 300000
+    amdgcn.end_kernel
+  }
+}

--- a/test/Dialect/AMDGCN/ops.mlir
+++ b/test/Dialect/AMDGCN/ops.mlir
@@ -59,6 +59,20 @@ amdgcn.module @cdna4_module target = #amdgcn.target<gfx950> {
   }
 }
 
+// Test gfx1250 module
+amdgcn.module @gfx1250_module target = #amdgcn.target<gfx1250> {
+  amdgcn.kernel @gfx1250_kernel {
+    amdgcn.end_kernel
+  }
+}
+
+// Test gfx1251 module
+amdgcn.module @gfx1251_module target = #amdgcn.target<gfx1251> {
+  amdgcn.kernel @gfx1251_kernel {
+    amdgcn.end_kernel
+  }
+}
+
 // Test library with cdna4 isa
 amdgcn.library @library_cdna4 isa = [#amdgcn.isa<cdna4>] {
   func.func @cdna4_func() {
@@ -104,6 +118,13 @@ amdgcn.library @library_with_multiple_funcs {
 // Test library operations (target-specific, with isa attribute)
 amdgcn.library @library_multi_isa isa = [#amdgcn.isa<cdna3>, #amdgcn.isa<rdna4>] {
   func.func @multi_target_func() {
+    return
+  }
+}
+
+// Test library with gfx12_50 isa
+amdgcn.library @library_multi_isa_gfx12_50 isa = [#amdgcn.isa<cdna3>, #amdgcn.isa<gfx12_50>] {
+  func.func @multi_target_func_gfx12_50() {
     return
   }
 }

--- a/test/Target/ASM/sopp-setprio-inc-wg-asm.mlir
+++ b/test/Target/ASM/sopp-setprio-inc-wg-asm.mlir
@@ -1,0 +1,14 @@
+// RUN: aster-translate %s --mlir-to-asm | FileCheck %s
+
+// CHECK-LABEL: test_setprio_inc_wg_asm:
+//       CHECK: s_setprio_inc_wg 100
+//  CHECK-NEXT: s_setprio_inc_wg 0
+//       CHECK: s_endpgm
+
+amdgcn.module @test_mod target = #amdgcn.target<gfx1250> {
+  amdgcn.kernel @test_setprio_inc_wg_asm {
+    s_setprio_inc_wg 100
+    s_setprio_inc_wg 0
+    amdgcn.end_kernel
+  }
+}

--- a/test/integration/setprio-inc-wg-e2e.mlir
+++ b/test/integration/setprio-inc-wg-e2e.mlir
@@ -1,0 +1,9 @@
+// RUN: aster-opt %s --verify-roundtrip
+
+amdgcn.module @setprio_inc_wg_mod target = #amdgcn.target<gfx1250> {
+  amdgcn.kernel @setprio_inc_wg {
+    s_setprio_inc_wg 100
+    s_setprio_inc_wg 0
+    amdgcn.end_kernel
+  }
+}

--- a/test/integration/test_setprio_inc_wg_e2e.py
+++ b/test/integration/test_setprio_inc_wg_e2e.py
@@ -1,0 +1,23 @@
+import pytest
+
+from aster.execution.helpers import compile_and_run
+from aster.test_pass_pipelines import TEST_SROA_PASS_PIPELINE
+
+
+@pytest.mark.parametrize("target", ["gfx1250", "gfx1251"])
+def test_setprio_inc_wg_e2e(target):
+    def preprocess(x):
+        return x.replace("<gfx1250>", f"<{target}>")
+
+    compile_and_run(
+        "setprio-inc-wg-e2e.mlir",
+        "setprio_inc_wg",
+        pass_pipeline=TEST_SROA_PASS_PIPELINE,
+        mcpu=target,
+        preprocess=preprocess,
+        library_paths=[],
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])


### PR DESCRIPTION
Also update the s_endpgm encoding for 1250.

Note there is a naming inconsistency here and in LLVM.

Ideally we would call this CDNA5 / RDNA5 or UDNA, as this sits at the same level as CDNA4/CDNA4/RDNA4 and should not conflict with GFX940/GFX950/GFX1201/GFX1250/GFX1251 terminology.

For lack of a better name we use GFX12_50 and GFX1250/1251 atm.