### PR TITLE
Add support for cluster_id ops (GFX12.5+)

### DIFF
--- a/include/aster/Dialect/AMDGCN/IR/AMDGCNEnums.td
+++ b/include/aster/Dialect/AMDGCN/IR/AMDGCNEnums.td
@@ -41,6 +41,7 @@ def RegisterKind : AutoI32EnumCases<"RegisterKind", "AMDGCN register kind", [
     EnumCaseInfo<"Unknown", "Unknown">,
     EnumCaseInfo<"AGPR">,
     EnumCaseInfo<"SGPR">,
+    EnumCaseInfo<"TTMP">,
     EnumCaseInfo<"VGPR">,
     EnumCaseInfo<"SREG">
   ] # !foreach(sreg, SpecialRegisters, EnumCaseInfo<sreg.name>)> {

--- a/include/aster/Dialect/AMDGCN/IR/AMDGCNOps.td
+++ b/include/aster/Dialect/AMDGCN/IR/AMDGCNOps.td
@@ -222,6 +222,46 @@ def AMDGCN_GridDimOp : AMDGCN_Op<"grid_dim", [Pure]> {
 }
 
 //===----------------------------------------------------------------------===//
+// Workgroup-cluster id ops (gfx1250+)
+//===----------------------------------------------------------------------===//
+
+def AMDGCN_ClusterIdOp : AMDGCN_Op<"cluster_id",
+    [Pure, DeclareOpInterfaceMethods<ISACompatibleOpInterface>]> {
+  let summary = "cluster ID in the specified dimension";
+  let description = [{
+    Returns the cluster ID in the grid in the (x, y, or z) dimension.
+    Valid on gfx1250+ (GFX12.5) targets.
+  }];
+  let arguments = (ins DimAttr:$dim);
+  let results = (outs SGPRType:$result);
+  let assemblyFormat = "custom<DimAttr>($dim) attr-dict `:` type($result)";
+}
+
+def AMDGCN_ClusterWorkgroupIdOp : AMDGCN_Op<"cluster_workgroup_id",
+    [Pure, DeclareOpInterfaceMethods<ISACompatibleOpInterface>]> {
+  let summary = "workgroup ID in the cluster in the specified dimension";
+  let description = [{
+    Returns the workgroup ID in the cluster in the (x, y, or z) dimension.
+    Valid on gfx1250+ (GFX12.5) targets.
+  }];
+  let arguments = (ins DimAttr:$dim);
+  let results = (outs SGPRType:$result);
+  let assemblyFormat = "custom<DimAttr>($dim) attr-dict `:` type($result)";
+}
+
+def AMDGCN_ClusterWorkgroupMaxIdOp : AMDGCN_Op<"cluster_workgroup_max_id",
+    [Pure, DeclareOpInterfaceMethods<ISACompatibleOpInterface>]> {
+  let summary = "max workgroup ID in the cluster in the specified dimension";
+  let description = [{
+    Returns the max workgroup ID in the cluster in the (x, y, or z) dimension.
+    Valid on gfx1250+ (GFX12.5) targets.
+  }];
+  let arguments = (ins DimAttr:$dim);
+  let results = (outs SGPRType:$result);
+  let assemblyFormat = "custom<DimAttr>($dim) attr-dict `:` type($result)";
+}
+
+//===----------------------------------------------------------------------===//
 // LoadArgOp
 //===----------------------------------------------------------------------===//
 
@@ -344,6 +384,9 @@ def AMDGCN_KernelOp : AMDGCN_Op<"kernel", [
     // Workgroup hints
     ConfinedAttr<IntMDAttr<1024>, [IntMaxValue<1024>]>:$max_flat_workgroup_size,
     ReqdWgpSize:$reqd_workgroup_size,
+    // gfx1250+ workgroup-cluster dimensions.
+    // Emitted as .cluster_dims metadata (default {0,0,0} erased from metadata).
+    ReqdWgpSize:$cluster_dims,
     // Math flags:
     FloatRoundModeAttr:$f32_round_mode,
     FloatRoundModeAttr:$f16_f64_round_mode,

--- a/include/aster/Dialect/AMDGCN/IR/AMDGCNTypeConstraints.td
+++ b/include/aster/Dialect/AMDGCN/IR/AMDGCNTypeConstraints.td
@@ -47,6 +47,7 @@ def EXECHiType : AMDReg<"EXECHiType", "EXEC Hi", /*isSReg=*/true>;
 def VCCZType : AMDReg<"VCCZType", "VCCZ", /*isSReg=*/true>;
 def EXECZType : AMDReg<"EXECZType", "EXECZ", /*isSReg=*/true>;
 def SCCType : AMDReg<"SCCType", "SCC", /*isSReg=*/true>;
+def TTMPType : AMDReg<"TTMPType", "TTMP", /*isSReg=*/true>;
 
 //===----------------------------------------------------------------------===//
 // Special register constraint
@@ -269,7 +270,7 @@ class OneGPROrSRegOrConstOf<Type litType, Type dataType> : AnyOperandOf<[VGPROf<
 class OneGPROrSRegOrLitOf<Type litType> : AnyOperandOf<[VGPROf<1>, SGPROf<1>, VCCLoType, VCCHiType, M0Type, EXECLoType, EXECHiType, VCCZType, EXECZType, SCCType, litType]>;
 class OneGPROrVCCM0OrFPConstOf<Type floatLit, Type fpConst> : AnyOperandOf<[VGPROf<1>, SGPROf<1>, VCCLoType, VCCHiType, M0Type, VCCZType, EXECZType, SCCType, floatLit, fpConst]>;
 class OneGPROrVCCM0OrFPLitOf<Type floatLit> : AnyOperandOf<[VGPROf<1>, SGPROf<1>, VCCLoType, VCCHiType, M0Type, VCCZType, EXECZType, SCCType, floatLit]>;
-class OneSGPROrSRegOrIntConstOf<Type intLit, Type intConst> : AnyOperandOf<[SGPROf<1>, VCCLoType, VCCHiType, M0Type, EXECLoType, EXECHiType, VCCZType, EXECZType, SCCType, intLit, intConst]>;
+class OneSGPROrSRegOrIntConstOf<Type intLit, Type intConst> : AnyOperandOf<[SGPROf<1>, VCCLoType, VCCHiType, M0Type, EXECLoType, EXECHiType, VCCZType, EXECZType, SCCType, TTMPType, intLit, intConst]>;
 class OneSGPROrSRegOrLitConstOf<Type floatLit, Type intLit, Type fpConst, Type intConst> : AnyOperandOf<[SGPROf<1>, VCCLoType, VCCHiType, M0Type, EXECLoType, EXECHiType, VCCZType, EXECZType, SCCType, floatLit, intLit, fpConst, intConst]>;
 class TwoGPROrSRegOrConstOf<Type litType, Type intConst> : AnyOperandOf<[VGPROf<2>, SGPROf<2>, VCCType, EXECType, VCCZType, EXECZType, SCCType, litType, intConst]>;
 class TwoGPROrVCCOrFPLitOf<Type floatLit> : AnyOperandOf<[VGPROf<2>, SGPROf<2>, VCCType, VCCZType, EXECZType, SCCType, floatLit]>;

--- a/include/aster/Dialect/AMDGCN/IR/AMDGCNTypes.td
+++ b/include/aster/Dialect/AMDGCN/IR/AMDGCNTypes.td
@@ -305,6 +305,15 @@ def SCCType : SRegTypeBase<"SCC", "scc"> {
   }];
 }
 
+// TTMP (trap-temporary) registers, special non-allocatable registers.
+// Supports cluster_id ops on gfx1250+.
+def TTMPType : GPRegTypeBase<"TTMP", "ttmp"> {
+  let summary = "TTMP trap-temporary register type";
+  let extraClassDeclaration = [{
+    static constexpr RegisterKind kRegisterKind = RegisterKind::TTMP;
+  }];
+}
+
 //===----------------------------------------------------------------------===//
 // Misc types
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/AMDGCN/IR/AMDGCN.cpp
+++ b/lib/Dialect/AMDGCN/IR/AMDGCN.cpp
@@ -971,6 +971,20 @@ ArrayRef<ISAVersion> WaitGfx1250Op::getCompatibleISAVersions() {
   return versions;
 }
 
+// Workgroup-cluster ops gfx1250 only for now.
+static ArrayRef<ISAVersion> clusterOpsISAVersions() {
+  static ISAVersion versions[] = {ISAVersion::GFX12_50};
+  return versions;
+}
+ArrayRef<ISAVersion> ClusterIdOp::getCompatibleISAVersions() {
+  return clusterOpsISAVersions();
+}
+ArrayRef<ISAVersion> ClusterWorkgroupIdOp::getCompatibleISAVersions() {
+  return clusterOpsISAVersions();
+}
+ArrayRef<ISAVersion> ClusterWorkgroupMaxIdOp::getCompatibleISAVersions() {
+  return clusterOpsISAVersions();
+}
 /// Merge contiguous wait_gfx1250 ops into one and canonicalize its operands.
 static LogicalResult canonicalizeWaitGfx1250Impl(WaitGfx1250Op waitOp,
                                                  RewriterBase &rewriter,

--- a/lib/Dialect/AMDGCN/IR/AMDGCNTypes.cpp
+++ b/lib/Dialect/AMDGCN/IR/AMDGCNTypes.cpp
@@ -231,6 +231,18 @@ LogicalResult VGPRType::verify(function_ref<InFlightDiagnostic()> emitError,
 Resource *VGPRType::getResource() const { return VGPRResource::get(); }
 
 //===----------------------------------------------------------------------===//
+// TTMP types
+//===----------------------------------------------------------------------===//
+
+LogicalResult TTMPType::verify(function_ref<InFlightDiagnostic()> emitError,
+                               RegisterRange range) {
+  return verifyRegisterRange(emitError, range, "TTMP");
+}
+
+// TTMP is not an allocatable GP resource; report the special-register resource.
+Resource *TTMPType::getResource() const { return SREGResource::get(); }
+
+//===----------------------------------------------------------------------===//
 // GPRegTrait interface method definitions
 //===----------------------------------------------------------------------===//
 
@@ -249,6 +261,7 @@ Resource *VGPRType::getResource() const { return VGPRResource::get(); }
 GP_REG_COMPOSITE_SPLIT(AGPRType)
 GP_REG_COMPOSITE_SPLIT(SGPRType)
 GP_REG_COMPOSITE_SPLIT(VGPRType)
+GP_REG_COMPOSITE_SPLIT(TTMPType)
 
 #undef GP_REG_COMPOSITE_SPLIT
 

--- a/lib/Dialect/AMDGCN/Transforms/ExpandMetadataOps.cpp
+++ b/lib/Dialect/AMDGCN/Transforms/ExpandMetadataOps.cpp
@@ -252,6 +252,70 @@ static void handleBlockId(RewriterBase &rewriter, KernelOp op,
   }
 }
 
+/// Field descriptor for a TTMP-backed cluster id read, lower to s_bfe_u32.
+struct ClusterField {
+  int16_t ttmpIdx;
+  uint32_t offset;
+  uint32_t width;
+};
+
+/// s_bfe_u32 control immediate:
+///   - bits [4:0] offset in ttmp register
+///   - bits [22:16] width in ttmp register.
+static uint32_t bfeU32Imm(uint32_t offset, uint32_t width) {
+  assert(offset < 32 && "offset must be less than 32");
+  assert(width <= 32 && "width must be less than or equal to 32");
+  return offset | (width << 16);
+}
+
+/// Lower a single TTMP-backed cluster identity op via s_bfe_u32.
+static void lowerClusterField(RewriterBase &rewriter, Operation *op,
+                              const ClusterField &field) {
+  rewriter.setInsertionPoint(op);
+  Location loc = op->getLoc();
+  Value ttmpSrc = createAllocation(
+      rewriter, loc,
+      TTMPType::get(rewriter.getContext(), Register(field.ttmpIdx)));
+  Value dst = createAllocation(
+      rewriter, loc, SGPRType::get(rewriter.getContext(), Register()));
+  Value ctrl = arith::ConstantIntOp::create(
+      rewriter, loc, bfeU32Imm(field.offset, field.width), 32);
+  Value id = createSOP2Out2In2<SBfeU32>(rewriter, loc, dst, ttmpSrc, ctrl);
+  assert(llvm::none_of(op->getUses(),
+                       [](OpOperand &use) {
+                         return isa<BranchOpInterface>(use.getOwner());
+                       }) &&
+         "NYI: cluster id op should not be carried through a branch");
+  rewriter.replaceOp(op, id);
+}
+
+/// Handle cluster id ops backed by TTMP registers, gfx1250 kernel ABI imposes:
+///   - cluster_id:               x / y / z ->  t9[31:0] /  t7[15:0] / t7[31:16]
+///   - cluster_workgroup_id:     x / y / z ->   t6[3:0] /   t6[7:4] /  t6[11:8]
+///   - cluster_workgroup_max_id: x / y / z -> t6[15:12] / t6[19:16] / t6[23:20]
+static void handleClusterId(RewriterBase &rewriter,
+                            ArrayRef<ClusterIdOp> clusterIds,
+                            ArrayRef<ClusterWorkgroupIdOp> wgIds,
+                            ArrayRef<ClusterWorkgroupMaxIdOp> wgMaxIds) {
+  for (ClusterIdOp op : clusterIds) {
+    int32_t dim = static_cast<int32_t>(op.getDim());
+    ClusterField field = (dim == 0)   ? ClusterField{9, 0, 32}
+                         : (dim == 1) ? ClusterField{7, 0, 16}
+                                      : ClusterField{7, 16, 16};
+    lowerClusterField(rewriter, op, field);
+  }
+  for (ClusterWorkgroupIdOp op : wgIds) {
+    int32_t dim = static_cast<int32_t>(op.getDim());
+    lowerClusterField(rewriter, op,
+                      ClusterField{6, static_cast<uint32_t>(dim) * 4, 4});
+  }
+  for (ClusterWorkgroupMaxIdOp op : wgMaxIds) {
+    int32_t dim = static_cast<int32_t>(op.getDim());
+    lowerClusterField(rewriter, op,
+                      ClusterField{6, 12 + static_cast<uint32_t>(dim) * 4, 4});
+  }
+}
+
 /// Handle MakeBufferRsrcOps in a kernel.
 /// Expands make_buffer_rsrc into split + s_mov/s_or (for dword 1 upper bits
 /// and dword 3 flags) + make_register_range.
@@ -518,6 +582,9 @@ void ExpandMetadataOps::runOnOperation() {
   SmallVector<BlockIdOp> blockIds;
   SmallVector<GridDimOp> gridDims;
   SmallVector<MakeBufferRsrcOp> makeBufferRsrcs;
+  SmallVector<ClusterIdOp> clusterIds;
+  SmallVector<ClusterWorkgroupIdOp> clusterWgIds;
+  SmallVector<ClusterWorkgroupMaxIdOp> clusterWgMaxIds;
   std::array<bool, 3> threadIdSeen = {false, false, false};
   std::array<bool, 3> blockIdSeen = {false, false, false};
   std::array<bool, 3> blockDimSeen = {false, false, false};
@@ -543,6 +610,12 @@ void ExpandMetadataOps::runOnOperation() {
       gridDimSeen[dim] = true;
     } else if (auto makeRsrc = dyn_cast<MakeBufferRsrcOp>(op)) {
       makeBufferRsrcs.push_back(makeRsrc);
+    } else if (auto clusterId = dyn_cast<ClusterIdOp>(op)) {
+      clusterIds.push_back(clusterId);
+    } else if (auto wgId = dyn_cast<ClusterWorkgroupIdOp>(op)) {
+      clusterWgIds.push_back(wgId);
+    } else if (auto wgMaxId = dyn_cast<ClusterWorkgroupMaxIdOp>(op)) {
+      clusterWgMaxIds.push_back(wgMaxId);
     }
   });
 
@@ -593,6 +666,9 @@ void ExpandMetadataOps::runOnOperation() {
   handleThreadId(rewriter, op, threadIds, threadIdSeen, packedTID);
 
   handleMakeBufferRsrc(rewriter, makeBufferRsrcs);
+
+  // Cluster id ops expand to architected TTMP reads.
+  handleClusterId(rewriter, clusterIds, clusterWgIds, clusterWgMaxIds);
 
   // Note: we do NOT set #amdgcn.no_metadata_ops here because the pipeline
   // may run expand-md-ops multiple times with aster-codegen in between

--- a/lib/Target/ASM/AsmPrinter.cpp
+++ b/lib/Target/ASM/AsmPrinter.cpp
@@ -76,6 +76,9 @@ static void printRegister(llvm::raw_ostream &os,
   case RegisterKind::SCC:
     os << " scc";
     return;
+  case RegisterKind::TTMP:
+    os << " ttmp" << range.begin().getRegister();
+    return;
   default:
     llvm_unreachable("nyi register kind");
   }

--- a/lib/Target/ASM/TranslateModule.cpp
+++ b/lib/Target/ASM/TranslateModule.cpp
@@ -149,9 +149,10 @@ struct YAMLList {
                        ArrayRef<int32_t> defaultValue) {
     if (value == defaultValue)
       return;
-    emit() << key << ": ";
+    // HSA metadata array values are YAML flow sequences, e.g. [ 2, 2, 1 ].
+    emit() << key << ": [ ";
     llvm::interleaveComma(value, os);
-    os << "\n";
+    os << " ]\n";
   }
   void printField(StringRef key, int32_t value, int32_t defaultValue) {
     if (value == defaultValue)
@@ -210,6 +211,7 @@ void RegisterUsage::updateRegisters(AMDGCNRegisterTypeInterface ty,
   case RegisterKind::EXECZ:
   case RegisterKind::M0:
   case RegisterKind::SCC:
+  case RegisterKind::TTMP:
     return;
   default:
     llvm_unreachable("nyi register kind");
@@ -523,6 +525,7 @@ LogicalResult TranslateModuleImpl::emitKernelMetadata(KernelOp kernel,
       emitKernelArgument(arg, argInfo.offsets[i]);
   }
 
+  yOs.printArrayField(".cluster_dims", kernel.getClusterDims(), {0, 0, 0});
   yOs.printField(".group_segment_fixed_size", kernel.getSharedMemorySize());
   yOs.printField(".kernarg_segment_align", argInfo.maxAlignment);
   yOs.printField(".kernarg_segment_size", argInfo.size);

--- a/python/aster/test_pass_pipelines.py
+++ b/python/aster/test_pass_pipelines.py
@@ -57,6 +57,19 @@ TEST_LOWER_WAITS_MINIMAL_PASS_PIPELINE = builtin_module(
     phase_nop_insertion(delays=0),
 )
 
+# Pipeline matching test/Target/ASM/gfx1250-cluster-id-asm.mlir lit RUN lines.
+TEST_GFX1250_CLUSTER_ASM_PASS_PIPELINE = builtin_module(
+    amdgcn_module(
+        amdgcn_kernel(
+            "aster-amdgcn-expand-md-ops",
+            "aster-amdgcn-bufferization",
+            "amdgcn-to-register-semantics",
+        ),
+    ),
+    PHASE_AMDGCN_BACKEND,
+    phase_nop_insertion(delays=0),
+)
+
 # --------------------------------------------------------------------------- #
 # SROA test pipeline (non-pipelined, scheduling-based)
 # --------------------------------------------------------------------------- #

--- a/test/Dialect/AMDGCN/IR/module-isa-compat-invalid.mlir
+++ b/test/Dialect/AMDGCN/IR/module-isa-compat-invalid.mlir
@@ -39,3 +39,23 @@ amdgcn.module @cdna4_new_wait target = #amdgcn.target<gfx950> {
     return
   }
 }
+
+// -----
+
+amdgcn.module @cdna3_cluster_id target = #amdgcn.target<gfx942> {
+  func.func @f() {
+    // expected-error @below {{'amdgcn.cluster_id' op is not compatible with module target gfx942}}
+    %0 = amdgcn.cluster_id x : !amdgcn.sgpr
+    return
+  }
+}
+
+// -----
+
+amdgcn.module @cdna4_cluster_id target = #amdgcn.target<gfx950> {
+  func.func @f() {
+    // expected-error @below {{'amdgcn.cluster_id' op is not compatible with module target gfx950}}
+    %0 = amdgcn.cluster_id x : !amdgcn.sgpr
+    return
+  }
+}

--- a/test/Dialect/AMDGCN/Transforms/expand-cluster-id.mlir
+++ b/test/Dialect/AMDGCN/Transforms/expand-cluster-id.mlir
@@ -1,0 +1,41 @@
+// RUN: aster-opt %s --pass-pipeline="builtin.module(amdgcn.module(amdgcn.kernel(aster-amdgcn-expand-md-ops)))" | FileCheck %s
+
+// cluster_id x/y/z -> ttmp9 full (ctrl 0x200000), ttmp7 [15:0] (0x100000),
+// ttmp7 [31:16] (0x100010).
+// CHECK-LABEL: kernel @cluster_id
+//       CHECK:   arith.constant 2097152 : i32
+//       CHECK:   s_bfe_u32{{.*}}ins(!amdgcn.ttmp<9>, i32)
+//       CHECK:   arith.constant 1048576 : i32
+//       CHECK:   s_bfe_u32{{.*}}ins(!amdgcn.ttmp<7>, i32)
+//       CHECK:   arith.constant 1048592 : i32
+//       CHECK:   s_bfe_u32{{.*}}ins(!amdgcn.ttmp<7>, i32)
+amdgcn.module @m_cid target = #amdgcn.target<gfx1250> {
+  amdgcn.kernel @cluster_id {
+    %x = amdgcn.cluster_id x : !amdgcn.sgpr
+    %y = amdgcn.cluster_id y : !amdgcn.sgpr
+    %z = amdgcn.cluster_id z : !amdgcn.sgpr
+    amdgcn.end_kernel
+  }
+}
+
+// cluster_workgroup_id x -> ttmp6 [3:0] (ctrl 0x40000).
+// CHECK-LABEL: kernel @cluster_wg_id
+//       CHECK:   arith.constant 262144 : i32
+//       CHECK:   s_bfe_u32{{.*}}ins(!amdgcn.ttmp<6>, i32)
+amdgcn.module @m_wgid target = #amdgcn.target<gfx1250> {
+  amdgcn.kernel @cluster_wg_id {
+    %x = amdgcn.cluster_workgroup_id x : !amdgcn.sgpr
+    amdgcn.end_kernel
+  }
+}
+
+// cluster_workgroup_max_id x -> ttmp6 [15:12] (ctrl 0x4000c).
+// CHECK-LABEL: kernel @cluster_wg_max_id
+//       CHECK:   arith.constant 262156 : i32
+//       CHECK:   s_bfe_u32{{.*}}ins(!amdgcn.ttmp<6>, i32)
+amdgcn.module @m_maxid target = #amdgcn.target<gfx1250> {
+  amdgcn.kernel @cluster_wg_max_id {
+    %x = amdgcn.cluster_workgroup_max_id x : !amdgcn.sgpr
+    amdgcn.end_kernel
+  }
+}

--- a/test/Dialect/AMDGCN/gfx1250-ops.mlir
+++ b/test/Dialect/AMDGCN/gfx1250-ops.mlir
@@ -59,6 +59,35 @@ func.func @test_s_wait_counters() {
   return
 }
 
+//===----------------------------------------------------------------------===//
+// Workgroup-cluster id ops (cluster_id, cluster_workgroup_*)
+//===----------------------------------------------------------------------===//
+
+func.func @test_cluster_id_dims() -> !amdgcn.sgpr {
+  %x = amdgcn.cluster_id x : !amdgcn.sgpr
+  %y = amdgcn.cluster_id y : !amdgcn.sgpr
+  %z = amdgcn.cluster_id z : !amdgcn.sgpr
+  return %x : !amdgcn.sgpr
+}
+
+func.func @test_cluster_workgroup_id_dims() -> !amdgcn.sgpr {
+  %x = amdgcn.cluster_workgroup_id x : !amdgcn.sgpr
+  %y = amdgcn.cluster_workgroup_id y : !amdgcn.sgpr
+  %z = amdgcn.cluster_workgroup_id z : !amdgcn.sgpr
+  return %x : !amdgcn.sgpr
+}
+
+func.func @test_cluster_workgroup_max_id_dims() -> !amdgcn.sgpr {
+  %x = amdgcn.cluster_workgroup_max_id x : !amdgcn.sgpr
+  %y = amdgcn.cluster_workgroup_max_id y : !amdgcn.sgpr
+  %z = amdgcn.cluster_workgroup_max_id z : !amdgcn.sgpr
+  return %x : !amdgcn.sgpr
+}
+
+//===----------------------------------------------------------------------===//
+// gfx1250 split wait op (amdgcn.wait_gfx1250; disjoint from the CDNA amdgcn.wait)
+//===----------------------------------------------------------------------===//
+
 func.func @test_s_wait_fused_counters() {
   amdgcn.s_wait_loadcnt_dscnt 259
   amdgcn.s_wait_storecnt_dscnt 0
@@ -77,10 +106,6 @@ func.func @test_s_barrier_gfx1250() {
   amdgcn.s_barrier_wait -1
   return
 }
-
-//===----------------------------------------------------------------------===//
-// gfx1250 split wait op (amdgcn.wait_gfx1250; disjoint from the CDNA amdgcn.wait)
-//===----------------------------------------------------------------------===//
 
 func.func @test_wait_gfx1250_explicit() {
   amdgcn.wait_gfx1250 load_cnt 1 store_cnt 2 ds_cnt 3 km_cnt 4 tensor_cnt 5

--- a/test/Target/ASM/gfx1250-cluster-dims-asm.mlir
+++ b/test/Target/ASM/gfx1250-cluster-dims-asm.mlir
@@ -1,0 +1,19 @@
+// RUN: aster-translate %s --mlir-to-asm | FileCheck %s
+
+// .cluster_dims kernel metadata is emitted when the cluster_dims attribute is
+// set, and omitted when it defaults to {0,0,0}.
+
+// CHECK-LABEL: amdhsa.kernels:
+//      CHECK: .cluster_dims: [ 2, 2, 1 ]
+//      CHECK: .name: with_clusters
+//  CHECK-NOT: .cluster_dims
+//      CHECK: .name: without_clusters
+
+amdgcn.module @cluster_dims_mod target = #amdgcn.target<gfx1250> {
+  amdgcn.kernel @with_clusters attributes {cluster_dims = array<i32: 2, 2, 1>} {
+    amdgcn.end_kernel
+  }
+  amdgcn.kernel @without_clusters {
+    amdgcn.end_kernel
+  }
+}

--- a/test/Target/ASM/gfx1250-cluster-id-asm.mlir
+++ b/test/Target/ASM/gfx1250-cluster-id-asm.mlir
@@ -1,0 +1,35 @@
+// RUN: aster-opt %s \
+// RUN:   --pass-pipeline='builtin.module(amdgcn.module(amdgcn.kernel( \
+// RUN:     aster-amdgcn-expand-md-ops, \
+// RUN:     aster-amdgcn-bufferization, \
+// RUN:     amdgcn-to-register-semantics)), \
+// RUN:   amdgcn-backend, \
+// RUN:   amdgcn-remove-test-inst, \
+// RUN:   amdgcn-hazards{v_nops=0 s_nops=0})' \
+// RUN: | aster-translate --mlir-to-asm | FileCheck %s
+//
+// RUN: aster-opt %s \
+// RUN:   --pass-pipeline='builtin.module(amdgcn.module(amdgcn.kernel( \
+// RUN:     aster-amdgcn-expand-md-ops, \
+// RUN:     aster-amdgcn-bufferization, \
+// RUN:     amdgcn-to-register-semantics)), \
+// RUN:   amdgcn-backend, \
+// RUN:   amdgcn-remove-test-inst, \
+// RUN:   amdgcn-hazards{v_nops=0 s_nops=0})' \
+// RUN: | aster-translate --mlir-to-asm \
+// RUN:   | llvm-mc -triple=amdgcn-amd-amdhsa -mcpu=gfx1250 -mattr=+wavefrontsize32 -filetype=obj -o %t.o
+
+// CHECK-LABEL: cluster_ids:
+//  CHECK: s_bfe_u32 s0, ttmp9, 2097152
+//  CHECK: s_bfe_u32 s1, ttmp6, 262144
+//  CHECK: s_bfe_u32 s2, ttmp6, 262156
+//  CHECK: s_endpgm
+amdgcn.module @m target = #amdgcn.target<gfx1250> {
+  amdgcn.kernel @cluster_ids {
+    %cx = amdgcn.cluster_id x : !amdgcn.sgpr
+    %wx = amdgcn.cluster_workgroup_id x : !amdgcn.sgpr
+    %mx = amdgcn.cluster_workgroup_max_id x : !amdgcn.sgpr
+    amdgcn.test_inst ins %cx, %wx, %mx : (!amdgcn.sgpr, !amdgcn.sgpr, !amdgcn.sgpr) -> ()
+    amdgcn.end_kernel
+  }
+}

--- a/test/integration/test_gfx1250_cluster_e2e.py
+++ b/test/integration/test_gfx1250_cluster_e2e.py
@@ -1,0 +1,23 @@
+import pytest
+
+from aster.execution.helpers import compile_and_run
+from aster.test_pass_pipelines import TEST_GFX1250_CLUSTER_ASM_PASS_PIPELINE
+
+
+@pytest.mark.parametrize("target", ["gfx1250", "gfx1251"])
+def test_gfx1250_cluster_e2e(target):
+    def preprocess(x):
+        return x.replace("<gfx1250>", f"<{target}>")
+
+    compile_and_run(
+        "../Target/ASM/gfx1250-cluster-id-asm.mlir",
+        "cluster_ids",
+        pass_pipeline=TEST_GFX1250_CLUSTER_ASM_PASS_PIPELINE,
+        mcpu=target,
+        preprocess=preprocess,
+        library_paths=[],
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])


### PR DESCRIPTION
Handle cluster id ops backed by TTMP registers, gfx1250 kernel ABI imposes:
  - cluster_id:               x / y / z ->  t9[31:0] /  t7[15:0] / t7[31:16]
  - cluster_workgroup_id:     x / y / z ->   t6[3:0] /   t6[7:4] /  t6[11:8]
  - cluster_workgroup_max_id: x / y / z -> t6[15:12] / t6[19:16] / t6[23:20]