### PR TITLE
Fix lsir.select lowering

### DIFF
--- a/include/aster/Dialect/AMDGCN/IR/AMDGCNInstBase.td
+++ b/include/aster/Dialect/AMDGCN/IR/AMDGCNInstBase.td
@@ -24,6 +24,11 @@ include "aster/Interfaces/InstOpInterfaces.td"
 // Base instruction class for AMDGCN instructions.
 //===----------------------------------------------------------------------===//
 
+// Lane-mask operand width must match module wave size.
+def LaneMaskWidthTrait : NativeOpTrait<"LaneMaskWidthTrait"> {
+  let cppNamespace = "::mlir::aster::amdgcn";
+}
+
 def AMDInstTrait : InstructionTrait {
   let extraConcreteClassDeclaration = [{
     /// Returns whether the instruction is valid for the given target and encoding.
@@ -85,6 +90,7 @@ class AMDISAInstruction<string mnemonic, list<Trait> opTraits = []>
     : Instruction<AMDGCN_Dialect, mnemonic, opTraits # [
         AMDInstTrait,
         AMDGCNInstOpInterface,
+        LaneMaskWidthTrait,
       ]>, AMDInstOpCode<mnemonic, mnemonic> {
   list<InstProp> props = [];
   code instExtraClassDeclaration = "";

--- a/include/aster/Dialect/AMDGCN/IR/AMDGCNOps.h
+++ b/include/aster/Dialect/AMDGCN/IR/AMDGCNOps.h
@@ -48,6 +48,19 @@ namespace aster::amdgcn {
 bool checkFloatConst(Value value, ArrayRef<float> values);
 bool checkIntConst(Value value, ArrayRef<int64_t> values);
 bool checkOffsetConst(Value value, int64_t offsetWidth, bool isSigned = false);
+
+namespace detail {
+/// Lane-mask operand/result width must match the enclosing module wave size.
+LogicalResult verifyLaneMaskWidth(Operation *op);
+} // namespace detail
+
+template <typename ConcreteType>
+struct LaneMaskWidthTrait
+    : public OpTrait::TraitBase<ConcreteType, LaneMaskWidthTrait> {
+  static LogicalResult verifyTrait(Operation *op) {
+    return detail::verifyLaneMaskWidth(op);
+  }
+};
 } // namespace aster::amdgcn
 } // namespace mlir
 

--- a/include/aster/Dialect/AMDGCN/IR/Instructions/ControlFlow.td
+++ b/include/aster/Dialect/AMDGCN/IR/Instructions/ControlFlow.td
@@ -161,7 +161,7 @@ def SCbranchScc1 : SCbranchInst<"s_cbranch_scc1",
 #ifndef SCBRANCHVCCNZ_DEF
 #define SCBRANCHVCCNZ_DEF
 def SCbranchVccnz : SCbranchInst<"s_cbranch_vccnz",
-    /*src=*/[VCCType]
+    /*src=*/[VCCType, VCCLoType]
   > {
   let description = [{
     If VCCZ is 0 then jump to a constant offset relative to the current PC.
@@ -173,7 +173,7 @@ def SCbranchVccnz : SCbranchInst<"s_cbranch_vccnz",
 #ifndef SCBRANCHVCCZ_DEF
 #define SCBRANCHVCCZ_DEF
 def SCbranchVccz : SCbranchInst<"s_cbranch_vccz",
-    /*src=*/[VCCType]
+    /*src=*/[VCCType, VCCLoType]
   > {
   let description = [{
     If VCCZ is 1 then jump to a constant offset relative to the current PC.

--- a/include/aster/Dialect/AMDGCN/IR/Instructions/VOP.td
+++ b/include/aster/Dialect/AMDGCN/IR/Instructions/VOP.td
@@ -1146,7 +1146,7 @@ class VCmpInst<string mnemonic> : AMDISAInstruction<mnemonic> {
   let props = [IsVALU];
   let archs = [CDNA3Isa, CDNA4Isa, GFX12_50Isa];
   let outputs = (ins
-    AnyRegOf<[TwoSGPROrVCCType, VCCType]>:$dst0
+    AnyRegOf<[TwoSGPROrVCCType, VCCLoType]>:$dst0
   );
   let inputs = (ins
     AnyOperandOf<[OneGPROrSRegOrLitOf<InlineLitInt<[IntType<32>]>>, OneGPROrSRegOrConstOf<InlineLitInt<[IntType<32>]>, IntType<32>>]>:$src0,
@@ -1154,7 +1154,7 @@ class VCmpInst<string mnemonic> : AMDISAInstruction<mnemonic> {
   );
   let trailingArgs = (ins);
   let asm_syntax = [
-    ASMString<[ENC_VOP3_CDNA3], "${mnemonic}_e64 $dst0, $src0, $src1">,
+    ASMString<[ENC_VOP3_CDNA3, ENC_VOP3_GFX12_50], "${mnemonic}_e64 $dst0, $src0, $src1">,
     ASMString<[ENC_VOPC_CDNA3, ENC_VOPC_CDNA4, ENC_VOP3_CDNA4], "${mnemonic} $dst0, $src0, $src1">
   ];
 }
@@ -1173,8 +1173,13 @@ def VCmpEqI32 : VCmpInst<"v_cmp_eq_i32"> {
       OneGPROrSRegOrConstOf<InlineLitInt<[IntType<32>]>, IntType<32>>:$src0,
       VGPROf<1>:$src1
     )>,
-    InstEnc<[ENC_VOP3_CDNA3, ENC_VOP3_CDNA4, ENC_VOP3_GFX12_50], 0b0011000010, (pred
+    InstEnc<[ENC_VOP3_CDNA3, ENC_VOP3_CDNA4], 0b0011000010, (pred
       TwoSGPROrVCCType:$dst0,
+      OneGPROrSRegOrLitOf<InlineLitInt<[IntType<32>]>>:$src0,
+      OneGPROrSRegOrLitOf<InlineLitInt<[IntType<32>]>>:$src1
+    )>,
+    InstEnc<[ENC_VOP3_GFX12_50], 0b0011000010, (pred
+      OneSGPROrVCCType:$dst0,
       OneGPROrSRegOrLitOf<InlineLitInt<[IntType<32>]>>:$src0,
       OneGPROrSRegOrLitOf<InlineLitInt<[IntType<32>]>>:$src1
     )>
@@ -1196,8 +1201,13 @@ def VCmpGeI32 : VCmpInst<"v_cmp_ge_i32"> {
       OneGPROrSRegOrConstOf<InlineLitInt<[IntType<32>]>, IntType<32>>:$src0,
       VGPROf<1>:$src1
     )>,
-    InstEnc<[ENC_VOP3_CDNA3, ENC_VOP3_CDNA4, ENC_VOP3_GFX12_50], 0b0011000110, (pred
+    InstEnc<[ENC_VOP3_CDNA3, ENC_VOP3_CDNA4], 0b0011000110, (pred
       TwoSGPROrVCCType:$dst0,
+      OneGPROrSRegOrLitOf<InlineLitInt<[IntType<32>]>>:$src0,
+      OneGPROrSRegOrLitOf<InlineLitInt<[IntType<32>]>>:$src1
+    )>,
+    InstEnc<[ENC_VOP3_GFX12_50], 0b0011000110, (pred
+      OneSGPROrVCCType:$dst0,
       OneGPROrSRegOrLitOf<InlineLitInt<[IntType<32>]>>:$src0,
       OneGPROrSRegOrLitOf<InlineLitInt<[IntType<32>]>>:$src1
     )>
@@ -1219,8 +1229,13 @@ def VCmpGeU32 : VCmpInst<"v_cmp_ge_u32"> {
       OneGPROrSRegOrConstOf<InlineLitInt<[IntType<32>]>, IntType<32>>:$src0,
       VGPROf<1>:$src1
     )>,
-    InstEnc<[ENC_VOP3_CDNA3, ENC_VOP3_CDNA4, ENC_VOP3_GFX12_50], 0b0011001110, (pred
+    InstEnc<[ENC_VOP3_CDNA3, ENC_VOP3_CDNA4], 0b0011001110, (pred
       TwoSGPROrVCCType:$dst0,
+      OneGPROrSRegOrLitOf<InlineLitInt<[IntType<32>]>>:$src0,
+      OneGPROrSRegOrLitOf<InlineLitInt<[IntType<32>]>>:$src1
+    )>,
+    InstEnc<[ENC_VOP3_GFX12_50], 0b0011001110, (pred
+      OneSGPROrVCCType:$dst0,
       OneGPROrSRegOrLitOf<InlineLitInt<[IntType<32>]>>:$src0,
       OneGPROrSRegOrLitOf<InlineLitInt<[IntType<32>]>>:$src1
     )>
@@ -1241,8 +1256,13 @@ def VCmpGtI32 : VCmpInst<"v_cmp_gt_i32"> {
       OneGPROrSRegOrConstOf<InlineLitInt<[IntType<32>]>, IntType<32>>:$src0,
       VGPROf<1>:$src1
     )>,
-    InstEnc<[ENC_VOP3_CDNA3, ENC_VOP3_CDNA4, ENC_VOP3_GFX12_50], 0b0011000100, (pred
+    InstEnc<[ENC_VOP3_CDNA3, ENC_VOP3_CDNA4], 0b0011000100, (pred
       TwoSGPROrVCCType:$dst0,
+      OneGPROrSRegOrLitOf<InlineLitInt<[IntType<32>]>>:$src0,
+      OneGPROrSRegOrLitOf<InlineLitInt<[IntType<32>]>>:$src1
+    )>,
+    InstEnc<[ENC_VOP3_GFX12_50], 0b0011000100, (pred
+      OneSGPROrVCCType:$dst0,
       OneGPROrSRegOrLitOf<InlineLitInt<[IntType<32>]>>:$src0,
       OneGPROrSRegOrLitOf<InlineLitInt<[IntType<32>]>>:$src1
     )>
@@ -1263,8 +1283,13 @@ def VCmpGtU32 : VCmpInst<"v_cmp_gt_u32"> {
       OneGPROrSRegOrConstOf<InlineLitInt<[IntType<32>]>, IntType<32>>:$src0,
       VGPROf<1>:$src1
     )>,
-    InstEnc<[ENC_VOP3_CDNA3, ENC_VOP3_CDNA4, ENC_VOP3_GFX12_50], 0b0011001100, (pred
+    InstEnc<[ENC_VOP3_CDNA3, ENC_VOP3_CDNA4], 0b0011001100, (pred
       TwoSGPROrVCCType:$dst0,
+      OneGPROrSRegOrLitOf<InlineLitInt<[IntType<32>]>>:$src0,
+      OneGPROrSRegOrLitOf<InlineLitInt<[IntType<32>]>>:$src1
+    )>,
+    InstEnc<[ENC_VOP3_GFX12_50], 0b0011001100, (pred
+      OneSGPROrVCCType:$dst0,
       OneGPROrSRegOrLitOf<InlineLitInt<[IntType<32>]>>:$src0,
       OneGPROrSRegOrLitOf<InlineLitInt<[IntType<32>]>>:$src1
     )>
@@ -1285,8 +1310,13 @@ def VCmpLeI32 : VCmpInst<"v_cmp_le_i32"> {
       OneGPROrSRegOrConstOf<InlineLitInt<[IntType<32>]>, IntType<32>>:$src0,
       VGPROf<1>:$src1
     )>,
-    InstEnc<[ENC_VOP3_CDNA3, ENC_VOP3_CDNA4, ENC_VOP3_GFX12_50], 0b0011000011, (pred
+    InstEnc<[ENC_VOP3_CDNA3, ENC_VOP3_CDNA4], 0b0011000011, (pred
       TwoSGPROrVCCType:$dst0,
+      OneGPROrSRegOrLitOf<InlineLitInt<[IntType<32>]>>:$src0,
+      OneGPROrSRegOrLitOf<InlineLitInt<[IntType<32>]>>:$src1
+    )>,
+    InstEnc<[ENC_VOP3_GFX12_50], 0b0011000011, (pred
+      OneSGPROrVCCType:$dst0,
       OneGPROrSRegOrLitOf<InlineLitInt<[IntType<32>]>>:$src0,
       OneGPROrSRegOrLitOf<InlineLitInt<[IntType<32>]>>:$src1
     )>
@@ -1307,8 +1337,13 @@ def VCmpLeU32 : VCmpInst<"v_cmp_le_u32"> {
       OneGPROrSRegOrConstOf<InlineLitInt<[IntType<32>]>, IntType<32>>:$src0,
       VGPROf<1>:$src1
     )>,
-    InstEnc<[ENC_VOP3_CDNA3, ENC_VOP3_CDNA4, ENC_VOP3_GFX12_50], 0b0011001011, (pred
+    InstEnc<[ENC_VOP3_CDNA3, ENC_VOP3_CDNA4], 0b0011001011, (pred
       TwoSGPROrVCCType:$dst0,
+      OneGPROrSRegOrLitOf<InlineLitInt<[IntType<32>]>>:$src0,
+      OneGPROrSRegOrLitOf<InlineLitInt<[IntType<32>]>>:$src1
+    )>,
+    InstEnc<[ENC_VOP3_GFX12_50], 0b0011001011, (pred
+      OneSGPROrVCCType:$dst0,
       OneGPROrSRegOrLitOf<InlineLitInt<[IntType<32>]>>:$src0,
       OneGPROrSRegOrLitOf<InlineLitInt<[IntType<32>]>>:$src1
     )>
@@ -1329,8 +1364,13 @@ def VCmpLtI32 : VCmpInst<"v_cmp_lt_i32"> {
       OneGPROrSRegOrConstOf<InlineLitInt<[IntType<32>]>, IntType<32>>:$src0,
       VGPROf<1>:$src1
     )>,
-    InstEnc<[ENC_VOP3_CDNA3, ENC_VOP3_CDNA4, ENC_VOP3_GFX12_50], 0b0011000001, (pred
+    InstEnc<[ENC_VOP3_CDNA3, ENC_VOP3_CDNA4], 0b0011000001, (pred
       TwoSGPROrVCCType:$dst0,
+      OneGPROrSRegOrLitOf<InlineLitInt<[IntType<32>]>>:$src0,
+      OneGPROrSRegOrLitOf<InlineLitInt<[IntType<32>]>>:$src1
+    )>,
+    InstEnc<[ENC_VOP3_GFX12_50], 0b0011000001, (pred
+      OneSGPROrVCCType:$dst0,
       OneGPROrSRegOrLitOf<InlineLitInt<[IntType<32>]>>:$src0,
       OneGPROrSRegOrLitOf<InlineLitInt<[IntType<32>]>>:$src1
     )>
@@ -1351,8 +1391,13 @@ def VCmpLtU32 : VCmpInst<"v_cmp_lt_u32"> {
       OneGPROrSRegOrConstOf<InlineLitInt<[IntType<32>]>, IntType<32>>:$src0,
       VGPROf<1>:$src1
     )>,
-    InstEnc<[ENC_VOP3_CDNA3, ENC_VOP3_CDNA4, ENC_VOP3_GFX12_50], 0b0011001001, (pred
+    InstEnc<[ENC_VOP3_CDNA3, ENC_VOP3_CDNA4], 0b0011001001, (pred
       TwoSGPROrVCCType:$dst0,
+      OneGPROrSRegOrLitOf<InlineLitInt<[IntType<32>]>>:$src0,
+      OneGPROrSRegOrLitOf<InlineLitInt<[IntType<32>]>>:$src1
+    )>,
+    InstEnc<[ENC_VOP3_GFX12_50], 0b0011001001, (pred
+      OneSGPROrVCCType:$dst0,
       OneGPROrSRegOrLitOf<InlineLitInt<[IntType<32>]>>:$src0,
       OneGPROrSRegOrLitOf<InlineLitInt<[IntType<32>]>>:$src1
     )>
@@ -1373,8 +1418,13 @@ def VCmpNeI32 : VCmpInst<"v_cmp_ne_i32"> {
       OneGPROrSRegOrConstOf<InlineLitInt<[IntType<32>]>, IntType<32>>:$src0,
       VGPROf<1>:$src1
     )>,
-    InstEnc<[ENC_VOP3_CDNA3, ENC_VOP3_CDNA4, ENC_VOP3_GFX12_50], 0b0011000101, (pred
+    InstEnc<[ENC_VOP3_CDNA3, ENC_VOP3_CDNA4], 0b0011000101, (pred
       TwoSGPROrVCCType:$dst0,
+      OneGPROrSRegOrLitOf<InlineLitInt<[IntType<32>]>>:$src0,
+      OneGPROrSRegOrLitOf<InlineLitInt<[IntType<32>]>>:$src1
+    )>,
+    InstEnc<[ENC_VOP3_GFX12_50], 0b0011000101, (pred
+      OneSGPROrVCCType:$dst0,
       OneGPROrSRegOrLitOf<InlineLitInt<[IntType<32>]>>:$src0,
       OneGPROrSRegOrLitOf<InlineLitInt<[IntType<32>]>>:$src1
     )>
@@ -1392,15 +1442,25 @@ def VCndmaskB32 : AMDISAInstruction<"v_cndmask_b32"> {
     store the result into a vector register.
   }];
   let encodings = [
-    InstEnc<[ENC_VOP2_CDNA3, ENC_VOP2_CDNA4, ENC_VOP2_GFX12_50], 0b000000, (pred
+    InstEnc<[ENC_VOP2_CDNA3, ENC_VOP2_CDNA4], 0b000000, (pred
       OneGPROrSRegOrConstType:$src0,
       VGPROf<1>:$src1,
       VCCType:$src2
     )>,
-    InstEnc<[ENC_VOP3_CDNA3, ENC_VOP3_CDNA4, ENC_VOP3_GFX12_50], 0b0100000000, (pred
+    InstEnc<[ENC_VOP2_GFX12_50], 0b000000, (pred
+      OneGPROrSRegOrConstType:$src0,
+      VGPROf<1>:$src1,
+      VCCLoType:$src2
+    )>,
+    InstEnc<[ENC_VOP3_CDNA3, ENC_VOP3_CDNA4], 0b0100000000, (pred
       OneGPROrSRegOrConstOf<InlineLitFP<[F32]>, InlineLitInt<[IntType<32>]>>:$src0,
       OneGPROrSRegOrConstOf<InlineLitFP<[F32]>, InlineLitInt<[IntType<32>]>>:$src1,
       TwoSGPROrVCCType:$src2
+    )>,
+    InstEnc<[ENC_VOP3_GFX12_50], 0b0100000000, (pred
+      OneGPROrSRegOrConstOf<InlineLitFP<[F32]>, InlineLitInt<[IntType<32>]>>:$src0,
+      OneGPROrSRegOrConstOf<InlineLitFP<[F32]>, InlineLitInt<[IntType<32>]>>:$src1,
+      OneSGPROrVCCType:$src2
     )>
   ];
   let outputs = (ins
@@ -1409,7 +1469,7 @@ def VCndmaskB32 : AMDISAInstruction<"v_cndmask_b32"> {
   let inputs = (ins
     AnyOperandOf<[OneGPROrSRegOrConstType, OneGPROrSRegOrConstOf<InlineLitFP<[F32]>, InlineLitInt<[IntType<32>]>>]>:$src0,
     AnyOperandOf<[VGPROf<1>, OneGPROrSRegOrConstOf<InlineLitFP<[F32]>, InlineLitInt<[IntType<32>]>>]>:$src1,
-    AnyRegOf<[VCCType, TwoSGPROrVCCType]>:$src2
+    AnyRegOf<[VCCType, VCCLoType, TwoSGPROrVCCType]>:$src2
   );
   let trailingArgs = (ins);
   let asm_syntax = [

--- a/include/aster/Dialect/AMDGCN/IR/Utils.h
+++ b/include/aster/Dialect/AMDGCN/IR/Utils.h
@@ -88,6 +88,28 @@ bool isAMDReg(Type regTy);
 /// Get the ISA version for the given target.
 ISAVersion getIsaForTarget(Target target);
 
+/// True when `isa` is modeled as wave32 (lane mask is VCC_LO).
+bool isWave32(ISAVersion isa);
+
+/// True when `target` is modeled as wave32.
+bool isWave32(Target target);
+
+/// True when the enclosing amdgcn.module target is wave32; false outside a
+/// module.
+bool isWave32(Operation *op);
+
+/// Lane-mask type for `isa` (VCC_LO on wave32, else VCC).
+Type getLaneMaskType(MLIRContext *ctx, ISAVersion isa);
+
+/// Lane-mask type from the enclosing amdgcn.module target.
+Type getLaneMaskType(Operation *op);
+
+/// Lane-mask type from the enclosing amdgcn.module target of `value`.
+Type getLaneMaskType(Value value);
+
+/// VCC or VCC_LO.
+bool isLaneMask(Type t);
+
 /// Bytes of LDS (aka shared memory) available per compute unit for the given
 /// target. CDNA3 is 64KB; CDNA4 is 256KB; RDNA4 is 128KB.
 int64_t getLdsBytesPerCU(Target target);

--- a/lib/Dialect/AMDGCN/CodeGen/CodeGenPatterns.cpp
+++ b/lib/Dialect/AMDGCN/CodeGen/CodeGenPatterns.cpp
@@ -319,7 +319,7 @@ static Type convertTypeImpl(Value value, const CodeGenConverter &converter) {
     std::optional<bool> isUniform = converter.isThreadUniform(value);
     if (isUniform.has_value() && *isUniform)
       return amdgcn::SCCType::get(value.getContext(), Register());
-    return amdgcn::VCCType::get(value.getContext(), Register());
+    return amdgcn::getLaneMaskType(value);
   }
 
   int64_t typeSize = converter.getTypeSize(value.getType());

--- a/lib/Dialect/AMDGCN/IR/AMDGCN.cpp
+++ b/lib/Dialect/AMDGCN/IR/AMDGCN.cpp
@@ -655,6 +655,29 @@ LogicalResult LibraryOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// LaneMaskWidthTrait
+//===----------------------------------------------------------------------===//
+
+LogicalResult mlir::aster::amdgcn::detail::verifyLaneMaskWidth(Operation *op) {
+  if (!llvm::any_of(op->getOperandTypes(), isLaneMask) &&
+      !llvm::any_of(op->getResultTypes(), isLaneMask))
+    return success();
+  auto module = op->getParentOfType<amdgcn::ModuleOp>();
+  if (!module)
+    return success();
+  TypeID expected =
+      getLaneMaskType(op->getContext(), getIsaForTarget(module.getTarget()))
+          .getTypeID();
+  for (Type t : op->getOperandTypes())
+    if (isLaneMask(t) && t.getTypeID() != expected)
+      return op->emitOpError("VCC operand must match the wave size: got ") << t;
+  for (Type t : op->getResultTypes())
+    if (isLaneMask(t) && t.getTypeID() != expected)
+      return op->emitOpError("VCC result must match the wave size: got ") << t;
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // PtrAddOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/AMDGCN/IR/Utils.cpp
+++ b/lib/Dialect/AMDGCN/IR/Utils.cpp
@@ -153,6 +153,48 @@ ISAVersion mlir::aster::amdgcn::getIsaForTarget(Target target) {
   llvm_unreachable("unknown target");
 }
 
+bool mlir::aster::amdgcn::isWave32(ISAVersion isa) {
+  // TODO: Some architectures (e.g. RDNA4) support both wave32 and wave64; we
+  // infer wave size from ISA only and do not model a per-module wave-size yet.
+  return isa == ISAVersion::GFX12_50;
+}
+
+bool mlir::aster::amdgcn::isWave32(Target target) {
+  return isWave32(getIsaForTarget(target));
+}
+
+bool mlir::aster::amdgcn::isWave32(Operation *op) {
+  if (auto module = op->getParentOfType<amdgcn::ModuleOp>())
+    return isWave32(module.getTarget());
+  return false;
+}
+
+Type mlir::aster::amdgcn::getLaneMaskType(MLIRContext *ctx, ISAVersion isa) {
+  if (isWave32(isa))
+    return VCCLoType::get(ctx, Register());
+  return VCCType::get(ctx, Register());
+}
+
+Type mlir::aster::amdgcn::getLaneMaskType(Operation *op) {
+  ISAVersion isa = ISAVersion::Invalid;
+  if (auto module = op->getParentOfType<amdgcn::ModuleOp>())
+    isa = getIsaForTarget(module.getTarget());
+  return getLaneMaskType(op->getContext(), isa);
+}
+
+Type mlir::aster::amdgcn::getLaneMaskType(Value value) {
+  Operation *anchor = value.getDefiningOp();
+  if (!anchor)
+    anchor = cast<BlockArgument>(value).getOwner()->getParentOp();
+  if (!anchor)
+    return getLaneMaskType(value.getContext(), ISAVersion::Invalid);
+  return getLaneMaskType(anchor);
+}
+
+bool mlir::aster::amdgcn::isLaneMask(Type t) {
+  return isa<VCCType, VCCLoType>(t);
+}
+
 int64_t mlir::aster::amdgcn::getLdsBytesPerCU(Target target) {
   switch (target) {
   case Target::GFX940:

--- a/lib/Dialect/AMDGCN/Transforms/LegalizeCF.cpp
+++ b/lib/Dialect/AMDGCN/Transforms/LegalizeCF.cpp
@@ -20,6 +20,7 @@
 #include "aster/Dialect/AMDGCN/IR/AMDGCNAttrs.h"
 #include "aster/Dialect/AMDGCN/IR/AMDGCNOps.h"
 #include "aster/Dialect/AMDGCN/IR/AMDGCNTypes.h"
+#include "aster/Dialect/AMDGCN/IR/Utils.h"
 #include "aster/Dialect/AMDGCN/Transforms/Passes.h"
 #include "aster/Dialect/LSIR/IR/LSIROps.h"
 #include "mlir/IR/Builders.h"
@@ -57,9 +58,9 @@ private:
 };
 
 LogicalResult LegalizeCF::lowerCondBranch(lsir::CondBranchOp condBr) {
-  // The condition is a register type (SCC or VCC) directly.
+  // The condition is a register type (SCC or lane mask) directly.
   Value flagReg = condBr.getCondition();
-  bool isVector = isa<VCCType>(flagReg.getType());
+  bool isVector = isLaneMask(flagReg.getType());
 
   // All values flow through side effects; operands must be allocated registers.
   for (auto &brOpRange :

--- a/lib/Dialect/AMDGCN/Transforms/PostRegAllocLegalization.cpp
+++ b/lib/Dialect/AMDGCN/Transforms/PostRegAllocLegalization.cpp
@@ -124,6 +124,17 @@ CopyExpansionPattern::matchAndRewrite(lsir::CopyOp op,
     return success();
   }
 
+  if (isa<VCCLoType>(srcTy) || isa<VCCLoType>(tgtTy)) {
+    assert((isa<VCCLoType>(srcTy) ||
+            srcTy.getRegisterKind() == RegisterKind::SGPR) &&
+           (isa<VCCLoType>(tgtTy) ||
+            tgtTy.getRegisterKind() == RegisterKind::SGPR) &&
+           "VCC_LO copy: the other side must be SGPR-class (s_mov_b32)");
+    SMovB32::create(rewriter, op.getLoc(), op.getTarget(), op.getSource());
+    rewriter.eraseOp(op);
+    return success();
+  }
+
   // Bail if the copy cannot be performed.
   if (srcTy.getRegisterKind() != RegisterKind::SGPR &&
       tgtTy.getRegisterKind() == RegisterKind::SGPR) {

--- a/lib/Dialect/AMDGCN/Transforms/ToAMDGCNPatterns.cpp
+++ b/lib/Dialect/AMDGCN/Transforms/ToAMDGCNPatterns.cpp
@@ -67,6 +67,21 @@ static Value createSOP2Out2In3(OpBuilder &builder, Location loc, Value dst,
       .getDst0Res();
 }
 
+/// Lane-mask AND/OR/XOR -> s_{and,or,xor}_b32/b64 by mask width.
+template <typename SOp32, typename SOp64>
+static LogicalResult lowerVCCBitwise(Operation *op, PatternRewriter &rewriter,
+                                     Value dst, Value lhs, Value rhs) {
+  Value result;
+  if (isa<VCCLoType>(dst.getType()))
+    result = createSOP2Out2In2<SOp32>(rewriter, op->getLoc(), dst, lhs, rhs);
+  else if (isa<VCCType>(dst.getType()))
+    result = createSOP2Out2In2<SOp64>(rewriter, op->getLoc(), dst, lhs, rhs);
+  else
+    return failure();
+  rewriter.replaceOp(op, result);
+  return success();
+}
+
 namespace {
 //===----------------------------------------------------------------------===//
 // AddIOpPattern
@@ -683,6 +698,10 @@ LogicalResult AndIOpPattern::matchAndRewrite(lsir::AndIOp op,
   unsigned width = op.getSemantics().getWidth();
   OperandKind lhsKind, rhsKind;
 
+  // VCC case short-circuit.
+  if (succeeded(lowerVCCBitwise<SAndB32, SAndB64>(op, rewriter, dst, lhs, rhs)))
+    return success();
+
   // Check we can transform this op
   if (failed(checkAIOp(op, rewriter, kind, lhs, rhs, oTy, width, lhsKind,
                        rhsKind, {32, 64}, {32})))
@@ -1169,6 +1188,10 @@ LogicalResult OrIOpPattern::matchAndRewrite(lsir::OrIOp op,
   unsigned width = op.getSemantics().getWidth();
   OperandKind lhsKind, rhsKind;
 
+  // VCC case short-circuit.
+  if (succeeded(lowerVCCBitwise<SOrB32, SOrB64>(op, rewriter, dst, lhs, rhs)))
+    return success();
+
   // Check we can transform this op
   if (failed(checkAIOp(op, rewriter, kind, lhs, rhs, oTy, width, lhsKind,
                        rhsKind, {32, 64}, {32})))
@@ -1207,6 +1230,10 @@ LogicalResult XOrIOpPattern::matchAndRewrite(lsir::XOrIOp op,
   OperandKind kind = getOperandKind(oTy);
   unsigned width = op.getSemantics().getWidth();
   OperandKind lhsKind, rhsKind;
+
+  // VCC case short-circuit.
+  if (succeeded(lowerVCCBitwise<SXorB32, SXorB64>(op, rewriter, dst, lhs, rhs)))
+    return success();
 
   // Check we can transform this op
   if (failed(checkAIOp(op, rewriter, kind, lhs, rhs, oTy, width, lhsKind,
@@ -1956,6 +1983,31 @@ PtrAddOpPattern::matchAndRewrite(PtrAddOp op, PatternRewriter &rewriter) const {
   return success();
 }
 
+/// Broadcast SCC (or other non-lane-mask flag) to a full lane mask.
+static Value broadcastFlagToLaneMask(PatternRewriter &rewriter, Location loc,
+                                     Operation *anchor, Value flagReg) {
+  if (isWave32(anchor)) {
+    Value vccDst = createAllocation(
+        rewriter, loc, VCCLoType::get(rewriter.getContext(), Register()));
+    Type i32 = rewriter.getI32Type();
+    Value allOnes = arith::ConstantOp::create(rewriter, loc, i32,
+                                              rewriter.getIntegerAttr(i32, -1));
+    Value zero = arith::ConstantOp::create(rewriter, loc, i32,
+                                           rewriter.getIntegerAttr(i32, 0));
+    return SCselectB32::create(rewriter, loc, vccDst, allOnes, zero, flagReg)
+        .getDst0Res();
+  }
+  Value vccDst = createAllocation(
+      rewriter, loc, VCCType::get(rewriter.getContext(), Register()));
+  Type i64 = rewriter.getI64Type();
+  Value allOnes = arith::ConstantOp::create(rewriter, loc, i64,
+                                            rewriter.getIntegerAttr(i64, -1));
+  Value zero = arith::ConstantOp::create(rewriter, loc, i64,
+                                         rewriter.getIntegerAttr(i64, 0));
+  return SCselectB64::create(rewriter, loc, vccDst, allOnes, zero, flagReg)
+      .getDst0Res();
+}
+
 //===----------------------------------------------------------------------===//
 // SelectOpPattern
 //===----------------------------------------------------------------------===//
@@ -1963,32 +2015,40 @@ PtrAddOpPattern::matchAndRewrite(PtrAddOp op, PatternRewriter &rewriter) const {
 LogicalResult
 SelectOpPattern::matchAndRewrite(lsir::SelectOp op,
                                  PatternRewriter &rewriter) const {
-  Value flagReg = op.getCondition();
-  bool isVector = isa<VCCType>(flagReg.getType());
   Location loc = op.getLoc();
   Value dst = op.getDst();
-  Value result;
+  Value flagReg = op.getCondition();
+  Value trueVal = op.getTrueValue();
+  Value falseVal = op.getFalseValue();
 
-  if (isVector) {
-    // v_cndmask_b32: vdst = VCC[lane] ? src1 : src0 (note: reversed order!).
-    // src0 = false_value, src1 = true_value, src2 = VCC.
-    // VOP2 src1 must be a VGPR; materialize via v_mov_b32 into dst if needed.
-    // The resulting dst WAR in v_cndmask_b32 is well-defined for VOP2.
-    Value trueVal = op.getTrueValue();
-    Value falseVal = op.getFalseValue();
-    if (!isa<VGPRType>(trueVal.getType())) {
-      VMovB32::create(rewriter, loc, dst, trueVal);
-      trueVal = dst;
-    }
-    result = VCndmaskB32::create(rewriter, loc, dst, falseVal, trueVal, flagReg)
-                 .getDst0Res();
-  } else {
+  bool resultIsVector = isVGPR(dst.getType(), /*numWords=*/-1) ||
+                        isVGPR(trueVal.getType(), /*numWords=*/-1) ||
+                        isVGPR(falseVal.getType(), /*numWords=*/-1);
+
+  if (!resultIsVector) {
     // s_cselect_b32: sdst = SCC ? src0 : src1.
     // src0 = true_value (selected when SCC=1), src1 = false_value.
-    result = SCselectB32::create(rewriter, loc, dst, op.getTrueValue(),
-                                 op.getFalseValue(), flagReg)
-                 .getDst0Res();
+    Value result =
+        SCselectB32::create(rewriter, loc, dst, trueVal, falseVal, flagReg)
+            .getDst0Res();
+    rewriter.replaceOp(op, result);
+    return success();
   }
+
+  // v_cndmask_b32: vdst = VCC[lane] ? src1 : src0 (note: reversed order!).
+  // src0 = false_value, src1 = true_value, src2 = lane mask.
+  Value vccMask = isLaneMask(flagReg.getType())
+                      ? flagReg
+                      : broadcastFlagToLaneMask(rewriter, loc, op, flagReg);
+  // VOP2 src1 must be a VGPR; materialize via v_mov_b32 into dst if needed.
+  // The resulting dst WAR in v_cndmask_b32 is well-defined for VOP2.
+  if (!isa<VGPRType>(trueVal.getType())) {
+    VMovB32::create(rewriter, loc, dst, trueVal);
+    trueVal = dst;
+  }
+  Value result =
+      VCndmaskB32::create(rewriter, loc, dst, falseVal, trueVal, vccMask)
+          .getDst0Res();
   rewriter.replaceOp(op, result);
   return success();
 }
@@ -2096,10 +2156,7 @@ LogicalResult CmpIOpPattern::matchAndRewrite(lsir::CmpIOp op,
   Location loc = op.getLoc();
 
   Value result;
-  if (isa<VCCType>(dst.getType())) {
-    // Vector compare: v_cmp_* writes to VCC. The 32-bit VOPC encoding requires
-    // src1 (rhs) to be a VGPR. If rhs is not a VGPR, swap operands and flip
-    // the predicate.
+  if (isLaneMask(dst.getType())) {
     if (!isa<VGPRType>(rhs.getType())) {
       assert(isa<VGPRType>(lhs.getType()) &&
              "at least one operand must be a VGPR for vector compare");

--- a/lib/Dialect/LSIR/CodeGen/CodeGenPatterns.cpp
+++ b/lib/Dialect/LSIR/CodeGen/CodeGenPatterns.cpp
@@ -136,7 +136,7 @@ struct ArithMinMaxOpPattern : public OpCodeGenPattern<MinMaxOp> {
     Value dst = this->createAlloca(rewriter, loc, regType);
     Type cmpDstType =
         isa<amdgcn::VGPRType>(lhs.getType())
-            ? Type(amdgcn::VCCType::get(rewriter.getContext(), Register()))
+            ? amdgcn::getLaneMaskType(op.getOperation())
             : Type(amdgcn::SCCType::get(rewriter.getContext(), Register()));
     Value cmpDst = this->createAlloca(rewriter, loc, cmpDstType);
     Value cmp = lsir::CmpIOp::create(
@@ -298,11 +298,9 @@ LogicalResult
 ArithCmpFOpPattern::matchAndRewrite(arith::CmpFOp op,
                                     arith::CmpFOp::Adaptor adaptor,
                                     ConversionPatternRewriter &rewriter) const {
-  // AMDGCN has no scalar float compare instructions (s_cmp_* is integer-only).
-  // All float comparisons use VOPC instructions (v_cmp_f_*) which write to VCC.
   assert(isa<amdgcn::VGPRType>(adaptor.getLhs().getType()) &&
          "arith.cmpf operands must be VGPRs after codegen conversion");
-  Type dstType = amdgcn::VCCType::get(op.getContext(), Register());
+  Type dstType = amdgcn::getLaneMaskType(op.getOperation());
   Value dst = createAlloca(rewriter, op.getLoc(), dstType);
   auto cmpOp = lsir::CmpFOp::create(
       rewriter, op.getLoc(), TypeAttr::get(op.getLhs().getType()),

--- a/test/Dialect/AMDGCN/Transforms/legalize-cf.mlir
+++ b/test/Dialect/AMDGCN/Transforms/legalize-cf.mlir
@@ -76,6 +76,32 @@ amdgcn.module @test_vcc target = <gfx942> {
 
 // -----
 
+// gfx1250 VCC_LO conditional branch.
+
+// CHECK-LABEL: kernel @test_cond_branch_vcc_lo
+// CHECK:         v_cmp_lt_i32 outs(%[[VCC:.*]]) ins(%{{.*}}, %{{.*}})
+// CHECK:         s_cbranch_vccz %[[VCC]], true(^bb2) false(^bb1)
+// CHECK:       ^bb1:
+// CHECK:         end_kernel
+// CHECK:       ^bb2:
+// CHECK:         end_kernel
+amdgcn.module @test_vcc_lo target = <gfx1250> {
+  amdgcn.kernel @test_cond_branch_vcc_lo attributes {normal_forms = [#amdgcn.all_registers_allocated]} {
+    %c0 = arith.constant 0 : i32
+    %v0 = alloca : !amdgcn.vgpr<0>
+    %vcc_lo = alloca : !amdgcn.vcc_lo<0>
+    v_mov_b32 outs(%v0) ins(%c0) : outs(!amdgcn.vgpr<0>) ins(i32)
+    v_cmp_lt_i32 outs(%vcc_lo) ins(%v0, %c0) : outs(!amdgcn.vcc_lo<0>) ins(!amdgcn.vgpr<0>, i32)
+    lsir.cond_br %vcc_lo : !amdgcn.vcc_lo<0>, ^bb1, ^bb2
+  ^bb1:
+    end_kernel
+  ^bb2:
+    end_kernel
+  }
+}
+
+// -----
+
 // Test: SCC conditional branch where falseDest (^bb1) is the next block.
 // This means the pass uses s_cbranch_scc1 to branch to ^bb2 when SCC=1,
 // falling through to ^bb1 when SCC=0.

--- a/test/Dialect/AMDGCN/Transforms/select-scc-flag-vgpr-result.mlir
+++ b/test/Dialect/AMDGCN/Transforms/select-scc-flag-vgpr-result.mlir
@@ -1,0 +1,60 @@
+// RUN: aster-opt %s -aster-to-amdgcn --split-input-file | FileCheck %s
+
+// VGPR select with SCC condition -> v_cndmask + s_cselect_b64 broadcast.
+
+// CHECK-LABEL: func.func @select_vgpr_result_scc_cond
+// CHECK: amdgcn.s_cselect_b64 {{.*}} : outs(!amdgcn.vcc)
+// CHECK: amdgcn.v_cndmask_b32 {{.*}} : outs(!amdgcn.vgpr) ins(i32, !amdgcn.vgpr, !amdgcn.vcc)
+// CHECK-NOT: amdgcn.s_cselect_b32
+func.func @select_vgpr_result_scc_cond(
+    %dst: !amdgcn.vgpr,
+    %tv: !amdgcn.vgpr,
+    %lhs: !amdgcn.sgpr,
+    %scc: !amdgcn.scc) -> !amdgcn.vgpr {
+  %c8_i32 = arith.constant 8 : i32
+  %c-1_i32 = arith.constant -1 : i32
+  %cond = lsir.cmpi i32 ult %scc, %lhs, %c8_i32 : !amdgcn.scc, !amdgcn.sgpr, i32
+  %result = lsir.select %dst, %cond, %tv, %c-1_i32 : !amdgcn.vgpr, !amdgcn.scc, !amdgcn.vgpr, i32
+  return %result : !amdgcn.vgpr
+}
+
+// -----
+
+// Scalar select still uses s_cselect_b32.
+
+// CHECK-LABEL: func.func @select_sgpr_result_scc_cond
+// CHECK: amdgcn.s_cselect_b32
+// CHECK-NOT: amdgcn.v_cndmask_b32
+func.func @select_sgpr_result_scc_cond(
+    %dst: !amdgcn.sgpr,
+    %tv: !amdgcn.sgpr,
+    %fv: !amdgcn.sgpr,
+    %lhs: !amdgcn.sgpr,
+    %scc: !amdgcn.scc) -> !amdgcn.sgpr {
+  %c8_i32 = arith.constant 8 : i32
+  %cond = lsir.cmpi i32 ult %scc, %lhs, %c8_i32 : !amdgcn.scc, !amdgcn.sgpr, i32
+  %result = lsir.select %dst, %cond, %tv, %fv : !amdgcn.sgpr, !amdgcn.scc, !amdgcn.sgpr, !amdgcn.sgpr
+  return %result : !amdgcn.sgpr
+}
+
+// -----
+
+// Wave32: s_cselect_b32 vcc_lo broadcast + v_cndmask_b32.
+
+// CHECK-LABEL: func.func @select_vgpr_result_scc_cond_wave32
+// CHECK: amdgcn.s_cselect_b32 {{.*}} : outs(!amdgcn.vcc_lo)
+// CHECK: amdgcn.v_cndmask_b32 {{.*}} : outs(!amdgcn.vgpr) ins(i32, !amdgcn.vgpr, !amdgcn.vcc_lo)
+// CHECK-NOT: amdgcn.s_cselect_b64
+amdgcn.module @select_wave32_mod target = #amdgcn.target<gfx1250> {
+  func.func @select_vgpr_result_scc_cond_wave32(
+      %dst: !amdgcn.vgpr,
+      %tv: !amdgcn.vgpr,
+      %lhs: !amdgcn.sgpr,
+      %scc: !amdgcn.scc) -> !amdgcn.vgpr {
+    %c8_i32 = arith.constant 8 : i32
+    %c-1_i32 = arith.constant -1 : i32
+    %cond = lsir.cmpi i32 ult %scc, %lhs, %c8_i32 : !amdgcn.scc, !amdgcn.sgpr, i32
+    %result = lsir.select %dst, %cond, %tv, %c-1_i32 : !amdgcn.vgpr, !amdgcn.scc, !amdgcn.vgpr, i32
+    return %result : !amdgcn.vgpr
+  }
+}

--- a/test/Dialect/AMDGCN/Transforms/to-amdgcn.mlir
+++ b/test/Dialect/AMDGCN/Transforms/to-amdgcn.mlir
@@ -416,6 +416,88 @@ func.func @test_xor_i64_sgpr(%dst: !amdgcn.sgpr<[? + 2]>, %lhs: !amdgcn.sgpr<[? 
   return %res : !amdgcn.sgpr<[? + 2]>
 }
 
+// Lane-mask bitwise ops -> s_{and,or,xor}_b32/b64.
+
+// CHECK-LABEL:   func.func @test_and_i1_vcc(
+// CHECK-SAME:      %[[ARG0:.*]]: !amdgcn.vcc, %[[ARG1:.*]]: !amdgcn.vcc, %[[ARG2:.*]]: !amdgcn.vcc) -> !amdgcn.vcc {
+// CHECK:           %[[SCC_ALLOCA_0:.*]] = amdgcn.alloca : !amdgcn.scc<0>
+// CHECK:           %[[VAL_0:.*]] = amdgcn.s_and_b64 outs(%[[ARG0]], %[[SCC_ALLOCA_0]]) ins(%[[ARG1]], %[[ARG2]]) : outs(!amdgcn.vcc, !amdgcn.scc<0>) ins(!amdgcn.vcc, !amdgcn.vcc)
+// CHECK:           return %[[VAL_0]] : !amdgcn.vcc
+// CHECK:         }
+func.func @test_and_i1_vcc(%dst: !amdgcn.vcc, %lhs: !amdgcn.vcc, %rhs: !amdgcn.vcc) -> !amdgcn.vcc{
+  %res = lsir.andi i1 %dst, %lhs, %rhs : !amdgcn.vcc, !amdgcn.vcc, !amdgcn.vcc
+  return %res : !amdgcn.vcc
+}
+
+// CHECK-LABEL:   func.func @test_or_i1_vcc(
+// CHECK-SAME:      %[[ARG0:.*]]: !amdgcn.vcc, %[[ARG1:.*]]: !amdgcn.vcc, %[[ARG2:.*]]: !amdgcn.vcc) -> !amdgcn.vcc {
+// CHECK:           %[[SCC_ALLOCA_0:.*]] = amdgcn.alloca : !amdgcn.scc<0>
+// CHECK:           %[[VAL_0:.*]] = amdgcn.s_or_b64 outs(%[[ARG0]], %[[SCC_ALLOCA_0]]) ins(%[[ARG1]], %[[ARG2]]) : outs(!amdgcn.vcc, !amdgcn.scc<0>) ins(!amdgcn.vcc, !amdgcn.vcc)
+// CHECK:           return %[[VAL_0]] : !amdgcn.vcc
+// CHECK:         }
+func.func @test_or_i1_vcc(%dst: !amdgcn.vcc, %lhs: !amdgcn.vcc, %rhs: !amdgcn.vcc) -> !amdgcn.vcc{
+  %res = lsir.ori i1 %dst, %lhs, %rhs : !amdgcn.vcc, !amdgcn.vcc, !amdgcn.vcc
+  return %res : !amdgcn.vcc
+}
+
+// CHECK-LABEL:   func.func @test_xor_i1_vcc(
+// CHECK-SAME:      %[[ARG0:.*]]: !amdgcn.vcc, %[[ARG1:.*]]: !amdgcn.vcc, %[[ARG2:.*]]: !amdgcn.vcc) -> !amdgcn.vcc {
+// CHECK:           %[[SCC_ALLOCA_0:.*]] = amdgcn.alloca : !amdgcn.scc<0>
+// CHECK:           %[[VAL_0:.*]] = amdgcn.s_xor_b64 outs(%[[ARG0]], %[[SCC_ALLOCA_0]]) ins(%[[ARG1]], %[[ARG2]]) : outs(!amdgcn.vcc, !amdgcn.scc<0>) ins(!amdgcn.vcc, !amdgcn.vcc)
+// CHECK:           return %[[VAL_0]] : !amdgcn.vcc
+// CHECK:         }
+func.func @test_xor_i1_vcc(%dst: !amdgcn.vcc, %lhs: !amdgcn.vcc, %rhs: !amdgcn.vcc) -> !amdgcn.vcc{
+  %res = lsir.xori i1 %dst, %lhs, %rhs : !amdgcn.vcc, !amdgcn.vcc, !amdgcn.vcc
+  return %res : !amdgcn.vcc
+}
+
+// Wave32 lane masks use the b32 form.
+
+// CHECK-LABEL:   func.func @test_and_i1_vcc_lo(
+// CHECK-SAME:      %[[ARG0:.*]]: !amdgcn.vcc_lo, %[[ARG1:.*]]: !amdgcn.vcc_lo, %[[ARG2:.*]]: !amdgcn.vcc_lo) -> !amdgcn.vcc_lo {
+// CHECK:           %[[SCC_ALLOCA_0:.*]] = amdgcn.alloca : !amdgcn.scc<0>
+// CHECK:           %[[VAL_0:.*]] = amdgcn.s_and_b32 outs(%[[ARG0]], %[[SCC_ALLOCA_0]]) ins(%[[ARG1]], %[[ARG2]]) : outs(!amdgcn.vcc_lo, !amdgcn.scc<0>) ins(!amdgcn.vcc_lo, !amdgcn.vcc_lo)
+// CHECK:           return %[[VAL_0]] : !amdgcn.vcc_lo
+// CHECK:         }
+func.func @test_and_i1_vcc_lo(%dst: !amdgcn.vcc_lo, %lhs: !amdgcn.vcc_lo, %rhs: !amdgcn.vcc_lo) -> !amdgcn.vcc_lo{
+  %res = lsir.andi i1 %dst, %lhs, %rhs : !amdgcn.vcc_lo, !amdgcn.vcc_lo, !amdgcn.vcc_lo
+  return %res : !amdgcn.vcc_lo
+}
+
+// CHECK-LABEL:   func.func @test_or_i1_vcc_lo(
+// CHECK-SAME:      %[[ARG0:.*]]: !amdgcn.vcc_lo, %[[ARG1:.*]]: !amdgcn.vcc_lo, %[[ARG2:.*]]: !amdgcn.vcc_lo) -> !amdgcn.vcc_lo {
+// CHECK:           %[[SCC_ALLOCA_0:.*]] = amdgcn.alloca : !amdgcn.scc<0>
+// CHECK:           %[[VAL_0:.*]] = amdgcn.s_or_b32 outs(%[[ARG0]], %[[SCC_ALLOCA_0]]) ins(%[[ARG1]], %[[ARG2]]) : outs(!amdgcn.vcc_lo, !amdgcn.scc<0>) ins(!amdgcn.vcc_lo, !amdgcn.vcc_lo)
+// CHECK:           return %[[VAL_0]] : !amdgcn.vcc_lo
+// CHECK:         }
+func.func @test_or_i1_vcc_lo(%dst: !amdgcn.vcc_lo, %lhs: !amdgcn.vcc_lo, %rhs: !amdgcn.vcc_lo) -> !amdgcn.vcc_lo{
+  %res = lsir.ori i1 %dst, %lhs, %rhs : !amdgcn.vcc_lo, !amdgcn.vcc_lo, !amdgcn.vcc_lo
+  return %res : !amdgcn.vcc_lo
+}
+
+// CHECK-LABEL:   func.func @test_xor_i1_vcc_lo(
+// CHECK-SAME:      %[[ARG0:.*]]: !amdgcn.vcc_lo, %[[ARG1:.*]]: !amdgcn.vcc_lo, %[[ARG2:.*]]: !amdgcn.vcc_lo) -> !amdgcn.vcc_lo {
+// CHECK:           %[[SCC_ALLOCA_0:.*]] = amdgcn.alloca : !amdgcn.scc<0>
+// CHECK:           %[[VAL_0:.*]] = amdgcn.s_xor_b32 outs(%[[ARG0]], %[[SCC_ALLOCA_0]]) ins(%[[ARG1]], %[[ARG2]]) : outs(!amdgcn.vcc_lo, !amdgcn.scc<0>) ins(!amdgcn.vcc_lo, !amdgcn.vcc_lo)
+// CHECK:           return %[[VAL_0]] : !amdgcn.vcc_lo
+// CHECK:         }
+func.func @test_xor_i1_vcc_lo(%dst: !amdgcn.vcc_lo, %lhs: !amdgcn.vcc_lo, %rhs: !amdgcn.vcc_lo) -> !amdgcn.vcc_lo{
+  %res = lsir.xori i1 %dst, %lhs, %rhs : !amdgcn.vcc_lo, !amdgcn.vcc_lo, !amdgcn.vcc_lo
+  return %res : !amdgcn.vcc_lo
+}
+
+// A vector lsir.cmpi with vcc_lo dst -> v_cmp.
+
+// CHECK-LABEL:   func.func @test_cmpi_slt_vcc_lo(
+// CHECK-SAME:      %[[ARG0:.*]]: !amdgcn.vcc_lo, %[[ARG1:.*]]: !amdgcn.vgpr, %[[ARG2:.*]]: !amdgcn.vgpr) -> !amdgcn.vcc_lo {
+// CHECK:           %[[VAL_0:.*]] = amdgcn.v_cmp_lt_i32 outs(%[[ARG0]]) ins(%[[ARG1]], %[[ARG2]]) : outs(!amdgcn.vcc_lo) ins(!amdgcn.vgpr, !amdgcn.vgpr)
+// CHECK:           return %[[VAL_0]] : !amdgcn.vcc_lo
+// CHECK:         }
+func.func @test_cmpi_slt_vcc_lo(%dst: !amdgcn.vcc_lo, %lhs: !amdgcn.vgpr, %rhs: !amdgcn.vgpr) -> !amdgcn.vcc_lo {
+  %res = lsir.cmpi i32 slt %dst, %lhs, %rhs : !amdgcn.vcc_lo, !amdgcn.vgpr, !amdgcn.vgpr
+  return %res : !amdgcn.vcc_lo
+}
+
 // CHECK-LABEL:   func.func @test_load_global_dword(
 // CHECK-SAME:      %[[ARG0:.*]]: !amdgcn.vgpr, %[[ARG1:.*]]: !amdgcn.vgpr<[? + 2]>) -> !amdgcn.vgpr {
 // CHECK:           %[[VAL_0:.*]], %[[LOAD_0:.*]] = amdgcn.global_load_dword dest %[[ARG0]] addr %[[ARG1]] offset c(%{{.*}}) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>

--- a/test/Dialect/AMDGCN/gfx1250-ops.mlir
+++ b/test/Dialect/AMDGCN/gfx1250-ops.mlir
@@ -156,3 +156,38 @@ amdgcn.library @library_multi_isa_gfx12_50 isa = [#amdgcn.isa<cdna3>, #amdgcn.is
     return
   }
 }
+
+//===----------------------------------------------------------------------===//
+// v_cndmask_b32 with VCC_LO mask
+//===----------------------------------------------------------------------===//
+
+func.func @test_v_cndmask_b32_vcc_lo(
+    %dst: !amdgcn.vgpr,
+    %src0: !amdgcn.vgpr,
+    %src1: !amdgcn.vgpr,
+    %mask: !amdgcn.vcc_lo) -> !amdgcn.vgpr {
+  %result = amdgcn.v_cndmask_b32 outs(%dst) ins(%src0, %src1, %mask)
+      : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr, !amdgcn.vgpr, !amdgcn.vcc_lo)
+  return %result : !amdgcn.vgpr
+}
+
+//===----------------------------------------------------------------------===//
+// v_cmp + s_cbranch with VCC_LO
+//===----------------------------------------------------------------------===//
+
+func.func @test_v_cmp_lt_i32_vcc_lo(
+    %dst: !amdgcn.vcc_lo,
+    %lhs: !amdgcn.vgpr,
+    %rhs: !amdgcn.vgpr) -> !amdgcn.vcc_lo {
+  %result = amdgcn.v_cmp_lt_i32 outs(%dst) ins(%lhs, %rhs)
+      : outs(!amdgcn.vcc_lo) ins(!amdgcn.vgpr, !amdgcn.vgpr)
+  return %result : !amdgcn.vcc_lo
+}
+
+func.func @test_s_cbranch_vccnz_vcc_lo(%cond: !amdgcn.vcc_lo) {
+  amdgcn.s_cbranch_vccnz %cond, true(^taken) false(^fallthru) : !amdgcn.vcc_lo
+^fallthru:
+  return
+^taken:
+  return
+}

--- a/test/Dialect/AMDGCN/lane-mask-width-invalid.mlir
+++ b/test/Dialect/AMDGCN/lane-mask-width-invalid.mlir
@@ -1,0 +1,68 @@
+// RUN: aster-opt %s --split-input-file --verify-diagnostics
+
+// LaneMaskWidthTrait: lane-mask width must match module wave size.
+amdgcn.module @cbranch_vcc64_on_wave32 target = #amdgcn.target<gfx1250> {
+  amdgcn.kernel @k {
+  ^entry:
+    %l = amdgcn.alloca : !amdgcn.vcc_lo<0>
+    %h = amdgcn.alloca : !amdgcn.vcc_hi<0>
+    %vcc = amdgcn.make_register_range %l, %h : !amdgcn.vcc_lo<0>, !amdgcn.vcc_hi<0>
+    // expected-error @+1 {{VCC operand must match the wave size}}
+    amdgcn.s_cbranch_vccnz %vcc, true(^t) false(^f) : !amdgcn.vcc<0>
+  ^f:
+    amdgcn.end_kernel
+  ^t:
+    amdgcn.end_kernel
+  }
+}
+
+// -----
+
+// wave64: s_cbranch rejects VCC_LO.
+amdgcn.module @cbranch_vcc_lo_on_wave64 target = #amdgcn.target<gfx942> {
+  amdgcn.kernel @k {
+  ^entry:
+    %l = amdgcn.alloca : !amdgcn.vcc_lo<0>
+    // expected-error @+1 {{VCC operand must match the wave size}}
+    amdgcn.s_cbranch_vccz %l, true(^t) false(^f) : !amdgcn.vcc_lo<0>
+  ^f:
+    amdgcn.end_kernel
+  ^t:
+    amdgcn.end_kernel
+  }
+}
+
+// -----
+
+// wave32: v_cmp rejects 64-bit VCC.
+amdgcn.module @vcmp_vcc64_on_wave32 target = #amdgcn.target<gfx1250> {
+  amdgcn.kernel @k {
+  ^entry:
+    %v0 = amdgcn.alloca : !amdgcn.vgpr<0>
+    %l = amdgcn.alloca : !amdgcn.vcc_lo<0>
+    %h = amdgcn.alloca : !amdgcn.vcc_hi<0>
+    %vcc = amdgcn.make_register_range %l, %h : !amdgcn.vcc_lo<0>, !amdgcn.vcc_hi<0>
+    %c0 = arith.constant 0 : i32
+    // expected-error @+1 {{VCC operand must match the wave size}}
+    amdgcn.v_cmp_lt_i32 outs(%vcc) ins(%v0, %c0) : outs(!amdgcn.vcc<0>) ins(!amdgcn.vgpr<0>, i32)
+    amdgcn.end_kernel
+  }
+}
+
+// -----
+
+// wave32: v_cndmask rejects 64-bit VCC.
+amdgcn.module @vcndmask_vcc64_on_wave32 target = #amdgcn.target<gfx1250> {
+  amdgcn.kernel @k {
+  ^entry:
+    %v0 = amdgcn.alloca : !amdgcn.vgpr<0>
+    %v1 = amdgcn.alloca : !amdgcn.vgpr<1>
+    %v2 = amdgcn.alloca : !amdgcn.vgpr<2>
+    %l = amdgcn.alloca : !amdgcn.vcc_lo<0>
+    %h = amdgcn.alloca : !amdgcn.vcc_hi<0>
+    %vcc = amdgcn.make_register_range %l, %h : !amdgcn.vcc_lo<0>, !amdgcn.vcc_hi<0>
+    // expected-error @+1 {{VCC operand must match the wave size}}
+    amdgcn.v_cndmask_b32 outs(%v2) ins(%v0, %v1, %vcc) : outs(!amdgcn.vgpr<2>) ins(!amdgcn.vgpr<0>, !amdgcn.vgpr<1>, !amdgcn.vcc<0>)
+    amdgcn.end_kernel
+  }
+}

--- a/test/Dialect/AMDGCN/lane-mask-width-valid.mlir
+++ b/test/Dialect/AMDGCN/lane-mask-width-valid.mlir
@@ -1,0 +1,37 @@
+// RUN: aster-opt %s --split-input-file
+
+// LaneMaskWidthTrait accepts correct-width lane masks.
+amdgcn.module @wave32_vcc_lo target = #amdgcn.target<gfx1250> {
+  amdgcn.kernel @k {
+  ^entry:
+    %v0 = amdgcn.alloca : !amdgcn.vgpr<0>
+    %vl = amdgcn.alloca : !amdgcn.vcc_lo<0>
+    %c0 = arith.constant 0 : i32
+    amdgcn.v_cmp_lt_i32 outs(%vl) ins(%v0, %c0) : outs(!amdgcn.vcc_lo<0>) ins(!amdgcn.vgpr<0>, i32)
+    amdgcn.s_cbranch_vccnz %vl, true(^t) false(^f) : !amdgcn.vcc_lo<0>
+  ^f:
+    amdgcn.end_kernel
+  ^t:
+    amdgcn.end_kernel
+  }
+}
+
+// -----
+
+// wave64 (gfx942): the 64-bit vcc is accepted on v_cmp and s_cbranch.
+amdgcn.module @wave64_vcc target = #amdgcn.target<gfx942> {
+  amdgcn.kernel @k {
+  ^entry:
+    %v0 = amdgcn.alloca : !amdgcn.vgpr<0>
+    %vl = amdgcn.alloca : !amdgcn.vcc_lo<0>
+    %vh = amdgcn.alloca : !amdgcn.vcc_hi<0>
+    %vcc = amdgcn.make_register_range %vl, %vh : !amdgcn.vcc_lo<0>, !amdgcn.vcc_hi<0>
+    %c0 = arith.constant 0 : i32
+    amdgcn.v_cmp_lt_i32 outs(%vcc) ins(%v0, %c0) : outs(!amdgcn.vcc<0>) ins(!amdgcn.vgpr<0>, i32)
+    amdgcn.s_cbranch_vccnz %vcc, true(^t) false(^f) : !amdgcn.vcc<0>
+  ^f:
+    amdgcn.end_kernel
+  ^t:
+    amdgcn.end_kernel
+  }
+}

--- a/test/Target/ASM/gfx1250-vcc-select-asm.mlir
+++ b/test/Target/ASM/gfx1250-vcc-select-asm.mlir
@@ -1,0 +1,38 @@
+// RUN: aster-translate %s --mlir-to-asm | FileCheck %s
+// RUN: aster-translate %s --mlir-to-asm \
+// RUN:   | llvm-mc -triple=amdgcn-amd-amdhsa -mcpu=gfx1250 -mattr=+wavefrontsize32 -filetype=obj -o %t.o
+
+amdgcn.module @gfx1250_vcc_select_mod target = #amdgcn.target<gfx1250> {
+
+  // CHECK-LABEL: test_s_and_b32_vcc_lo:
+  // CHECK:       s_and_b32 vcc_lo, s0, s1
+  // CHECK:       s_endpgm
+  amdgcn.kernel @test_s_and_b32_vcc_lo {
+  ^entry:
+    %vcc_lo = amdgcn.alloca : !amdgcn.vcc_lo<0>
+    %s0 = amdgcn.alloca : !amdgcn.sgpr<0>
+    %s1 = amdgcn.alloca : !amdgcn.sgpr<1>
+    %scc = amdgcn.alloca : !amdgcn.scc<0>
+    amdgcn.s_and_b32 outs(%vcc_lo, %scc) ins(%s0, %s1) : outs(!amdgcn.vcc_lo<0>, !amdgcn.scc<0>) ins(!amdgcn.sgpr<0>, !amdgcn.sgpr<1>)
+    amdgcn.end_kernel
+  }
+
+  // s_cselect_b32 broadcasts SCC to vcc_lo (-1 = all lanes true, 0 = all false).
+  // CHECK-LABEL: test_s_cselect_b32_vcc_lo:
+  // CHECK:       s_cselect_b32 vcc_lo, -1, 0
+  // CHECK:       v_cndmask_b32 v2, v0, v1, vcc_lo
+  // CHECK:       s_endpgm
+  amdgcn.kernel @test_s_cselect_b32_vcc_lo {
+  ^entry:
+    %v0 = amdgcn.alloca : !amdgcn.vgpr<0>
+    %v1 = amdgcn.alloca : !amdgcn.vgpr<1>
+    %v2 = amdgcn.alloca : !amdgcn.vgpr<2>
+    %vcc_lo = amdgcn.alloca : !amdgcn.vcc_lo<0>
+    %scc = amdgcn.alloca : !amdgcn.scc<0>
+    %cm1 = arith.constant -1 : i32
+    %c0 = arith.constant 0 : i32
+    amdgcn.s_cselect_b32 outs(%vcc_lo) ins(%cm1, %c0, %scc) : outs(!amdgcn.vcc_lo<0>) ins(i32, i32, !amdgcn.scc<0>)
+    amdgcn.v_cndmask_b32 outs(%v2) ins(%v0, %v1, %vcc_lo) : outs(!amdgcn.vgpr<2>) ins(!amdgcn.vgpr<0>, !amdgcn.vgpr<1>, !amdgcn.vcc_lo<0>)
+    amdgcn.end_kernel
+  }
+}

--- a/test/Target/ASM/gfx1250-vcmp-branch-asm.mlir
+++ b/test/Target/ASM/gfx1250-vcmp-branch-asm.mlir
@@ -1,0 +1,26 @@
+// RUN: aster-translate %s --mlir-to-asm | FileCheck %s
+// RUN: aster-translate %s --mlir-to-asm \
+// RUN:   | llvm-mc -triple=amdgcn-amd-amdhsa -mcpu=gfx1250 -mattr=+wavefrontsize32 -filetype=obj -o %t.o
+
+// gfx1250: v_cmp -> vcc_lo, s_cbranch_vccnz consumes vcc_lo.
+
+// CHECK-LABEL: test_vcmp_lt_i32_vcc_lo:
+// CHECK:       v_cmp_lt_i32_e64 vcc_lo, 0, v0
+// CHECK:       s_cbranch_vccnz .AMDGCN_BB_1
+// CHECK:       s_endpgm
+
+amdgcn.module @gfx1250_vcmp_branch_mod target = #amdgcn.target<gfx1250> {
+
+  amdgcn.kernel @test_vcmp_lt_i32_vcc_lo {
+  ^entry:
+    %v0 = amdgcn.alloca : !amdgcn.vgpr<0>
+    %vcc_lo = amdgcn.alloca : !amdgcn.vcc_lo<0>
+    %c0 = arith.constant 0 : i32
+    amdgcn.v_cmp_lt_i32 outs(%vcc_lo) ins(%c0, %v0) : outs(!amdgcn.vcc_lo<0>) ins(i32, !amdgcn.vgpr<0>)
+    amdgcn.s_cbranch_vccnz %vcc_lo, true(^taken) false(^fallthru) : !amdgcn.vcc_lo<0>
+  ^fallthru:
+    amdgcn.end_kernel
+  ^taken:
+    amdgcn.end_kernel
+  }
+}


### PR DESCRIPTION
Add gfx1250 wave32 lane mask: VCC_LO TableGen + verification Use v_cndmask when result/operands are VGPRs
Broadcast SCC to a lane mask (vcc_lo on wave32)
Lower chained boolean lane-mask AND/OR/XOR for select(a && b, ...)