### PR TITLE
Revive a memory dependence analysis

### DIFF
--- a/include/aster/Analysis/MemoryDependenceAnalysis.h
+++ b/include/aster/Analysis/MemoryDependenceAnalysis.h
@@ -1,0 +1,77 @@
+//===- MemoryDependenceAnalysis.h - Memory dependence analysis ---*- C++-*-===//
+//
+// Copyright 2026 The ASTER Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Late memory dependence analysis operating on CFG IR.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ASTER_ANALYSIS_MEMORYDEPENDENCEANALYSIS_H
+#define ASTER_ANALYSIS_MEMORYDEPENDENCEANALYSIS_H
+
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/Support/LLVM.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/LogicalResult.h"
+
+namespace mlir {
+class Operation;
+} // namespace mlir
+
+namespace mlir::aster {
+
+enum class DepKind { RAW, WAR, WAW };
+struct MemDepEdge {
+  Operation *producer;
+  DepKind kind;
+  mlir::SideEffects::Resource *resource;
+};
+
+/// Cross-block memory dependence analysis. At construction time the analysis
+/// collects memory access sites, assigns alias equivalence classes, and
+/// precomputes RAW/WAR/WAW dependences ending at each operation.
+class MemoryDependenceAnalysis {
+public:
+  /// Verify the flat-CFG normal form on `root` (#amdgcn.no_scf_ops), then
+  /// build alias classes and dependence summaries for the whole region.
+  static FailureOr<MemoryDependenceAnalysis>
+  create(Operation *root, ArrayRef<SideEffects::Resource *> resources);
+
+  /// Precomputed dependences ending at `op` (empty if none or no memory
+  /// effects on the tracked resources).
+  ArrayRef<MemDepEdge> getDependences(Operation *op) const;
+
+private:
+  struct AccessSite {
+    Operation *op;
+    bool isWrite;
+    SideEffects::Resource *resource;
+    int64_t aliasClass;
+  };
+
+  MemoryDependenceAnalysis(ArrayRef<SideEffects::Resource *> resources);
+
+  void buildAccessSites(Operation *root);
+  void buildDependences(Operation *root);
+
+  bool mayAlias(const AccessSite &a, const AccessSite &b) const;
+
+  SmallVector<SideEffects::Resource *, 2> resources;
+  SmallVector<AccessSite> accessSites;
+  DenseMap<Operation *, SmallVector<int64_t, 2>> opAccessIndices;
+  DenseMap<SideEffects::Resource *, int64_t> unknownAliasClass;
+  int64_t nextAliasClass = 0;
+  DenseMap<Operation *, SmallVector<MemDepEdge>> dependences;
+  static const SmallVector<MemDepEdge> emptyDeps;
+};
+
+} // namespace mlir::aster
+
+#endif // ASTER_ANALYSIS_MEMORYDEPENDENCEANALYSIS_H

--- a/lib/Analysis/CMakeLists.txt
+++ b/lib/Analysis/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_mlir_library(ASTERAnalysis
   DPSAnalysis.cpp
   LivenessAnalysis.cpp
+  MemoryDependenceAnalysis.cpp
   RegisterConstraints.cpp
   ThreadUniformAnalysis.cpp
 
@@ -12,6 +13,7 @@ add_mlir_library(ASTERAnalysis
   AsterUtilsDialect
   LSIRDialect
   MLIRAnalysis
+  MLIRControlFlowInterfaces
   MLIRGPUDialect
   MLIRIR
   MLIRSupport

--- a/lib/Analysis/MemoryDependenceAnalysis.cpp
+++ b/lib/Analysis/MemoryDependenceAnalysis.cpp
@@ -1,0 +1,237 @@
+//===- MemoryDependenceAnalysis.cpp - Memory dependence analysis ---------===//
+//
+// Copyright 2026 The ASTER Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "aster/Analysis/MemoryDependenceAnalysis.h"
+#include "aster/Dialect/AMDGCN/IR/AMDGCNOps.h"
+#include "aster/Dialect/LSIR/IR/LSIROps.h"
+#include "mlir/Analysis/SliceWalk.h"
+#include "mlir/Dialect/Transform/Utils/DiagnosedSilenceableFailure.h"
+#include "mlir/IR/Block.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/Support/LLVM.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
+#include <utility>
+
+using namespace mlir;
+using namespace mlir::aster;
+using namespace mlir::aster::amdgcn;
+using namespace mlir::aster::lsir;
+
+const SmallVector<MemDepEdge> MemoryDependenceAnalysis::emptyDeps = {};
+
+/// Resolve the value that identifies the resource instance `op`'s access on
+/// `resource` derives from, by tracing back def-use chains to RootOps and
+/// through bbargs.
+/// From the point of multi-buffer LDS, 3 main cases of interest are supported,
+/// driven by 2 key considerations.
+///
+/// The key considerations are:
+///   1. ds_write / ds_read memory patterns are subject to layout transfers and
+///      swizzles that make single-op level analysis useless: the minimal
+///      aliasing granularity is the entire buffer. To avoid over-conservative
+///      analysis, buffers should be as small as possible to support a full
+///      wave GR -> DS_W -> DS_R with good swizzle and layout transfers.
+///   2. Unrolling by an amount that is not a multiple of the buffer count
+///      results in rotating patterns that are handled conservatively. This is
+///      acceptable because rotation without a matching unroll is a perf
+///      non-starter due to register clobber and all its implications w/ static
+///      register names.
+///
+/// The 3 main cases are:
+///   1. Single buffer (with or without unrolling): every path reaches the one
+///      alloc_lds and all accesses alias.
+///   2. Multi-buffer + unrolling by a multiple of the buffer count: no yield
+///      rotation pattern, alloc_lds has a precise 1-1 disambiguation.
+///   3. Multi-buffer not unrolled by a multiple, iter_args ROTATE and tracing
+///      one block arg reaches several distinct alloc_lds. We treat this
+///      conservatively. This is acceptable by key consideration 2.
+///
+///      Example:
+///        cf.br ^body(%off1, %off0 : i32, i32)
+///      ^body(%cur: i32, %prev: i32):              // %cur, %prev both -> null
+///        ds_write ... addr (to_reg %cur)          //   (each reaches off0+off1
+///        ds_read  ... addr (to_reg %prev)         //    via the rotated yield)
+///        cf.cond_br %c, ^body(%prev, %cur), ^exit // rotation
+///
+/// Return failure if zero or > 1 instances reach, treat it conservatively.
+template <typename... RootOps>
+static FailureOr<Value> resolveInstance(Operation *op) {
+  Value data;
+  if (auto store = dyn_cast<StoreOpInterface>(op))
+    data = store.getDataOperand().getValue();
+
+  SmallVector<Value> worklist;
+  for (Value v : op->getOperands())
+    if (v != data)
+      worklist.push_back(v);
+
+  DenseSet<Value> seen;
+  Value root;
+  while (!worklist.empty()) {
+    Value v = worklist.pop_back_val();
+    if (!seen.insert(v).second)
+      continue;
+    Operation *def = v.getDefiningOp();
+    if (def && (isa<RootOps>(def) || ...)) {
+      if (root && root != v)
+        return failure(); // several distinct instances reach -> unresolved
+      root = v;
+      continue; // do not trace past a resource root
+    }
+    if (def) {
+      worklist.append(def->getOperands().begin(), def->getOperands().end());
+      continue;
+    }
+    // Block arguments trace through the predecessor branch. Rotation patterns
+    // will trigger aliases that we do not try to disambiguate for now.
+    if (auto preds = getControlFlowPredecessors(v))
+      worklist.append(preds->begin(), preds->end());
+  }
+  if (!root)
+    return failure();
+  return root;
+}
+
+namespace {
+using AliasClassKey = std::pair<SideEffects::Resource *, Value>;
+} // namespace
+
+bool MemoryDependenceAnalysis::mayAlias(const AccessSite &a,
+                                        const AccessSite &b) const {
+  if (a.resource != b.resource)
+    return false;
+  if (auto unknown = unknownAliasClass.find(a.resource);
+      unknown != unknownAliasClass.end() &&
+      (a.aliasClass == unknown->second || b.aliasClass == unknown->second))
+    return true;
+  return a.aliasClass == b.aliasClass;
+}
+
+void MemoryDependenceAnalysis::buildAccessSites(Operation *root) {
+  DenseMap<AliasClassKey, int64_t> resolvedAliasClass;
+
+  root->walk([&](Operation *op) {
+    auto iface = dyn_cast<MemoryEffectOpInterface>(op);
+    if (!iface)
+      return;
+    SmallVector<SideEffects::EffectInstance<MemoryEffects::Effect>> effects;
+    iface.getEffects(effects);
+    for (const auto &e : effects) {
+      SideEffects::Resource *r = e.getResource();
+      if (!llvm::is_contained(resources, r))
+        continue;
+      bool isWrite = isa<MemoryEffects::Write>(e.getEffect());
+      if (!isWrite && !isa<MemoryEffects::Read>(e.getEffect()))
+        continue;
+
+      FailureOr<Value> instance =
+          resolveInstance<AllocLDSOp, AssumeNoaliasOp>(op);
+      int64_t aliasClass;
+      if (succeeded(instance)) {
+        aliasClass =
+            resolvedAliasClass.try_emplace({r, *instance}, nextAliasClass++)
+                .first->second;
+      } else {
+        aliasClass =
+            unknownAliasClass.try_emplace(r, nextAliasClass++).first->second;
+      }
+
+      int64_t siteIdx = accessSites.size();
+      accessSites.push_back({op, isWrite, r, aliasClass});
+      opAccessIndices[op].push_back(siteIdx);
+    }
+  });
+}
+
+void MemoryDependenceAnalysis::buildDependences(Operation *root) {
+  root->walk([&](Operation *op) {
+    auto it = opAccessIndices.find(op);
+    if (it == opAccessIndices.end())
+      return;
+
+    struct Reachability {
+      const MemoryDependenceAnalysis &analysis;
+      ArrayRef<AccessSite> accessSites;
+      const DenseMap<Operation *, SmallVector<int64_t, 2>> &opAccessIndices;
+      ArrayRef<int64_t> queryIndices;
+      DenseSet<Block *> seenBlocks;
+      DenseSet<std::pair<Operation *, int>> seenEdges;
+      SmallVector<MemDepEdge> deps;
+
+      void collect(Block *block, Operation *onlyBefore) {
+        for (Operation &producer : *block) {
+          if (&producer == onlyBefore)
+            break;
+          auto prodIt = opAccessIndices.find(&producer);
+          if (prodIt == opAccessIndices.end())
+            continue;
+          for (int64_t pi : prodIt->second)
+            for (int64_t qi : queryIndices) {
+              const AccessSite &p = accessSites[pi];
+              const AccessSite &a = accessSites[qi];
+              if (!analysis.mayAlias(p, a) || (!p.isWrite && !a.isWrite))
+                continue;
+              DepKind kind = p.isWrite
+                                 ? (a.isWrite ? DepKind::WAW : DepKind::RAW)
+                                 : DepKind::WAR;
+              if (seenEdges.insert({p.op, static_cast<int>(kind)}).second)
+                deps.push_back({p.op, kind, a.resource});
+            }
+        }
+      }
+
+      void reachesEntryOf(Block *block) {
+        for (Block *pred : block->getPredecessors()) {
+          if (!seenBlocks.insert(pred).second)
+            continue;
+          collect(pred, /*onlyBefore=*/nullptr);
+          reachesEntryOf(pred);
+        }
+      }
+    };
+
+    Reachability walk{*this, accessSites, opAccessIndices, it->second, {},
+                      {},    {}};
+    walk.collect(op->getBlock(), /*onlyBefore=*/op);
+    walk.reachesEntryOf(op->getBlock());
+
+    if (!walk.deps.empty())
+      dependences[op] = std::move(walk.deps);
+  });
+}
+
+MemoryDependenceAnalysis::MemoryDependenceAnalysis(
+    ArrayRef<SideEffects::Resource *> resources)
+    : resources(resources.begin(), resources.end()) {}
+
+FailureOr<MemoryDependenceAnalysis>
+MemoryDependenceAnalysis::create(Operation *root,
+                                 ArrayRef<SideEffects::Resource *> resources) {
+  // Ensure flat CFG normal form. Ideally this should be done by the caller.
+  if (failed(NoScfOpsAttr::get(root->getContext())
+                 .checkOperation(root)
+                 .checkAndReport()))
+    return failure();
+  MemoryDependenceAnalysis analysis(resources);
+  analysis.buildAccessSites(root);
+  analysis.buildDependences(root);
+  return analysis;
+}
+
+ArrayRef<MemDepEdge>
+MemoryDependenceAnalysis::getDependences(Operation *op) const {
+  auto it = dependences.find(op);
+  if (it == dependences.end())
+    return emptyDeps;
+  return it->second;
+}

--- a/lib/Dialect/AMDGCN/Scheduler/GraphBuilderAttrs.cpp
+++ b/lib/Dialect/AMDGCN/Scheduler/GraphBuilderAttrs.cpp
@@ -8,8 +8,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "aster/Analysis/MemoryDependenceAnalysis.h"
 #include "aster/Dialect/AMDGCN/Analysis/WaitAnalysis.h"
 #include "aster/Dialect/AMDGCN/IR/AMDGCNOps.h"
+#include "aster/Dialect/AMDGCN/IR/Interfaces/AMDGCNInterfaces.h"
 #include "aster/Dialect/AMDGCN/IR/Utils.h"
 #include "aster/Interfaces/SchedInterfaces.h"
 #include "mlir/Analysis/DataFlowFramework.h"
@@ -44,6 +46,12 @@ private:
   /// Build the non-SSA dependencies for the graph.
   void buildNonSSADeps(SchedGraph &graph);
 
+  /// Add hard ordering edges from the memory-dependence analysis, scoped to
+  /// LDS. Same-buffer LDS RAW/WAR/WAW is a correctness constraint the
+  /// post-schedule wait insertion cannot repair (DS ops issue in order, no hw
+  /// interlock). Global ordering is left to the existing token/wait machinery.
+  void buildMemDepEdges(SchedGraph &graph);
+
   /// Handle a wait operation.
   void handleWaitOp(SchedGraph &graph, int64_t pos, WaitCntOpInterface wait);
 
@@ -63,8 +71,34 @@ private:
 LogicalResult GraphBuilder::run(SchedGraph &graph) {
   buildSSADeps(graph);
   buildNonSSADeps(graph);
+  buildMemDepEdges(graph);
   addI1SerializationEdges(graph);
   return success();
+}
+
+void GraphBuilder::buildMemDepEdges(SchedGraph &graph) {
+  // The scheduler enforces ordering only WITHIN this block. Build the
+  // cross-block analysis (which verifies the flat-CFG normal form), then add
+  // only the LDS dependences whose producer is earlier in THIS block.
+  // Cross-block producers are structural (CFG edges + waits) and a loop-carried
+  // back edge (producer not before the consumer in program order) would be a
+  // cycle in this block's graph. Scope to LDS: same-buffer DS RAW/WAR/WAW is a
+  // correctness constraint the scheduler must respect; distinct buffers carry
+  // no edge; global ordering stays with the token/wait machinery.
+  auto mdaOr = MemoryDependenceAnalysis::create(
+      block->getParentOp(),
+      {GlobalMemoryResource::get(), LDSMemoryResource::get()});
+  if (failed(mdaOr)) {
+    LDBG() << "memdep analysis unavailable (non-flat CFG); skipping LDS edges";
+    return;
+  }
+  MemoryDependenceAnalysis &mda = *mdaOr;
+  for (Operation *op : graph.getOps())
+    for (const MemDepEdge &edge : mda.getDependences(op))
+      if (edge.resource == LDSMemoryResource::get() &&
+          edge.producer->getBlock() == block &&
+          edge.producer->isBeforeInBlock(op))
+        graph.addEdge(edge.producer, op);
 }
 
 void GraphBuilder::buildSSADeps(SchedGraph &graph) {

--- a/test/Dialect/AMDGCN/Analysis/memory-dependence-analysis.mlir
+++ b/test/Dialect/AMDGCN/Analysis/memory-dependence-analysis.mlir
@@ -1,0 +1,602 @@
+// RUN: aster-opt %s --test-memory-dependence-analysis 2>&1 | FileCheck %s
+
+//===----------------------------------------------------------------------===//
+// Normal form: create() verifies flat CFG (#amdgcn.no_scf_ops semantics).
+//===----------------------------------------------------------------------===//
+
+// CHECK: normal form violation: SCF dialect operations are disallowed
+amdgcn.module @test_normal_form target = #amdgcn.target<gfx942> {
+  amdgcn.kernel @has_scf {
+    %lb = arith.constant 0 : index
+    %ub = arith.constant 4 : index
+    %st = arith.constant 1 : index
+    scf.for %i = %lb to %ub step %st {
+      scf.yield
+    }
+    amdgcn.end_kernel
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Single-block edge kinds: RAW, WAR, WAW, and RAR (no edge).
+//===----------------------------------------------------------------------===//
+
+//   CHECK-LABEL: Kernel: raw_war_waw
+amdgcn.module @test_edge_kinds target = #amdgcn.target<gfx942> {
+  amdgcn.kernel @raw_war_waw {
+    %data0 = amdgcn.alloca : !amdgcn.vgpr
+    %data1 = amdgcn.alloca : !amdgcn.vgpr
+    %dst0  = amdgcn.alloca : !amdgcn.vgpr
+    %dst1  = amdgcn.alloca : !amdgcn.vgpr
+    %addr  = amdgcn.alloca : !amdgcn.vgpr
+    %bufA  = amdgcn.alloc_lds 64 alignment 16
+    %offA  = amdgcn.get_lds_offset %bufA : i32
+
+    // CHECK: Operation: {{.*}}ds_write{{.*}}test.W0
+    // CHECK:   RAW deps ending here: 0:
+    // CHECK:   WAR deps ending here: 0:
+    // CHECK:   WAW deps ending here: 0:
+    %tokW0 = amdgcn.ds_write_b32 data %data0 addr %addr offset c(%offA) { test.W0 }
+      : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
+
+    // CHECK: Operation: {{.*}}ds_read{{.*}}test.R0
+    // CHECK:   RAW deps ending here: 1: test.W0
+    // CHECK:   WAR deps ending here: 0:
+    // CHECK:   WAW deps ending here: 0:
+    %val0, %tokR0 = amdgcn.ds_read_b32 dest %dst0 addr %addr offset c(%offA) { test.R0 }
+      : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
+
+    // CHECK: Operation: {{.*}}ds_read{{.*}}test.R1
+    // CHECK:   RAW deps ending here: 1: test.W0
+    // CHECK:   WAR deps ending here: 0:
+    // CHECK:   WAW deps ending here: 0:
+    %val1, %tokR1 = amdgcn.ds_read_b32 dest %dst1 addr %addr offset c(%offA) { test.R1 }
+      : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
+
+    // CHECK: Operation: {{.*}}ds_write{{.*}}test.W1
+    // CHECK:   RAW deps ending here: 0:
+    // CHECK:   WAR deps ending here: 2: test.R0, test.R1
+    // CHECK:   WAW deps ending here: 1: test.W0
+    %tokW1 = amdgcn.ds_write_b32 data %data1 addr %addr offset c(%offA) { test.W1 }
+      : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
+
+    amdgcn.end_kernel
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// G2S: buffer_load_lds cross-resource RAW to a following ds_read.
+//===----------------------------------------------------------------------===//
+
+//   CHECK-LABEL: Kernel: g2s_then_read
+amdgcn.module @test_g2s target = #amdgcn.target<gfx950> {
+  amdgcn.kernel @g2s_then_read {
+    %m0 = amdgcn.alloca : !amdgcn.m0<0>
+    %c0 = arith.constant 0 : i32
+    amdgcn.s_mov_b32 outs(%m0) ins(%c0) : outs(!amdgcn.m0<0>) ins(i32)
+    %s0 = amdgcn.alloca : !amdgcn.sgpr<0>
+    %s1 = amdgcn.alloca : !amdgcn.sgpr<1>
+    %s2 = amdgcn.alloca : !amdgcn.sgpr<2>
+    %s3 = amdgcn.alloca : !amdgcn.sgpr<3>
+    %rsrc = amdgcn.make_register_range %s0, %s1, %s2, %s3
+      : !amdgcn.sgpr<0>, !amdgcn.sgpr<1>, !amdgcn.sgpr<2>, !amdgcn.sgpr<3>
+    %soff = amdgcn.alloca : !amdgcn.sgpr<4>
+    %voff = amdgcn.alloca : !amdgcn.vgpr<0>
+    %dst  = amdgcn.alloca : !amdgcn.vgpr
+    %addr = amdgcn.alloca : !amdgcn.vgpr
+    %bufA = amdgcn.alloc_lds 64 alignment 16
+    %offA = amdgcn.get_lds_offset %bufA : i32
+
+    // CHECK: Operation: {{.*}}buffer_load_lds_dword{{.*}}test.g2s
+    // CHECK:   RAW deps ending here: 0:
+    // CHECK:   WAR deps ending here: 0:
+    // CHECK:   WAW deps ending here: 0:
+    %tokG = amdgcn.buffer_load_lds_dword addr %rsrc m0 %m0 offset u(%soff) + off_idx(%voff) + c(%c0) {offen, test.g2s}
+      : ins(!amdgcn.sgpr<[0 : 4]>, !amdgcn.m0<0>, !amdgcn.sgpr<4>, !amdgcn.vgpr<0>) mods(i32) -> !amdgcn.read_token<flat>
+
+    // CHECK: Operation: {{.*}}ds_read{{.*}}test.read
+    // CHECK:   RAW deps ending here: 1: test.g2s
+    // CHECK:   WAR deps ending here: 0:
+    // CHECK:   WAW deps ending here: 0:
+    %val, %tokR = amdgcn.ds_read_b32 dest %dst addr %addr offset c(%offA) { test.read }
+      : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
+    amdgcn.end_kernel
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Global: assume_noalias disambiguation and loop iter_arg tracing.
+//===----------------------------------------------------------------------===//
+
+//   CHECK-LABEL: Kernel: global_noalias
+amdgcn.module @test_global target = #amdgcn.target<gfx942> {
+  amdgcn.kernel @global_noalias {
+    %data0 = lsir.alloca : !amdgcn.vgpr<[? + 4]>
+    %data1 = lsir.alloca : !amdgcn.vgpr<[? + 4]>
+    %voff  = amdgcn.alloca : !amdgcn.vgpr
+    %c0    = arith.constant 0 : i32
+    %a_s = lsir.alloca : !amdgcn.sgpr<[? + 2]>
+    %b_s = lsir.alloca : !amdgcn.sgpr<[? + 2]>
+    %ptr:2 = lsir.assume_noalias %a_s, %b_s
+      : (!amdgcn.sgpr<[? + 2]>, !amdgcn.sgpr<[? + 2]>) -> (!amdgcn.sgpr<[? + 2]>, !amdgcn.sgpr<[? + 2]>)
+
+    // CHECK: Operation: {{.*}}global_store{{.*}}test.wa
+    // CHECK:   RAW deps ending here: 0:
+    // CHECK:   WAR deps ending here: 0:
+    // CHECK:   WAW deps ending here: 0:
+    %tokA = amdgcn.global_store_dwordx4 data %data0 addr %ptr#0 offset d(%voff) + c(%c0) { test.wa }
+      : ins(!amdgcn.vgpr<[? + 4]>, !amdgcn.sgpr<[? + 2]>, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<flat>
+
+    // CHECK: Operation: {{.*}}global_store{{.*}}test.wb
+    // CHECK:   RAW deps ending here: 0:
+    // CHECK:   WAR deps ending here: 0:
+    // CHECK:   WAW deps ending here: 0:
+    %tokB = amdgcn.global_store_dwordx4 data %data1 addr %ptr#1 offset d(%voff) + c(%c0) { test.wb }
+      : ins(!amdgcn.vgpr<[? + 4]>, !amdgcn.sgpr<[? + 2]>, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<flat>
+
+    // CHECK: Operation: {{.*}}global_store{{.*}}test.wa2
+    // CHECK:   RAW deps ending here: 0:
+    // CHECK:   WAR deps ending here: 0:
+    // CHECK:   WAW deps ending here: 1: test.wa
+    %tokC = amdgcn.global_store_dwordx4 data %data1 addr %ptr#0 offset d(%voff) + c(%c0) { test.wa2 }
+      : ins(!amdgcn.vgpr<[? + 4]>, !amdgcn.sgpr<[? + 2]>, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<flat>
+    amdgcn.end_kernel
+  }
+}
+
+//   CHECK-LABEL: Kernel: global_noalias_loop_arg
+amdgcn.module @test_global_loop target = #amdgcn.target<gfx942> {
+  amdgcn.kernel @global_noalias_loop_arg {
+    %data0 = lsir.alloca : !amdgcn.vgpr<[? + 4]>
+    %data1 = lsir.alloca : !amdgcn.vgpr<[? + 4]>
+    %voff  = amdgcn.alloca : !amdgcn.vgpr
+    %c0    = arith.constant 0 : i32
+    %cond  = arith.constant 1 : i1
+    %a_s = lsir.alloca : !amdgcn.sgpr<[? + 2]>
+    %b_s = lsir.alloca : !amdgcn.sgpr<[? + 2]>
+    %ptr:2 = lsir.assume_noalias %a_s, %b_s
+      : (!amdgcn.sgpr<[? + 2]>, !amdgcn.sgpr<[? + 2]>) -> (!amdgcn.sgpr<[? + 2]>, !amdgcn.sgpr<[? + 2]>)
+    cf.br ^body(%ptr#0, %ptr#1 : !amdgcn.sgpr<[? + 2]>, !amdgcn.sgpr<[? + 2]>)
+
+  ^body(%pa: !amdgcn.sgpr<[? + 2]>, %pb: !amdgcn.sgpr<[? + 2]>):
+    // CHECK: Operation: {{.*}}global_store{{.*}}test.g_wa
+    // CHECK:   RAW deps ending here: 0:
+    // CHECK:   WAR deps ending here: 0:
+    // CHECK:   WAW deps ending here: 1: test.g_wa
+    %tokA = amdgcn.global_store_dwordx4 data %data0 addr %pa offset d(%voff) + c(%c0) { test.g_wa }
+      : ins(!amdgcn.vgpr<[? + 4]>, !amdgcn.sgpr<[? + 2]>, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<flat>
+
+    // CHECK: Operation: {{.*}}global_store{{.*}}test.g_wb
+    // CHECK:   RAW deps ending here: 0:
+    // CHECK:   WAR deps ending here: 0:
+    // CHECK:   WAW deps ending here: 1: test.g_wb
+    %tokB = amdgcn.global_store_dwordx4 data %data1 addr %pb offset d(%voff) + c(%c0) { test.g_wb }
+      : ins(!amdgcn.vgpr<[? + 4]>, !amdgcn.sgpr<[? + 2]>, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<flat>
+    cf.cond_br %cond, ^body(%pa, %pb : !amdgcn.sgpr<[? + 2]>, !amdgcn.sgpr<[? + 2]>), ^exit
+
+  ^exit:
+    amdgcn.end_kernel
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// LDS buffer disambiguation: distinct alloc_lds vs same buffer.
+//===----------------------------------------------------------------------===//
+
+//   CHECK-LABEL: Kernel: two_buffers
+amdgcn.module @test_lds_buffer_disambig target = #amdgcn.target<gfx942> {
+  amdgcn.kernel @two_buffers {
+    %data = amdgcn.alloca : !amdgcn.vgpr
+    %dst  = amdgcn.alloca : !amdgcn.vgpr
+    %addr = amdgcn.alloca : !amdgcn.vgpr
+    %bufA = amdgcn.alloc_lds 256 alignment 16
+    %bufB = amdgcn.alloc_lds 256 alignment 16
+    %offA = amdgcn.get_lds_offset %bufA : i32
+    %offB = amdgcn.get_lds_offset %bufB : i32
+
+    // CHECK: Operation: {{.*}}ds_write{{.*}}test.write_a
+    // CHECK:   RAW deps ending here: 0:
+    // CHECK:   WAR deps ending here: 0:
+    // CHECK:   WAW deps ending here: 0:
+    %tokA = amdgcn.ds_write_b32 data %data addr %addr offset c(%offA) { test.write_a }
+      : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
+
+    // CHECK: Operation: {{.*}}ds_read{{.*}}test.read_b
+    // CHECK:   RAW deps ending here: 0:
+    // CHECK:   WAR deps ending here: 0:
+    // CHECK:   WAW deps ending here: 0:
+    %valB, %tokB = amdgcn.ds_read_b32 dest %dst addr %addr offset c(%offB) { test.read_b }
+      : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
+
+    amdgcn.end_kernel
+  }
+
+  //   CHECK-LABEL: Kernel: same_buffer
+  amdgcn.kernel @same_buffer {
+    %data = amdgcn.alloca : !amdgcn.vgpr
+    %dst  = amdgcn.alloca : !amdgcn.vgpr
+    %addr = amdgcn.alloca : !amdgcn.vgpr
+    %bufA = amdgcn.alloc_lds 256 alignment 16
+    %offA = amdgcn.get_lds_offset %bufA : i32
+
+    // CHECK: Operation: {{.*}}ds_write{{.*}}test.write_a
+    // CHECK:   RAW deps ending here: 0:
+    // CHECK:   WAR deps ending here: 0:
+    // CHECK:   WAW deps ending here: 0:
+    %tokA = amdgcn.ds_write_b32 data %data addr %addr offset c(%offA) { test.write_a }
+      : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
+
+    // CHECK: Operation: {{.*}}ds_read{{.*}}test.read_a
+    // CHECK:   RAW deps ending here: 1: test.write_a
+    // CHECK:   WAR deps ending here: 0:
+    // CHECK:   WAW deps ending here: 0:
+    %valA, %tokR = amdgcn.ds_read_b32 dest %dst addr %addr offset c(%offA) { test.read_a }
+      : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
+
+    amdgcn.end_kernel
+  }
+
+  //   CHECK-LABEL: Kernel: selective_flush
+  amdgcn.kernel @selective_flush {
+    %dataA = amdgcn.alloca : !amdgcn.vgpr
+    %dataB = amdgcn.alloca : !amdgcn.vgpr
+    %dst   = amdgcn.alloca : !amdgcn.vgpr
+    %addr  = amdgcn.alloca : !amdgcn.vgpr
+    %bufA  = amdgcn.alloc_lds 256 alignment 16
+    %bufB  = amdgcn.alloc_lds 256 alignment 16
+    %offA  = amdgcn.get_lds_offset %bufA : i32
+    %offB  = amdgcn.get_lds_offset %bufB : i32
+
+    // CHECK: Operation: {{.*}}ds_write{{.*}}test.write_a
+    // CHECK:   RAW deps ending here: 0:
+    // CHECK:   WAR deps ending here: 0:
+    // CHECK:   WAW deps ending here: 0:
+    %tokA = amdgcn.ds_write_b32 data %dataA addr %addr offset c(%offA) { test.write_a }
+      : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
+
+    // CHECK: Operation: {{.*}}ds_write{{.*}}test.write_b
+    // CHECK:   RAW deps ending here: 0:
+    // CHECK:   WAR deps ending here: 0:
+    // CHECK:   WAW deps ending here: 0:
+    %tokB = amdgcn.ds_write_b32 data %dataB addr %addr offset c(%offB) { test.write_b }
+      : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
+
+    // CHECK: Operation: {{.*}}ds_read{{.*}}test.read_a
+    // CHECK:   RAW deps ending here: 1: test.write_a
+    // CHECK:   WAR deps ending here: 0:
+    // CHECK:   WAW deps ending here: 0:
+    %valA, %tokR = amdgcn.ds_read_b32 dest %dst addr %addr offset c(%offA) { test.read_a }
+      : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
+
+    amdgcn.end_kernel
+  }
+
+  //   CHECK-LABEL: Kernel: transitive_address
+  amdgcn.kernel @transitive_address {
+    %dataA = amdgcn.alloca : !amdgcn.vgpr
+    %dst   = amdgcn.alloca : !amdgcn.vgpr
+    %addr  = amdgcn.alloca : !amdgcn.vgpr
+    %bufA  = amdgcn.alloc_lds 256 alignment 16
+    %bufB  = amdgcn.alloc_lds 256 alignment 16
+    %offA  = amdgcn.get_lds_offset %bufA : i32
+    %offB  = amdgcn.get_lds_offset %bufB : i32
+    %c0    = arith.constant 0 : i32
+    %adjB  = arith.addi %offB, %c0 : i32
+
+    // CHECK: Operation: {{.*}}ds_write{{.*}}test.write_a
+    // CHECK:   RAW deps ending here: 0:
+    // CHECK:   WAR deps ending here: 0:
+    // CHECK:   WAW deps ending here: 0:
+    %tokA = amdgcn.ds_write_b32 data %dataA addr %addr offset c(%offA) { test.write_a }
+      : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
+
+    // CHECK: Operation: {{.*}}ds_read{{.*}}test.read_b_adj
+    // CHECK:   RAW deps ending here: 0:
+    // CHECK:   WAR deps ending here: 0:
+    // CHECK:   WAW deps ending here: 0:
+    %valB, %tokR = amdgcn.ds_read_b32 dest %dst addr %addr offset c(%adjB) { test.read_b_adj }
+      : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
+
+    amdgcn.end_kernel
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Loop-carried dependences via the back edge.
+//===----------------------------------------------------------------------===//
+
+amdgcn.module @test_loop target = #amdgcn.target<gfx942> {
+  //   CHECK-LABEL: Kernel: loop_rw
+  amdgcn.kernel @loop_rw {
+    %data = amdgcn.alloca : !amdgcn.vgpr
+    %dst  = amdgcn.alloca : !amdgcn.vgpr
+    %addr = amdgcn.alloca : !amdgcn.vgpr
+    %bufA = amdgcn.alloc_lds 64 alignment 16
+    %offA = amdgcn.get_lds_offset %bufA : i32
+    %cond = arith.constant 1 : i1
+    cf.br ^body
+
+  ^body:
+    // CHECK: Operation: {{.*}}ds_read{{.*}}test.r
+    // CHECK:   RAW deps ending here: 1: test.w
+    // CHECK:   WAR deps ending here: 0:
+    // CHECK:   WAW deps ending here: 0:
+    %v, %tokR = amdgcn.ds_read_b32 dest %dst addr %addr offset c(%offA) { test.r }
+      : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
+
+    // CHECK: Operation: {{.*}}ds_write{{.*}}test.w
+    // CHECK:   RAW deps ending here: 0:
+    // CHECK:   WAR deps ending here: 1: test.r
+    // CHECK:   WAW deps ending here: 1: test.w
+    %tokW = amdgcn.ds_write_b32 data %data addr %addr offset c(%offA) { test.w }
+      : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
+    cf.cond_br %cond, ^body, ^exit
+
+  ^exit:
+    amdgcn.end_kernel
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Cross-block dependences via backward predecessor walk.
+//===----------------------------------------------------------------------===//
+
+amdgcn.module @test_multiblock target = #amdgcn.target<gfx942> {
+  //   CHECK-LABEL: Kernel: cross_block_raw
+  amdgcn.kernel @cross_block_raw {
+    %data = amdgcn.alloca : !amdgcn.vgpr
+    %dst  = amdgcn.alloca : !amdgcn.vgpr
+    %addr = amdgcn.alloca : !amdgcn.vgpr
+    %bufA = amdgcn.alloc_lds 64 alignment 16
+    %offA = amdgcn.get_lds_offset %bufA : i32
+
+    // CHECK: Operation: {{.*}}ds_write{{.*}}test.bb0_write
+    // CHECK:   RAW deps ending here: 0:
+    // CHECK:   WAR deps ending here: 0:
+    // CHECK:   WAW deps ending here: 0:
+    %tokW = amdgcn.ds_write_b32 data %data addr %addr offset c(%offA) { test.bb0_write }
+      : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
+    cf.br ^bb1
+
+  ^bb1:
+    // CHECK: Operation: {{.*}}ds_read{{.*}}test.bb1_read
+    // CHECK:   RAW deps ending here: 1: test.bb0_write
+    // CHECK:   WAR deps ending here: 0:
+    // CHECK:   WAW deps ending here: 0:
+    %v, %tokR = amdgcn.ds_read_b32 dest %dst addr %addr offset c(%offA) { test.bb1_read }
+      : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
+    amdgcn.end_kernel
+  }
+
+  //   CHECK-LABEL: Kernel: diamond
+  amdgcn.kernel @diamond {
+    %data0 = amdgcn.alloca : !amdgcn.vgpr
+    %data1 = amdgcn.alloca : !amdgcn.vgpr
+    %dst   = amdgcn.alloca : !amdgcn.vgpr
+    %addr  = amdgcn.alloca : !amdgcn.vgpr
+    %bufA  = amdgcn.alloc_lds 64 alignment 16
+    %offA  = amdgcn.get_lds_offset %bufA : i32
+    %cond  = arith.constant 1 : i1
+    cf.cond_br %cond, ^bb1, ^bb2
+
+  ^bb1:
+    %tokA = amdgcn.ds_write_b32 data %data0 addr %addr offset c(%offA) { test.arm1 }
+      : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
+    cf.br ^bb3
+
+  ^bb2:
+    %tokB = amdgcn.ds_write_b32 data %data1 addr %addr offset c(%offA) { test.arm2 }
+      : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
+    cf.br ^bb3
+
+  ^bb3:
+    // CHECK: Operation: {{.*}}ds_read{{.*}}test.join
+    // CHECK:   RAW deps ending here: 2: test.arm1, test.arm2
+    // CHECK:   WAR deps ending here: 0:
+    // CHECK:   WAW deps ending here: 0:
+    %v, %tokR = amdgcn.ds_read_b32 dest %dst addr %addr offset c(%offA) { test.join }
+      : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
+    amdgcn.end_kernel
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Multi-buffer LDS forms: single, non-rotating, and rotating iter_args.
+//===----------------------------------------------------------------------===//
+
+//   CHECK-LABEL: Kernel: single_buf_straight
+amdgcn.module @test_single_buf target = #amdgcn.target<gfx942> {
+  amdgcn.kernel @single_buf_straight {
+    %data = amdgcn.alloca : !amdgcn.vgpr
+    %dst  = amdgcn.alloca : !amdgcn.vgpr
+    %addr = amdgcn.alloca : !amdgcn.vgpr
+    %lds  = amdgcn.alloc_lds 256 offset 0
+    %off  = amdgcn.get_lds_offset %lds : i32
+
+    // CHECK: Operation: {{.*}}ds_write{{.*}}test.write_single
+    // CHECK:   RAW deps ending here: 0:
+    // CHECK:   WAR deps ending here: 0:
+    // CHECK:   WAW deps ending here: 0:
+    %wtok = amdgcn.ds_write_b32 data %data addr %addr offset c(%off) { test.write_single }
+      : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
+
+    // CHECK: Operation: {{.*}}ds_read{{.*}}test.read_single
+    // CHECK:   RAW deps ending here: 1: test.write_single
+    // CHECK:   WAR deps ending here: 0:
+    // CHECK:   WAW deps ending here: 0:
+    %v, %rtok = amdgcn.ds_read_b32 dest %dst addr %addr offset c(%off) { test.read_single }
+      : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
+    amdgcn.end_kernel
+  }
+
+  //   CHECK-LABEL: Kernel: single_buf_loop_invariant_arg
+  amdgcn.kernel @single_buf_loop_invariant_arg {
+    %data = amdgcn.alloca : !amdgcn.vgpr
+    %dst  = amdgcn.alloca : !amdgcn.vgpr
+    %addr = amdgcn.alloca : !amdgcn.vgpr
+    %cond = arith.constant 1 : i1
+    %lds  = amdgcn.alloc_lds 256 offset 0
+    %off  = amdgcn.get_lds_offset %lds : i32
+    cf.br ^body(%off : i32)
+
+  ^body(%loop_off: i32):
+    // CHECK: Operation: {{.*}}ds_write{{.*}}test.write_loop
+    // CHECK:   RAW deps ending here: 0:
+    // CHECK:   WAR deps ending here: 1: test.read_loop
+    // CHECK:   WAW deps ending here: 1: test.write_loop
+    %wtok = amdgcn.ds_write_b32 data %data addr %addr offset c(%loop_off) { test.write_loop }
+      : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
+
+    // CHECK: Operation: {{.*}}ds_read{{.*}}test.read_loop
+    // CHECK:   RAW deps ending here: 1: test.write_loop
+    // CHECK:   WAR deps ending here: 0:
+    // CHECK:   WAW deps ending here: 0:
+    %v, %rtok = amdgcn.ds_read_b32 dest %dst addr %addr offset c(%loop_off) { test.read_loop }
+      : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
+    cf.cond_br %cond, ^body(%loop_off : i32), ^exit
+
+  ^exit:
+    amdgcn.end_kernel
+  }
+}
+
+//   CHECK-LABEL: Kernel: two_buf_no_rotate
+amdgcn.module @test_two_buf_no_rotate target = #amdgcn.target<gfx942> {
+  amdgcn.kernel @two_buf_no_rotate {
+    %data = amdgcn.alloca : !amdgcn.vgpr
+    %dst  = amdgcn.alloca : !amdgcn.vgpr
+    %addr = amdgcn.alloca : !amdgcn.vgpr
+    %cond = arith.constant 1 : i1
+    %lds0 = amdgcn.alloc_lds 256 offset 0
+    %lds1 = amdgcn.alloc_lds 256 offset 256
+    %off0 = amdgcn.get_lds_offset %lds0 : i32
+    %off1 = amdgcn.get_lds_offset %lds1 : i32
+    cf.br ^body(%off0, %off1 : i32, i32)
+
+  ^body(%cur0: i32, %cur1: i32):
+    // CHECK: Operation: {{.*}}ds_write{{.*}}test.write_buf0
+    // CHECK:   RAW deps ending here: 0:
+    // CHECK:   WAR deps ending here: 0:
+    // CHECK:   WAW deps ending here: 1: test.write_buf0
+    %wtok = amdgcn.ds_write_b32 data %data addr %addr offset c(%cur0) { test.write_buf0 }
+      : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
+
+    // CHECK: Operation: {{.*}}ds_read{{.*}}test.read_buf1
+    // CHECK:   RAW deps ending here: 0:
+    // CHECK:   WAR deps ending here: 0:
+    // CHECK:   WAW deps ending here: 0:
+    %v, %rtok = amdgcn.ds_read_b32 dest %dst addr %addr offset c(%cur1) { test.read_buf1 }
+      : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
+    cf.cond_br %cond, ^body(%cur0, %cur1 : i32, i32), ^exit
+
+  ^exit:
+    amdgcn.end_kernel
+  }
+
+  //   CHECK-LABEL: Kernel: two_buf_invariant_refs
+  amdgcn.kernel @two_buf_invariant_refs {
+    %data = amdgcn.alloca : !amdgcn.vgpr
+    %dst  = amdgcn.alloca : !amdgcn.vgpr
+    %addr = amdgcn.alloca : !amdgcn.vgpr
+    %cond = arith.constant 1 : i1
+    %lds0 = amdgcn.alloc_lds 256 offset 0
+    %lds1 = amdgcn.alloc_lds 256 offset 256
+    %off0 = amdgcn.get_lds_offset %lds0 : i32
+    %off1 = amdgcn.get_lds_offset %lds1 : i32
+    cf.br ^body
+
+  ^body:
+    // CHECK: Operation: {{.*}}ds_write{{.*}}test.wI_buf0
+    // CHECK:   RAW deps ending here: 0:
+    // CHECK:   WAR deps ending here: 0:
+    // CHECK:   WAW deps ending here: 1: test.wI_buf0
+    %wtok = amdgcn.ds_write_b32 data %data addr %addr offset c(%off0) { test.wI_buf0 }
+      : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
+
+    // CHECK: Operation: {{.*}}ds_read{{.*}}test.rI_buf1
+    // CHECK:   RAW deps ending here: 0:
+    // CHECK:   WAR deps ending here: 0:
+    // CHECK:   WAW deps ending here: 0:
+    %v, %rtok = amdgcn.ds_read_b32 dest %dst addr %addr offset c(%off1) { test.rI_buf1 }
+      : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
+    cf.cond_br %cond, ^body, ^exit
+
+  ^exit:
+    amdgcn.end_kernel
+  }
+}
+
+//   CHECK-LABEL: Kernel: double_buffer_rotate
+amdgcn.module @test_rotating target = #amdgcn.target<gfx942> {
+  amdgcn.kernel @double_buffer_rotate {
+    %data = amdgcn.alloca : !amdgcn.vgpr
+    %dst  = amdgcn.alloca : !amdgcn.vgpr
+    %addr = amdgcn.alloca : !amdgcn.vgpr
+    %cond = arith.constant 1 : i1
+    %lds0 = amdgcn.alloc_lds 256 offset 0
+    %off0 = amdgcn.get_lds_offset %lds0 : i32
+    %lds1 = amdgcn.alloc_lds 256 offset 256
+    %off1 = amdgcn.get_lds_offset %lds1 : i32
+    cf.br ^body(%off1, %off0 : i32, i32)
+
+  ^body(%cur: i32, %prev: i32):
+    // CHECK: Operation: {{.*}}ds_write{{.*}}test.rot_write_cur
+    // CHECK:   RAW deps ending here: 0:
+    // CHECK:   WAR deps ending here: 1: test.rot_read_prev
+    // CHECK:   WAW deps ending here: 1: test.rot_write_cur
+    %wtok = amdgcn.ds_write_b32 data %data addr %addr offset c(%cur) { test.rot_write_cur }
+      : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
+
+    // CHECK: Operation: {{.*}}ds_read{{.*}}test.rot_read_prev
+    // CHECK:   RAW deps ending here: 1: test.rot_write_cur
+    // CHECK:   WAR deps ending here: 0:
+    // CHECK:   WAW deps ending here: 0:
+    %v, %rtok = amdgcn.ds_read_b32 dest %dst addr %addr offset c(%prev) { test.rot_read_prev }
+      : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
+    cf.cond_br %cond, ^body(%prev, %cur : i32, i32), ^exit
+
+  ^exit:
+    amdgcn.end_kernel
+  }
+
+  //   CHECK-LABEL: Kernel: triple_buffer_rotate
+  amdgcn.kernel @triple_buffer_rotate {
+    %data = amdgcn.alloca : !amdgcn.vgpr
+    %dst  = amdgcn.alloca : !amdgcn.vgpr
+    %addr = amdgcn.alloca : !amdgcn.vgpr
+    %cond = arith.constant 1 : i1
+    %lds0 = amdgcn.alloc_lds 256 offset 0
+    %off0 = amdgcn.get_lds_offset %lds0 : i32
+    %lds1 = amdgcn.alloc_lds 256 offset 256
+    %off1 = amdgcn.get_lds_offset %lds1 : i32
+    %lds2 = amdgcn.alloc_lds 256 offset 512
+    %off2 = amdgcn.get_lds_offset %lds2 : i32
+    cf.br ^body(%off2, %off1, %off0 : i32, i32, i32)
+
+  ^body(%cur: i32, %mid: i32, %old: i32):
+    // CHECK: Operation: {{.*}}ds_write{{.*}}test.tri_write_cur
+    // CHECK:   RAW deps ending here: 0:
+    // CHECK:   WAR deps ending here: 1: test.tri_read_old
+    // CHECK:   WAW deps ending here: 2: test.tri_write_cur, test.tri_write_mid
+    %wtok = amdgcn.ds_write_b32 data %data addr %addr offset c(%cur) { test.tri_write_cur }
+      : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
+
+    // CHECK: Operation: {{.*}}ds_write{{.*}}test.tri_write_mid
+    // CHECK:   RAW deps ending here: 0:
+    // CHECK:   WAR deps ending here: 1: test.tri_read_old
+    // CHECK:   WAW deps ending here: 2: test.tri_write_cur, test.tri_write_mid
+    %wtok2 = amdgcn.ds_write_b32 data %data addr %addr offset c(%mid) { test.tri_write_mid }
+      : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
+
+    // CHECK: Operation: {{.*}}ds_read{{.*}}test.tri_read_old
+    // CHECK:   RAW deps ending here: 2: test.tri_write_cur, test.tri_write_mid
+    // CHECK:   WAR deps ending here: 0:
+    // CHECK:   WAW deps ending here: 0:
+    %v, %rtok = amdgcn.ds_read_b32 dest %dst addr %addr offset c(%old) { test.tri_read_old }
+      : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
+    cf.cond_br %cond, ^body(%old, %cur, %mid : i32, i32, i32), ^exit
+
+  ^exit:
+    amdgcn.end_kernel
+  }
+}

--- a/test/Dialect/AMDGCN/Transforms/ll-sched-memdep.mlir
+++ b/test/Dialect/AMDGCN/Transforms/ll-sched-memdep.mlir
@@ -1,0 +1,225 @@
+// RUN: aster-opt %s --pass-pipeline="builtin.module(test-amdgcn-sched-graph)" 2>&1 | FileCheck %s
+
+// Memory-dependence edges in the per-block SchedGraph: proper tracking of
+// RAW/WAR/WAW.
+
+amdgcn.module @same_buffer_mod target = #amdgcn.target<gfx942> {
+  // CHECK-LABEL: Kernel: @same_buffer
+  // CHECK:       digraph SchedGraph
+  // CHECK-DAG:     label = "ds_write_b32 -> ds_read_b32"
+  // CHECK:       }
+  amdgcn.kernel @same_buffer {
+    %data = amdgcn.alloca : !amdgcn.vgpr
+    %dst = amdgcn.alloca : !amdgcn.vgpr
+    %perthread = amdgcn.alloca : !amdgcn.vgpr
+    %bufA = amdgcn.alloc_lds 256 alignment 16
+    %offA = amdgcn.get_lds_offset %bufA : i32
+    %tokA = amdgcn.ds_write_b32 data %data addr %perthread offset c(%offA)
+      : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
+    %valA, %tokB = amdgcn.ds_read_b32 dest %dst addr %perthread offset c(%offA)
+      : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
+    amdgcn.end_kernel
+  }
+}
+
+// -----
+
+amdgcn.module @two_buffers_mod target = #amdgcn.target<gfx942> {
+  // CHECK-LABEL: Kernel: @two_buffers
+  // CHECK:       digraph SchedGraph
+  // CHECK-NOT:     label = "ds_write_b32 -> ds_read_b32"
+  // CHECK:       }
+  amdgcn.kernel @two_buffers {
+    %data = amdgcn.alloca : !amdgcn.vgpr
+    %dst = amdgcn.alloca : !amdgcn.vgpr
+    %perthread = amdgcn.alloca : !amdgcn.vgpr
+    %bufA = amdgcn.alloc_lds 256 alignment 16
+    %bufB = amdgcn.alloc_lds 256 alignment 16
+    %offA = amdgcn.get_lds_offset %bufA : i32
+    %offB = amdgcn.get_lds_offset %bufB : i32
+    %tokA = amdgcn.ds_write_b32 data %data addr %perthread offset c(%offA)
+      : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
+    %valB, %tokB = amdgcn.ds_read_b32 dest %dst addr %perthread offset c(%offB)
+      : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
+    amdgcn.end_kernel
+  }
+}
+
+// -----
+
+amdgcn.module @war_mod target = #amdgcn.target<gfx942> {
+  // WAR: a read then a write to the same buffer must stay ordered.
+  // CHECK-LABEL: Kernel: @war_same_buffer
+  // CHECK:       digraph SchedGraph
+  // CHECK-DAG:     label = "ds_read_b32 -> ds_write_b32"
+  // CHECK:       }
+  amdgcn.kernel @war_same_buffer {
+    %data = amdgcn.alloca : !amdgcn.vgpr
+    %dst = amdgcn.alloca : !amdgcn.vgpr
+    %perthread = amdgcn.alloca : !amdgcn.vgpr
+    %bufA = amdgcn.alloc_lds 256 alignment 16
+    %offA = amdgcn.get_lds_offset %bufA : i32
+    %valA, %tokR = amdgcn.ds_read_b32 dest %dst addr %perthread offset c(%offA)
+      : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
+    %tokW = amdgcn.ds_write_b32 data %data addr %perthread offset c(%offA)
+      : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
+    amdgcn.end_kernel
+  }
+}
+
+// -----
+
+amdgcn.module @waw_mod target = #amdgcn.target<gfx942> {
+  // WAW: two writes to the same buffer must stay ordered.
+  // CHECK-LABEL: Kernel: @waw_same_buffer
+  // CHECK:       digraph SchedGraph
+  // CHECK-DAG:     label = "ds_write_b32 -> ds_write_b32"
+  // CHECK:       }
+  amdgcn.kernel @waw_same_buffer {
+    %data0 = amdgcn.alloca : !amdgcn.vgpr
+    %data1 = amdgcn.alloca : !amdgcn.vgpr
+    %perthread = amdgcn.alloca : !amdgcn.vgpr
+    %bufA = amdgcn.alloc_lds 256 alignment 16
+    %offA = amdgcn.get_lds_offset %bufA : i32
+    %tokW0 = amdgcn.ds_write_b32 data %data0 addr %perthread offset c(%offA)
+      : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
+    %tokW1 = amdgcn.ds_write_b32 data %data1 addr %perthread offset c(%offA)
+      : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
+    amdgcn.end_kernel
+  }
+}
+
+// -----
+
+// Non-rotating 4-buffer GEMM double-buffer (A0,A1,B0,B1).
+
+amdgcn.module @gemm_buffers_no_rotate_mod target = #amdgcn.target<gfx942> {
+  // CHECK-LABEL: Kernel: @gemm_buffers_no_rotate Block: 1
+  // CHECK:       digraph SchedGraph
+  // wA feeds both A sub-tile reads; wB feeds both B sub-tile reads (RAW).
+  // CHECK-DAG:     label = "ds_write_b32/test.wA -> ds_read_b32/test.rA0"
+  // CHECK-DAG:     label = "ds_write_b32/test.wA -> ds_read_b32/test.rA1"
+  // CHECK-DAG:     label = "ds_write_b32/test.wB -> ds_read_b32/test.rB0"
+  // CHECK-DAG:     label = "ds_write_b32/test.wB -> ds_read_b32/test.rB1"
+  // Distinct A/B alloc_lds: no cross-operand RAW and no wA/wB WAW.
+  // CHECK-NOT:     label = "ds_write_b32/test.wA -> ds_read_b32/test.rB0"
+  // CHECK-NOT:     label = "ds_write_b32/test.wA -> ds_read_b32/test.rB1"
+  // CHECK-NOT:     label = "ds_write_b32/test.wB -> ds_read_b32/test.rA0"
+  // CHECK-NOT:     label = "ds_write_b32/test.wB -> ds_read_b32/test.rA1"
+  // CHECK-NOT:     label = "ds_write_b32/test.wA -> ds_write_b32/test.wB"
+  // CHECK:       }
+  amdgcn.kernel @gemm_buffers_no_rotate {
+    %dataA  = amdgcn.alloca : !amdgcn.vgpr
+    %dataB  = amdgcn.alloca : !amdgcn.vgpr
+    %dstA0  = amdgcn.alloca : !amdgcn.vgpr
+    %dstA1  = amdgcn.alloca : !amdgcn.vgpr
+    %dstB0  = amdgcn.alloca : !amdgcn.vgpr
+    %dstB1  = amdgcn.alloca : !amdgcn.vgpr
+    %pt     = amdgcn.alloca : !amdgcn.vgpr
+    %cond   = arith.constant 1 : i1
+    // Four distinct LDS buffers: A tile double-buffer, B tile double-buffer.
+    %ldsA0  = amdgcn.alloc_lds 1024 offset 0
+    %ldsA1  = amdgcn.alloc_lds 1024 offset 1024
+    %ldsB0  = amdgcn.alloc_lds 1024 offset 2048
+    %ldsB1  = amdgcn.alloc_lds 1024 offset 3072
+    %offA0  = amdgcn.get_lds_offset %ldsA0 : i32
+    %offA1  = amdgcn.get_lds_offset %ldsA1 : i32
+    %offB0  = amdgcn.get_lds_offset %ldsB0 : i32
+    %offB1  = amdgcn.get_lds_offset %ldsB1 : i32
+    // Non-rotating: pass offsets as iter_args and yield them unchanged.
+    cf.br ^body(%offA0, %offA1, %offB0, %offB1 : i32, i32, i32, i32)
+
+  ^body(%curA: i32, %prevA: i32, %curB: i32, %prevB: i32):
+    // Write A tile to the current A buffer (traces precisely to ldsA0).
+    %tokWA = amdgcn.ds_write_b32 data %dataA addr %pt offset c(%curA)
+      {test.wA} : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
+    // Write B tile to the current B buffer (traces precisely to ldsB0).
+    %tokWB = amdgcn.ds_write_b32 data %dataB addr %pt offset c(%curB)
+      {test.wB} : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
+    // Read A sub-tile 0 from the same current A buffer.
+    %valA0, %tokRA0 = amdgcn.ds_read_b32 dest %dstA0 addr %pt offset c(%curA)
+      {test.rA0} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
+    // Read A sub-tile 1 from the same current A buffer.
+    %valA1, %tokRA1 = amdgcn.ds_read_b32 dest %dstA1 addr %pt offset c(%curA)
+      {test.rA1} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
+    // Read B sub-tile 0 from the same current B buffer.
+    %valB0, %tokRB0 = amdgcn.ds_read_b32 dest %dstB0 addr %pt offset c(%curB)
+      {test.rB0} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
+    // Read B sub-tile 1 from the same current B buffer.
+    %valB1, %tokRB1 = amdgcn.ds_read_b32 dest %dstB1 addr %pt offset c(%curB)
+      {test.rB1} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
+    // Yield unchanged: non-rotating double-buffer.
+    cf.cond_br %cond, ^body(%curA, %prevA, %curB, %prevB : i32, i32, i32, i32), ^exit
+
+  ^exit:
+    amdgcn.end_kernel
+  }
+}
+
+// -----
+
+// Rotating 4-buffer GEMM double-buffer (A0,A1,B0,B1) defeats the current
+// disambiguation logic.
+// TODO: improve when needed.
+
+amdgcn.module @gemm_buffers_rotate_mod target = #amdgcn.target<gfx942> {
+  // CHECK-LABEL: Kernel: @gemm_buffers_rotate Block: 1
+  // CHECK:       digraph SchedGraph
+  // CHECK-DAG:     label = "ds_write_b32/test.wA -> ds_write_b32/test.wB"
+  // CHECK-DAG:     label = "ds_write_b32/test.wA -> ds_read_b32/test.rA0"
+  // CHECK-DAG:     label = "ds_write_b32/test.wA -> ds_read_b32/test.rA1"
+  // CHECK-DAG:     label = "ds_write_b32/test.wA -> ds_read_b32/test.rB0"
+  // CHECK-DAG:     label = "ds_write_b32/test.wA -> ds_read_b32/test.rB1"
+  // CHECK-DAG:     label = "ds_write_b32/test.wB -> ds_read_b32/test.rA0"
+  // CHECK-DAG:     label = "ds_write_b32/test.wB -> ds_read_b32/test.rA1"
+  // CHECK-DAG:     label = "ds_write_b32/test.wB -> ds_read_b32/test.rB0"
+  // CHECK-DAG:     label = "ds_write_b32/test.wB -> ds_read_b32/test.rB1"
+  // CHECK:       }
+  amdgcn.kernel @gemm_buffers_rotate {
+    %dataA  = amdgcn.alloca : !amdgcn.vgpr
+    %dataB  = amdgcn.alloca : !amdgcn.vgpr
+    %dstA0  = amdgcn.alloca : !amdgcn.vgpr
+    %dstA1  = amdgcn.alloca : !amdgcn.vgpr
+    %dstB0  = amdgcn.alloca : !amdgcn.vgpr
+    %dstB1  = amdgcn.alloca : !amdgcn.vgpr
+    %pt     = amdgcn.alloca : !amdgcn.vgpr
+    %cond   = arith.constant 1 : i1
+    // Four distinct LDS buffers: A tile double-buffer, B tile double-buffer.
+    %ldsA0  = amdgcn.alloc_lds 1024 offset 0
+    %ldsA1  = amdgcn.alloc_lds 1024 offset 1024
+    %ldsB0  = amdgcn.alloc_lds 1024 offset 2048
+    %ldsB1  = amdgcn.alloc_lds 1024 offset 3072
+    %offA0  = amdgcn.get_lds_offset %ldsA0 : i32
+    %offA1  = amdgcn.get_lds_offset %ldsA1 : i32
+    %offB0  = amdgcn.get_lds_offset %ldsB0 : i32
+    %offB1  = amdgcn.get_lds_offset %ldsB1 : i32
+    // Rotating: initial cur = A1/B1, prev = A0/B0.
+    // On the back edge %prevA<->%curA and %prevB<->%curB swap each cycle.
+    cf.br ^body(%offA1, %offA0, %offB1, %offB0 : i32, i32, i32, i32)
+
+  ^body(%curA: i32, %prevA: i32, %curB: i32, %prevB: i32):
+    // Write A tile to the current A buffer (rotates between ldsA0 and ldsA1).
+    %tokWA = amdgcn.ds_write_b32 data %dataA addr %pt offset c(%curA)
+      {test.wA} : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
+    // Write B tile to the current B buffer (rotates between ldsB0 and ldsB1).
+    %tokWB = amdgcn.ds_write_b32 data %dataB addr %pt offset c(%curB)
+      {test.wB} : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
+    // Read A sub-tile 0 from the previous A buffer (written last iteration).
+    %valA0, %tokRA0 = amdgcn.ds_read_b32 dest %dstA0 addr %pt offset c(%prevA)
+      {test.rA0} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
+    // Read A sub-tile 1 from the previous A buffer.
+    %valA1, %tokRA1 = amdgcn.ds_read_b32 dest %dstA1 addr %pt offset c(%prevA)
+      {test.rA1} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
+    // Read B sub-tile 0 from the previous B buffer (written last iteration).
+    %valB0, %tokRB0 = amdgcn.ds_read_b32 dest %dstB0 addr %pt offset c(%prevB)
+      {test.rB0} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
+    // Read B sub-tile 1 from the previous B buffer.
+    %valB1, %tokRB1 = amdgcn.ds_read_b32 dest %dstB1 addr %pt offset c(%prevB)
+      {test.rB1} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
+    // Rotate: swap cur<->prev for both A and B on the back edge.
+    cf.cond_br %cond, ^body(%prevA, %curA, %prevB, %curB : i32, i32, i32, i32), ^exit
+
+  ^exit:
+    amdgcn.end_kernel
+  }
+}

--- a/test/lib/Pass/CMakeLists.txt
+++ b/test/lib/Pass/CMakeLists.txt
@@ -15,6 +15,7 @@ add_mlir_library(ASTERTestPass
   TestLDSInterferenceGraph.cpp
   TestAMDGCNSchedGraph.cpp
   TestLDSMultibufferPrep.cpp
+  TestMemoryDependenceAnalysis.cpp
   TestWaitAnalysis.cpp
   TestHazardAnalysis.cpp
 

--- a/test/lib/Pass/Passes.td
+++ b/test/lib/Pass/Passes.td
@@ -112,6 +112,14 @@ def TestHazardAnalysis : Pass<"test-hazard-analysis"> {
   }];
 }
 
+def TestMemoryDependenceAnalysis : Pass<"test-memory-dependence-analysis"> {
+  let summary = "Test pass for memory dependence analysis";
+  let description = [{
+    This pass runs the memory dependence analysis and prints the RAW/WAR/WAW
+    dependence edges ending at each operation in kernel functions.
+  }];
+}
+
 def TestLDSInterferenceGraph
     : InterfacePass<"test-lds-interference-graph", "::mlir::FunctionOpInterface"> {
   let summary = "Test pass that prints the LDS interference graph";

--- a/test/lib/Pass/TestAMDGCNSchedGraph.cpp
+++ b/test/lib/Pass/TestAMDGCNSchedGraph.cpp
@@ -78,30 +78,49 @@ struct TestAMDGCNSchedGraph
     }
 
     root->walk([&](amdgcn::KernelOp kernel) {
-      Block &block = kernel.getBodyRegion().front();
-      auto graph = schedGraphAttr.createGraph(&block, analysis);
-      if (failed(graph)) {
-        kernel.emitError() << "failed to build SchedGraph";
-        signalPassFailure();
-        return;
+      // Graph every block, not just the entry: loop bodies (where multi-buffer
+      // DS ops live) are non-entry blocks, so the memdep edges only appear in
+      // a later block's graph. Blocks are labeled by their index in the region.
+      int32_t blockIdx = 0;
+      for (Block &block : kernel.getBodyRegion()) {
+        auto graph = schedGraphAttr.createGraph(&block, analysis);
+        if (failed(graph)) {
+          kernel.emitError()
+              << "failed to build SchedGraph for block " << blockIdx;
+          signalPassFailure();
+          return;
+        }
+
+        const SchedGraph &g = *graph;
+        // Append the first test.* attr (if any) to disambiguate same-opname
+        // nodes/edges -- e.g. multiple ds_write_b32 to different LDS buffers.
+        auto testAttrSuffix = [](Operation *op) -> std::string {
+          for (NamedAttribute attr : op->getAttrs())
+            if (attr.getName().getValue().starts_with("test."))
+              return "/" + attr.getName().getValue().str();
+          return "";
+        };
+        auto nodePrinter = [&g, &testAttrSuffix](raw_ostream &os,
+                                                 const int32_t &nodeId) {
+          Operation *op = g.getOp(nodeId);
+          os << "label = \"" << nodeId << ": " << op->getName().stripDialect()
+             << testAttrSuffix(op) << "\"";
+        };
+        auto edgePrinter = [&g, &testAttrSuffix](raw_ostream &os,
+                                                 const Graph::Edge &edge) {
+          Operation *src = g.getOp(edge.first);
+          Operation *tgt = g.getOp(edge.second);
+          os << "label = \"" << src->getName().stripDialect()
+             << testAttrSuffix(src) << " -> " << tgt->getName().stripDialect()
+             << testAttrSuffix(tgt) << "\"";
+        };
+
+        llvm::errs() << "Kernel: @" << kernel.getSymName()
+                     << " Block: " << blockIdx << "\n";
+        g.print(llvm::errs(), "SchedGraph", nodePrinter, edgePrinter);
+        llvm::errs() << "\n\n";
+        ++blockIdx;
       }
-
-      const SchedGraph &g = *graph;
-      auto nodePrinter = [&g](raw_ostream &os, const int32_t &nodeId) {
-        Operation *op = g.getOp(nodeId);
-        os << "label = \"" << nodeId << ": " << op->getName().stripDialect()
-           << "\"";
-      };
-      auto edgePrinter = [&g](raw_ostream &os, const Graph::Edge &edge) {
-        Operation *src = g.getOp(edge.first);
-        Operation *tgt = g.getOp(edge.second);
-        os << "label = \"" << src->getName().stripDialect() << " -> "
-           << tgt->getName().stripDialect() << "\"";
-      };
-
-      llvm::errs() << "Kernel: @" << kernel.getSymName() << "\n";
-      g.print(llvm::errs(), "SchedGraph", nodePrinter, edgePrinter);
-      llvm::errs() << "\n\n";
     });
   }
 };

--- a/test/lib/Pass/TestMemoryDependenceAnalysis.cpp
+++ b/test/lib/Pass/TestMemoryDependenceAnalysis.cpp
@@ -1,0 +1,109 @@
+//===- TestMemoryDependenceAnalysis.cpp - Test Memory Dependence Analysis ===//
+//
+// Copyright 2026 The ASTER Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Test pass that prints the RAW/WAR/WAW memory-dependence edges ending at each
+// operation, for FileCheck verification of MemoryDependenceAnalysis.
+//
+//===----------------------------------------------------------------------===//
+
+#include "aster/Analysis/MemoryDependenceAnalysis.h"
+#include "aster/Dialect/AMDGCN/IR/AMDGCNOps.h"
+
+#include "mlir/IR/Operation.h"
+#include "mlir/Pass/Pass.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/raw_ostream.h"
+
+#define DEBUG_TYPE "test-memory-dependence-analysis"
+
+namespace mlir::aster::test {
+#define GEN_PASS_DEF_TESTMEMORYDEPENDENCEANALYSIS
+#include "Passes.h.inc"
+} // namespace mlir::aster::test
+
+using namespace mlir;
+using namespace mlir::aster;
+using namespace mlir::aster::amdgcn;
+
+namespace {
+//===----------------------------------------------------------------------===//
+// TestMemoryDependenceAnalysis pass
+//===----------------------------------------------------------------------===//
+class TestMemoryDependenceAnalysis
+    : public mlir::aster::test::impl::TestMemoryDependenceAnalysisBase<
+          TestMemoryDependenceAnalysis> {
+public:
+  using TestMemoryDependenceAnalysisBase::TestMemoryDependenceAnalysisBase;
+
+  void runOnOperation() override {
+    Operation *root = getOperation();
+
+    llvm::outs() << "=== Memory Dependence Analysis Results ===\n";
+
+    root->walk([&](KernelOp kernel) {
+      llvm::outs() << "\nKernel: " << kernel.getSymName() << "\n";
+
+      // Deterministic producer ordering: index ops in program order.
+      llvm::DenseMap<Operation *, int> order;
+      int idx = 0;
+      kernel.walk([&](Operation *op) { order[op] = idx++; });
+
+      // Cross-block analysis: verify the flat-CFG normal form, then query.
+      auto mdaOr = MemoryDependenceAnalysis::create(
+          kernel, {GlobalMemoryResource::get(), LDSMemoryResource::get()});
+      if (failed(mdaOr))
+        return;
+      MemoryDependenceAnalysis &mda = *mdaOr;
+      kernel.walk([&](Operation *op) {
+        bool hasTestAttr = llvm::any_of(op->getAttrs(), [](NamedAttribute a) {
+          return a.getName().getValue().starts_with("test.");
+        });
+        if (!hasTestAttr)
+          return;
+
+        llvm::outs() << "\nOperation: " << *op << "\n";
+        ArrayRef<MemDepEdge> edges = mda.getDependences(op);
+        printKind(edges, DepKind::RAW, "RAW", order);
+        printKind(edges, DepKind::WAR, "WAR", order);
+        printKind(edges, DepKind::WAW, "WAW", order);
+      });
+    });
+
+    llvm::outs() << "\n=== End Analysis Results ===\n";
+  }
+
+private:
+  static void printTestAttrs(Operation *op) {
+    for (NamedAttribute a : op->getAttrs())
+      if (a.getName().getValue().starts_with("test."))
+        llvm::outs() << a.getName().getValue() << ", ";
+  }
+
+  /// Print one edge-kind line: count, then the producers' test.* attributes in
+  /// program order.
+  static void printKind(ArrayRef<MemDepEdge> edges, DepKind kind,
+                        StringRef label,
+                        const llvm::DenseMap<Operation *, int> &order) {
+    SmallVector<Operation *> producers;
+    for (const MemDepEdge &e : edges)
+      if (e.kind == kind)
+        producers.push_back(e.producer);
+    llvm::sort(producers, [&](Operation *a, Operation *b) {
+      return order.lookup(a) < order.lookup(b);
+    });
+    llvm::outs() << "\t" << label << " deps ending here: " << producers.size()
+                 << ": ";
+    for (Operation *p : producers)
+      printTestAttrs(p);
+    llvm::outs() << "\n";
+  }
+};
+} // namespace


### PR DESCRIPTION
A primitive memory dependence analysis was previously removed, this commit revives it and adds cross-block support. Like in the case of register allocation, we require the IR to be in CFG form and use a custom walk instead of the Dataflow framework.