### PR TITLE
Add a fence_token type and a relaxed cross_wave_token_barrier op

### DIFF
--- a/contrib/kittens/test/bench/bench_harness.py
+++ b/contrib/kittens/test/bench/bench_harness.py
@@ -1675,7 +1675,7 @@ def print_config(cfg, resources=None, iterations=None):
     print(f"  unroll:     {lcm}, multiplier={cfg.unroll_factor_multiplier}, {epeel}")
     sched = []
     if cfg.ll_sched:
-        sched.append("ll-sched")
+        sched.append(f"ll-sched={cfg.ll_sched}")
     if cfg.hoist_wait:
         sched.append("hoist-wait")
     if cfg.num_wg_per_cu > 1:

--- a/contrib/kittens/test/bench/bench_perf_001_gemm_fp16_weak_scaled.py
+++ b/contrib/kittens/test/bench/bench_perf_001_gemm_fp16_weak_scaled.py
@@ -82,7 +82,7 @@ def make_tiered_schedule(max_configs: int, random_seed: int, constraints: tuple[
                 occ=[1, 2, 3],
                 ps=[1, 2, 3, 4, 5],
                 unroll_factor_multiplier=[1, 2, 3],
-                ll_sched=[True, False],
+                ll_sched=[0, 1, 2, 3, 4, 5],
                 rotate_compute_stage=[True, False],
                 hoist_wait=[True, False],
                 variant=[
@@ -99,12 +99,12 @@ def make_tiered_schedule(max_configs: int, random_seed: int, constraints: tuple[
             random_seed=random_seed,
             constraints=constraints,
             axis_grid=dict(
-                ll_sched=[True, False],
+                ll_sched=[0, 1, 2, 3, 4, 5],
                 rotate_compute_stage=[True, False],
                 hoist_wait=[True, False],
                 epilogue_peeling=[True, False],
             ),
-            anchor_axes=dict(ll_sched=True, rotate_compute_stage=True),
+            anchor_axes=dict(ll_sched=1, rotate_compute_stage=True),
             discriminator=("hoist_wait", "ll_sched", "rotate_compute_stage"),
         ),
         TierSpec(
@@ -113,12 +113,12 @@ def make_tiered_schedule(max_configs: int, random_seed: int, constraints: tuple[
             random_seed=random_seed,
             constraints=constraints,
             axis_grid=dict(
-                ll_sched=[True, False],
+                ll_sched=[0, 1, 2, 3, 4, 5],
                 rotate_compute_stage=[True, False],
                 hoist_wait=[True, False],
                 epilogue_peeling=[True, False],
             ),
-            anchor_axes=dict(ll_sched=True, rotate_compute_stage=True),
+            anchor_axes=dict(ll_sched=1, rotate_compute_stage=True),
             neighbor_radius=dict(
                 wg_m=1,
                 wg_n=1,

--- a/contrib/kittens/test/bench/bench_perf_102_gemm_python_multitile_directb_cdna3.py
+++ b/contrib/kittens/test/bench/bench_perf_102_gemm_python_multitile_directb_cdna3.py
@@ -86,7 +86,7 @@ def make_tiered_schedule(max_configs: int, random_seed: int, constraints: tuple[
                 occ=[1, 2],
                 ps=[1, 3, 5],
                 unroll_factor_multiplier=[1, 3],
-                ll_sched=[True],
+                ll_sched=[1],
                 rotate_compute_stage=[True],
                 hoist_wait=[False],
             ),
@@ -98,12 +98,12 @@ def make_tiered_schedule(max_configs: int, random_seed: int, constraints: tuple[
             random_seed=random_seed,
             constraints=constraints,
             axis_grid=dict(
-                ll_sched=[True, False],
+                ll_sched=[0, 1, 2, 3, 4, 5],
                 rotate_compute_stage=[True, False],
                 hoist_wait=[True, False],
                 epilogue_peeling=[True, False],
             ),
-            anchor_axes=dict(ll_sched=True, rotate_compute_stage=True),
+            anchor_axes=dict(ll_sched=1, rotate_compute_stage=True),
             discriminator=("hoist_wait", "ll_sched", "rotate_compute_stage"),
         ),
         TierSpec(
@@ -114,12 +114,12 @@ def make_tiered_schedule(max_configs: int, random_seed: int, constraints: tuple[
             axis_grid=dict(
                 ps=[1, 2, 3, 4, 5, 6, 7, 8],
                 unroll_factor_multiplier=[1, 2, 3, 4, 5],
-                ll_sched=[True, False],
+                ll_sched=[0, 1, 2, 3, 4, 5],
                 rotate_compute_stage=[True, False],
                 hoist_wait=[True, False],
                 epilogue_peeling=[True, False],
             ),
-            anchor_axes=dict(ll_sched=True, rotate_compute_stage=True),
+            anchor_axes=dict(ll_sched=1, rotate_compute_stage=True),
             discriminator=("ps", "unroll_factor_multiplier", "hoist_wait"),
         ),
     ]

--- a/contrib/kittens/test/bench/bench_perf_102_gemm_python_multitile_g2s_directb_cdna4.py
+++ b/contrib/kittens/test/bench/bench_perf_102_gemm_python_multitile_g2s_directb_cdna4.py
@@ -81,7 +81,7 @@ def make_tiered_schedule(max_configs: int, random_seed: int, constraints: tuple[
                 occ=[1, 2],
                 ps=[1, 3, 5, 11, 13],
                 unroll_factor_multiplier=[1, 3],
-                ll_sched=[True],
+                ll_sched=[1],
                 rotate_compute_stage=[True],
                 hoist_wait=[False],
             ),
@@ -93,12 +93,12 @@ def make_tiered_schedule(max_configs: int, random_seed: int, constraints: tuple[
             random_seed=random_seed,
             constraints=constraints,
             axis_grid=dict(
-                ll_sched=[True, False],
+                ll_sched=[0, 1, 2, 3, 4, 5],
                 rotate_compute_stage=[True, False],
                 hoist_wait=[True, False],
                 epilogue_peeling=[True, False],
             ),
-            anchor_axes=dict(ll_sched=True, rotate_compute_stage=True),
+            anchor_axes=dict(ll_sched=1, rotate_compute_stage=True),
             discriminator=("hoist_wait", "ll_sched", "rotate_compute_stage"),
         ),
         TierSpec(
@@ -107,12 +107,12 @@ def make_tiered_schedule(max_configs: int, random_seed: int, constraints: tuple[
             random_seed=random_seed,
             constraints=constraints,
             axis_grid=dict(
-                ll_sched=[True, False],
+                ll_sched=[0, 1, 2, 3, 4, 5],
                 rotate_compute_stage=[True, False],
                 hoist_wait=[True, False],
                 epilogue_peeling=[True, False],
             ),
-            anchor_axes=dict(ll_sched=True, rotate_compute_stage=True),
+            anchor_axes=dict(ll_sched=1, rotate_compute_stage=True),
             neighbor_radius=dict(
                 wg_m=1,
                 wg_n=1,

--- a/contrib/kittens/test/bench/bench_perf_102_gemm_python_multitile_g2s_lds_cdna4.py
+++ b/contrib/kittens/test/bench/bench_perf_102_gemm_python_multitile_g2s_lds_cdna4.py
@@ -81,7 +81,7 @@ def make_tiered_schedule(max_configs: int, random_seed: int, constraints: tuple[
                 occ=[1, 2],
                 ps=[1, 3, 5, 11, 13],
                 unroll_factor_multiplier=[1, 3],
-                ll_sched=[True],
+                ll_sched=[1],
                 rotate_compute_stage=[True],
                 hoist_wait=[False],
             ),
@@ -93,12 +93,12 @@ def make_tiered_schedule(max_configs: int, random_seed: int, constraints: tuple[
             random_seed=random_seed,
             constraints=constraints,
             axis_grid=dict(
-                ll_sched=[True, False],
+                ll_sched=[0, 1, 2, 3, 4, 5],
                 rotate_compute_stage=[True, False],
                 hoist_wait=[True, False],
                 epilogue_peeling=[True, False],
             ),
-            anchor_axes=dict(ll_sched=True, rotate_compute_stage=True),
+            anchor_axes=dict(ll_sched=1, rotate_compute_stage=True),
             discriminator=("hoist_wait", "ll_sched", "rotate_compute_stage"),
         ),
         TierSpec(
@@ -107,12 +107,12 @@ def make_tiered_schedule(max_configs: int, random_seed: int, constraints: tuple[
             random_seed=random_seed,
             constraints=constraints,
             axis_grid=dict(
-                ll_sched=[True, False],
+                ll_sched=[0, 1, 2, 3, 4, 5],
                 rotate_compute_stage=[True, False],
                 hoist_wait=[True, False],
                 epilogue_peeling=[True, False],
             ),
-            anchor_axes=dict(ll_sched=True, rotate_compute_stage=True),
+            anchor_axes=dict(ll_sched=1, rotate_compute_stage=True),
             neighbor_radius=dict(
                 wg_m=1,
                 wg_n=1,

--- a/contrib/kittens/test/bench/bench_perf_102_gemm_python_multitile_lds_cdna3.py
+++ b/contrib/kittens/test/bench/bench_perf_102_gemm_python_multitile_lds_cdna3.py
@@ -92,7 +92,7 @@ def make_tiered_schedule(max_configs: int, random_seed: int, constraints: tuple[
                 occ=[1, 2],
                 ps=[1, 3, 5],
                 unroll_factor_multiplier=[1, 3],
-                ll_sched=[True],
+                ll_sched=[1],
                 rotate_compute_stage=[True],
                 hoist_wait=[False],
             ),
@@ -104,12 +104,12 @@ def make_tiered_schedule(max_configs: int, random_seed: int, constraints: tuple[
             random_seed=random_seed,
             constraints=constraints,
             axis_grid=dict(
-                ll_sched=[True, False],
+                ll_sched=[0, 1, 2, 3, 4, 5],
                 rotate_compute_stage=[True, False],
                 hoist_wait=[True, False],
                 epilogue_peeling=[True, False],
             ),
-            anchor_axes=dict(ll_sched=True, rotate_compute_stage=True),
+            anchor_axes=dict(ll_sched=1, rotate_compute_stage=True),
             discriminator=("hoist_wait", "ll_sched", "rotate_compute_stage"),
         ),
         TierSpec(
@@ -120,12 +120,12 @@ def make_tiered_schedule(max_configs: int, random_seed: int, constraints: tuple[
             axis_grid=dict(
                 ps=[1, 2, 3, 4, 5, 6, 7, 8],
                 unroll_factor_multiplier=[1, 2, 3, 4, 5],
-                ll_sched=[True, False],
+                ll_sched=[0, 1, 2, 3, 4, 5],
                 rotate_compute_stage=[True, False],
                 hoist_wait=[True, False],
                 epilogue_peeling=[True, False],
             ),
-            anchor_axes=dict(ll_sched=True, rotate_compute_stage=True),
+            anchor_axes=dict(ll_sched=1, rotate_compute_stage=True),
             discriminator=("ps", "unroll_factor_multiplier", "hoist_wait"),
         ),
     ]

--- a/contrib/kittens/test/bench/bench_tier_driver.py
+++ b/contrib/kittens/test/bench/bench_tier_driver.py
@@ -314,7 +314,7 @@ def _format_axes(r: dict) -> str:
         f"twg={r.get('twg_m')}x{r.get('twg_n')}x{r.get('twg_k')} "
         f"w={r.get('waves_m')}x{r.get('waves_n')} "
         f"occ={r.get('occ')} ps={r.get('ps')} um={r.get('unroll_factor_multiplier')} "
-        f"hw={int(bool(r.get('hoist_wait')))} ll={int(bool(r.get('ll_sched')))} "
+        f"hw={int(bool(r.get('hoist_wait')))} ll={int(r.get('ll_sched') or 0)} "
         f"rotc={int(bool(r.get('rotate_compute_stage')))} "
         f"epeel={int(bool(r.get('epilogue_peeling')))}"
     )

--- a/contrib/kittens/test/gemm_16x32_f16_k_loop_helpers.mlir
+++ b/contrib/kittens/test/gemm_16x32_f16_k_loop_helpers.mlir
@@ -332,7 +332,7 @@
     %tok_count = memref.dim %tok_buf, %c0 : memref<?x!lds_write_token>
     scf.for %idx = %c0 to %tok_count step %c1 {
       %tok = memref.load %tok_buf[%idx] : memref<?x!lds_write_token>
-      amdgcn.wait deps %tok {sched.stage = {{A_STAGE_READ}} : i32} : !lds_write_token
+      %wf0 = amdgcn.wait deps %tok {sched.stage = {{A_STAGE_READ}} : i32} : !lds_write_token -> !amdgcn.fence_token
     } {aster.constexpr}
     return
   }

--- a/contrib/kittens/test/test_001_gemm_fp16_lds_1buf.mlir
+++ b/contrib/kittens/test/test_001_gemm_fp16_lds_1buf.mlir
@@ -92,10 +92,10 @@ amdgcn.module @kittens_gemm_16x16xK_lds_1buf target = #amdgcn.target<gfx942> {
           : (index, !future_global_read) -> (!lds_write_token, !lds_write_token)
 
       // === Step 3: Wait for all LDS writes ===
-      amdgcn.wait deps %tok_A0 : !lds_write_token
-      amdgcn.wait deps %tok_A1 : !lds_write_token
-      amdgcn.wait deps %tok_B0 : !lds_write_token
-      amdgcn.wait deps %tok_B1 : !lds_write_token
+      %wf0 = amdgcn.wait deps %tok_A0 : !lds_write_token -> !amdgcn.fence_token
+      %wf1 = amdgcn.wait deps %tok_A1 : !lds_write_token -> !amdgcn.fence_token
+      %wf2 = amdgcn.wait deps %tok_B0 : !lds_write_token -> !amdgcn.fence_token
+      %wf3 = amdgcn.wait deps %tok_B1 : !lds_write_token -> !amdgcn.fence_token
 
       // === Step 4: K0 sub-tile (byte offset 0 within LDS row) ===
       %A0_future = func.call @load_lds_A_swizzled(%lds_A, %c0, %c2) : (index, index, index) -> !future_lds_read

--- a/contrib/kittens/test/test_002_gemm_fp16_lds_2buf.mlir
+++ b/contrib/kittens/test/test_002_gemm_fp16_lds_2buf.mlir
@@ -85,10 +85,10 @@ amdgcn.module @kittens_gemm_16x16xK_lds_2buf target = #amdgcn.target<gfx942> {
         : (index, !future_global_read) -> (!lds_write_token, !lds_write_token)
     %pf_B0_t0, %pf_B0_t1 = func.call @store_global_tile_to_lds_16x64_b(%lds_B0, %pf_B0_gfut)
         : (index, !future_global_read) -> (!lds_write_token, !lds_write_token)
-    amdgcn.wait deps %pf_A0_t0 : !lds_write_token
-    amdgcn.wait deps %pf_A0_t1 : !lds_write_token
-    amdgcn.wait deps %pf_B0_t0 : !lds_write_token
-    amdgcn.wait deps %pf_B0_t1 : !lds_write_token
+    %wf0 = amdgcn.wait deps %pf_A0_t0 : !lds_write_token -> !amdgcn.fence_token
+    %wf1 = amdgcn.wait deps %pf_A0_t1 : !lds_write_token -> !amdgcn.fence_token
+    %wf2 = amdgcn.wait deps %pf_B0_t0 : !lds_write_token -> !amdgcn.fence_token
+    %wf3 = amdgcn.wait deps %pf_B0_t1 : !lds_write_token -> !amdgcn.fence_token
 
     // K-loop: double-buffered iteration over K dimension
     %C_final = scf.for %k = %c0 to %K_tiles step %c1 iter_args(%acc = %C_init) -> (!rt_C_f32) {
@@ -113,10 +113,10 @@ amdgcn.module @kittens_gemm_16x16xK_lds_2buf target = #amdgcn.target<gfx942> {
             : (index, !future_global_read) -> (!lds_write_token, !lds_write_token)
         %pf_Bt0, %pf_Bt1 = func.call @store_global_tile_to_lds_16x64_b(%lds_B_next, %pf_B_gfut)
             : (index, !future_global_read) -> (!lds_write_token, !lds_write_token)
-        amdgcn.wait deps %pf_At0 : !lds_write_token
-        amdgcn.wait deps %pf_At1 : !lds_write_token
-        amdgcn.wait deps %pf_Bt0 : !lds_write_token
-        amdgcn.wait deps %pf_Bt1 : !lds_write_token
+        %wf4 = amdgcn.wait deps %pf_At0 : !lds_write_token -> !amdgcn.fence_token
+        %wf5 = amdgcn.wait deps %pf_At1 : !lds_write_token -> !amdgcn.fence_token
+        %wf6 = amdgcn.wait deps %pf_Bt0 : !lds_write_token -> !amdgcn.fence_token
+        %wf7 = amdgcn.wait deps %pf_Bt1 : !lds_write_token -> !amdgcn.fence_token
       }
 
       // === K0 sub-tile (byte offset 0 within LDS row) ===

--- a/contrib/kittens/test/test_003_gemm_fp16_lds_3buf.mlir
+++ b/contrib/kittens/test/test_003_gemm_fp16_lds_3buf.mlir
@@ -91,10 +91,10 @@ amdgcn.module @kittens_gemm_16x16xK_lds_3buf target = #amdgcn.target<gfx942> {
         : (index, !future_global_read) -> (!lds_write_token, !lds_write_token)
     %pf0_Bt0, %pf0_Bt1 = func.call @store_global_tile_to_lds_16x64_b(%lds_B0, %pf0_B_gfut)
         : (index, !future_global_read) -> (!lds_write_token, !lds_write_token)
-    amdgcn.wait deps %pf0_At0 : !lds_write_token
-    amdgcn.wait deps %pf0_At1 : !lds_write_token
-    amdgcn.wait deps %pf0_Bt0 : !lds_write_token
-    amdgcn.wait deps %pf0_Bt1 : !lds_write_token
+    %wf0 = amdgcn.wait deps %pf0_At0 : !lds_write_token -> !amdgcn.fence_token
+    %wf1 = amdgcn.wait deps %pf0_At1 : !lds_write_token -> !amdgcn.fence_token
+    %wf2 = amdgcn.wait deps %pf0_Bt0 : !lds_write_token -> !amdgcn.fence_token
+    %wf3 = amdgcn.wait deps %pf0_Bt1 : !lds_write_token -> !amdgcn.fence_token
 
     // Prefetch iteration 1 into buffer 1 (if K_tiles > 1)
     %has_iter1 = arith.cmpi ugt, %K_tiles, %c1 : index
@@ -107,10 +107,10 @@ amdgcn.module @kittens_gemm_16x16xK_lds_3buf target = #amdgcn.target<gfx942> {
           : (index, !future_global_read) -> (!lds_write_token, !lds_write_token)
       %pf1_Bt0, %pf1_Bt1 = func.call @store_global_tile_to_lds_16x64_b(%lds_B1, %pf1_B_gfut)
           : (index, !future_global_read) -> (!lds_write_token, !lds_write_token)
-      amdgcn.wait deps %pf1_At0 : !lds_write_token
-      amdgcn.wait deps %pf1_At1 : !lds_write_token
-      amdgcn.wait deps %pf1_Bt0 : !lds_write_token
-      amdgcn.wait deps %pf1_Bt1 : !lds_write_token
+      %wf4 = amdgcn.wait deps %pf1_At0 : !lds_write_token -> !amdgcn.fence_token
+      %wf5 = amdgcn.wait deps %pf1_At1 : !lds_write_token -> !amdgcn.fence_token
+      %wf6 = amdgcn.wait deps %pf1_Bt0 : !lds_write_token -> !amdgcn.fence_token
+      %wf7 = amdgcn.wait deps %pf1_Bt1 : !lds_write_token -> !amdgcn.fence_token
     }
 
     // K-loop: triple-buffered iteration over K dimension
@@ -147,10 +147,10 @@ amdgcn.module @kittens_gemm_16x16xK_lds_3buf target = #amdgcn.target<gfx942> {
             : (index, !future_global_read) -> (!lds_write_token, !lds_write_token)
         %pf_Bt0, %pf_Bt1 = func.call @store_global_tile_to_lds_16x64_b(%pf_B, %pf_B_gfut)
             : (index, !future_global_read) -> (!lds_write_token, !lds_write_token)
-        amdgcn.wait deps %pf_At0 : !lds_write_token
-        amdgcn.wait deps %pf_At1 : !lds_write_token
-        amdgcn.wait deps %pf_Bt0 : !lds_write_token
-        amdgcn.wait deps %pf_Bt1 : !lds_write_token
+        %wf8 = amdgcn.wait deps %pf_At0 : !lds_write_token -> !amdgcn.fence_token
+        %wf9 = amdgcn.wait deps %pf_At1 : !lds_write_token -> !amdgcn.fence_token
+        %wf10 = amdgcn.wait deps %pf_Bt0 : !lds_write_token -> !amdgcn.fence_token
+        %wf11 = amdgcn.wait deps %pf_Bt1 : !lds_write_token -> !amdgcn.fence_token
       }
 
       // === K0 sub-tile (byte offset 0 within LDS row) ===

--- a/contrib/kittens/test/test_004_gemm_fp16_2wave_lds.mlir
+++ b/contrib/kittens/test/test_004_gemm_fp16_2wave_lds.mlir
@@ -108,10 +108,10 @@ amdgcn.module @kittens_gemm_2wave_lds target = #amdgcn.target<gfx942> {
           : (index, !future_global_read) -> (!lds_write_token, !lds_write_token)
 
       // === Step 3: Wait for LDS writes + cross-wave barrier ===
-      amdgcn.wait deps %tok_A0 : !lds_write_token
-      amdgcn.wait deps %tok_A1 : !lds_write_token
-      amdgcn.wait deps %tok_B0 : !lds_write_token
-      amdgcn.wait deps %tok_B1 : !lds_write_token
+      %wf0 = amdgcn.wait deps %tok_A0 : !lds_write_token -> !amdgcn.fence_token
+      %wf1 = amdgcn.wait deps %tok_A1 : !lds_write_token -> !amdgcn.fence_token
+      %wf2 = amdgcn.wait deps %tok_B0 : !lds_write_token -> !amdgcn.fence_token
+      %wf3 = amdgcn.wait deps %tok_B1 : !lds_write_token -> !amdgcn.fence_token
       amdgcn.s_barrier
 
       // === Step 4: K0 sub-tile (byte offset 0 within LDS row) ===

--- a/contrib/kittens/test/test_005_gemm_fp16_lds_pipelined.mlir
+++ b/contrib/kittens/test/test_005_gemm_fp16_lds_pipelined.mlir
@@ -102,10 +102,10 @@ amdgcn.module @kittens_gemm_16x16xK_lds_pipelined target = #amdgcn.target<gfx942
           : (index, !future_global_read) -> (!lds_write_token, !lds_write_token)
 
       // === Stage DS_READ: Wait for LDS writes + read K0/K1 sub-tiles ===
-      amdgcn.wait deps %tok_A0 {sched.stage = {{A_STAGE_READ}} : i32} : !lds_write_token
-      amdgcn.wait deps %tok_A1 {sched.stage = {{A_STAGE_READ}} : i32} : !lds_write_token
-      amdgcn.wait deps %tok_B0 {sched.stage = {{A_STAGE_READ}} : i32} : !lds_write_token
-      amdgcn.wait deps %tok_B1 {sched.stage = {{A_STAGE_READ}} : i32} : !lds_write_token
+      %wf0 = amdgcn.wait deps %tok_A0 {sched.stage = {{A_STAGE_READ}} : i32} : !lds_write_token -> !amdgcn.fence_token
+      %wf1 = amdgcn.wait deps %tok_A1 {sched.stage = {{A_STAGE_READ}} : i32} : !lds_write_token -> !amdgcn.fence_token
+      %wf2 = amdgcn.wait deps %tok_B0 {sched.stage = {{A_STAGE_READ}} : i32} : !lds_write_token -> !amdgcn.fence_token
+      %wf3 = amdgcn.wait deps %tok_B1 {sched.stage = {{A_STAGE_READ}} : i32} : !lds_write_token -> !amdgcn.fence_token
 
       // K0 sub-tile at byte offset 0 within LDS row
       %A0_fut = func.call @load_lds_A_swizzled(%lds_A, %c0, %c2)

--- a/contrib/kittens/test/test_006_gemm_fp16_multitile_lds_pipelined.mlir
+++ b/contrib/kittens/test/test_006_gemm_fp16_multitile_lds_pipelined.mlir
@@ -120,14 +120,14 @@ amdgcn.module @kittens_gemm_multitile_lds_pipelined target = #amdgcn.target<gfx9
           : (index, !future_global_read) -> (!lds_write_token, !lds_write_token)
 
       // === Stage DS_READ: Wait + read K0/K1 sub-tiles ===
-      amdgcn.wait deps %tA0_0 {sched.stage = {{A_STAGE_READ}} : i32} : !lds_write_token
-      amdgcn.wait deps %tA0_1 {sched.stage = {{A_STAGE_READ}} : i32} : !lds_write_token
-      amdgcn.wait deps %tA1_0 {sched.stage = {{A_STAGE_READ}} : i32} : !lds_write_token
-      amdgcn.wait deps %tA1_1 {sched.stage = {{A_STAGE_READ}} : i32} : !lds_write_token
-      amdgcn.wait deps %tB0_0 {sched.stage = {{A_STAGE_READ}} : i32} : !lds_write_token
-      amdgcn.wait deps %tB0_1 {sched.stage = {{A_STAGE_READ}} : i32} : !lds_write_token
-      amdgcn.wait deps %tB1_0 {sched.stage = {{A_STAGE_READ}} : i32} : !lds_write_token
-      amdgcn.wait deps %tB1_1 {sched.stage = {{A_STAGE_READ}} : i32} : !lds_write_token
+      %wf0 = amdgcn.wait deps %tA0_0 {sched.stage = {{A_STAGE_READ}} : i32} : !lds_write_token -> !amdgcn.fence_token
+      %wf1 = amdgcn.wait deps %tA0_1 {sched.stage = {{A_STAGE_READ}} : i32} : !lds_write_token -> !amdgcn.fence_token
+      %wf2 = amdgcn.wait deps %tA1_0 {sched.stage = {{A_STAGE_READ}} : i32} : !lds_write_token -> !amdgcn.fence_token
+      %wf3 = amdgcn.wait deps %tA1_1 {sched.stage = {{A_STAGE_READ}} : i32} : !lds_write_token -> !amdgcn.fence_token
+      %wf4 = amdgcn.wait deps %tB0_0 {sched.stage = {{A_STAGE_READ}} : i32} : !lds_write_token -> !amdgcn.fence_token
+      %wf5 = amdgcn.wait deps %tB0_1 {sched.stage = {{A_STAGE_READ}} : i32} : !lds_write_token -> !amdgcn.fence_token
+      %wf6 = amdgcn.wait deps %tB1_0 {sched.stage = {{A_STAGE_READ}} : i32} : !lds_write_token -> !amdgcn.fence_token
+      %wf7 = amdgcn.wait deps %tB1_1 {sched.stage = {{A_STAGE_READ}} : i32} : !lds_write_token -> !amdgcn.fence_token
 
       // K0 sub-tiles (byte offset 0 within LDS row)
       %A0_K0_fut = func.call @load_lds_A_swizzled(%lds_A0, %c0, %c2)

--- a/contrib/kittens/test/test_007_gemm_fp16_4wave_lds_pipelined.mlir
+++ b/contrib/kittens/test/test_007_gemm_fp16_4wave_lds_pipelined.mlir
@@ -112,10 +112,10 @@ amdgcn.module @kittens_gemm_4wave_lds_pipelined target = #amdgcn.target<gfx942> 
           : (index, !future_global_read) -> (!lds_write_token, !lds_write_token)
 
       // === Stage DS_READ: Wait + barrier + read K0/K1 ===
-      amdgcn.wait deps %tok_A0 {sched.stage = {{A_STAGE_READ}} : i32} : !lds_write_token
-      amdgcn.wait deps %tok_A1 {sched.stage = {{A_STAGE_READ}} : i32} : !lds_write_token
-      amdgcn.wait deps %tok_B0 {sched.stage = {{A_STAGE_READ}} : i32} : !lds_write_token
-      amdgcn.wait deps %tok_B1 {sched.stage = {{A_STAGE_READ}} : i32} : !lds_write_token
+      %wf0 = amdgcn.wait deps %tok_A0 {sched.stage = {{A_STAGE_READ}} : i32} : !lds_write_token -> !amdgcn.fence_token
+      %wf1 = amdgcn.wait deps %tok_A1 {sched.stage = {{A_STAGE_READ}} : i32} : !lds_write_token -> !amdgcn.fence_token
+      %wf2 = amdgcn.wait deps %tok_B0 {sched.stage = {{A_STAGE_READ}} : i32} : !lds_write_token -> !amdgcn.fence_token
+      %wf3 = amdgcn.wait deps %tok_B1 {sched.stage = {{A_STAGE_READ}} : i32} : !lds_write_token -> !amdgcn.fence_token
       amdgcn.s_barrier {sched.stage = {{A_STAGE_READ}} : i32}
 
       // K0 sub-tiles (byte offset 0 within LDS row)

--- a/contrib/kittens/test/test_101e_gemm_python_coopload.py
+++ b/contrib/kittens/test/test_101e_gemm_python_coopload.py
@@ -260,16 +260,16 @@ def _build_gemm_pipelined(num_workgroups, num_waves_per_wg, num_tiles_per_wg, K,
             b_write = b.transfer_tiles(sB_write, tc_dsw_b, unroll_axes=plan_b.unroll_axes, data=b_load)
 
         with b.stage(STG_A_READ):
-            b.wait_deps(a_write)
-            b.s_barrier()
+            wfence_a = b.wait_deps(a_write)
+            bfence_a = b.cross_wave_token_barrier(wfence_a)
             sA_read = b.slice(sA_full, {wave_m: wave_m_idx})
-            a_frags = b.transfer_tiles(sA_read, tc_dsr_a, unroll_axes=(m, k_tile))
+            a_frags = b.transfer_tiles(sA_read, tc_dsr_a, unroll_axes=(m, k_tile), fence_token=bfence_a)
 
         with b.stage(STG_B_READ):
-            b.wait_deps(b_write)
-            b.s_barrier()
+            wfence_b = b.wait_deps(b_write)
+            bfence_b = b.cross_wave_token_barrier(wfence_b)
             sB_read = b.slice(sB_full, {wave_n: wave_n_idx})
-            b_frags = b.transfer_tiles(sB_read, tc_dsr_b, unroll_axes=(n, k_tile))
+            b_frags = b.transfer_tiles(sB_read, tc_dsr_b, unroll_axes=(n, k_tile), fence_token=bfence_b)
 
         with b.stage(STG_COMPUTE):
             b.wait_deps(a_frags, b_frags)

--- a/contrib/kittens/test/test_101f_gemm_python_directb.py
+++ b/contrib/kittens/test/test_101f_gemm_python_directb.py
@@ -240,10 +240,10 @@ def _build_gemm_pipelined(num_workgroups, num_waves_per_wg, num_tiles_per_wg, K,
             a_write = b.transfer_tiles(sA_write, tc_dsw_a, unroll_axes=plan_a.unroll_axes, data=a_load)
 
         with b.stage(STG_A_READ):
-            b.wait_deps(a_write)
-            b.s_barrier()
+            wfence = b.wait_deps(a_write)
+            bfence = b.cross_wave_token_barrier(wfence)
             sA_read = b.slice(sA_full, {wave_m: wave_m_idx})
-            a_frags = b.transfer_tiles(sA_read, tc_dsr_a, unroll_axes=(m, k_tile))
+            a_frags = b.transfer_tiles(sA_read, tc_dsr_a, unroll_axes=(m, k_tile), fence_token=bfence)
 
         with b.stage(STG_COMPUTE):
             b.wait_deps(a_frags, b_vx4)

--- a/contrib/kittens/test/test_102_gemm_python_multitile_directb_cdna3.py
+++ b/contrib/kittens/test/test_102_gemm_python_multitile_directb_cdna3.py
@@ -279,9 +279,9 @@ def _build_multitile_gemm(cfg: "MultitileGemmInstance") -> ir.Module:
 
         with b.stage(STG_A_READ):
             b.wait_deps(a_write)
-            b.s_barrier()
+            bfence = b.cross_wave_token_barrier(a_write)
             sA_read = b.slice(sA_full, {wave_m: wave_m_idx})
-            a_frags = b.transfer_tiles(sA_read, tc_dsr_a, unroll_axes=(m, k_tile))
+            a_frags = b.transfer_tiles(sA_read, tc_dsr_a, unroll_axes=(m, k_tile), fence_token=bfence)
 
         with b.stage(STG_COMPUTE):
             b.wait_deps(a_frags, b_vx4)

--- a/contrib/kittens/test/test_102_gemm_python_multitile_directb_cdna3.py
+++ b/contrib/kittens/test/test_102_gemm_python_multitile_directb_cdna3.py
@@ -668,6 +668,20 @@ class TestPipelineDirectBLLSched:
         _run_multitile(cfg)
 
 
+class TestLLSched:
+    @pytest.mark.parametrize("ll_sched", [0, 1, 2, 3, 5], ids=lambda v: f"llsched{v}")
+    def test_correctness(self, ll_sched):
+        cfg = _make_instance(
+            [1, 1, 1],
+            [2, 2, 1],
+            [6, 4, 1],
+            k_mult=4,
+            pipeline_strategy=3,
+            ll_sched=ll_sched,
+        )
+        _run_multitile(cfg)
+
+
 # ---------------------------------------------------------------------------
 # Resource estimation accuracy tests
 # ---------------------------------------------------------------------------

--- a/contrib/kittens/test/test_102_gemm_python_multitile_directb_cdna4.py
+++ b/contrib/kittens/test/test_102_gemm_python_multitile_directb_cdna4.py
@@ -518,3 +518,18 @@ class TestCdna4Mfma:
             mcpu="gfx950",
         )
         _run_multitile(cfg)
+
+
+class TestLLSched:
+    @pytest.mark.parametrize("ll_sched", [0, 1, 2, 3, 5], ids=lambda v: f"llsched{v}")
+    def test_correctness(self, ll_sched):
+        cfg = _make_instance(
+            [1, 1, 1],
+            [2, 2, 1],
+            [6, 4, 1],
+            k_mult=4,
+            pipeline_strategy=3,
+            mcpu="gfx950",
+            ll_sched=ll_sched,
+        )
+        _run_multitile(cfg)

--- a/contrib/kittens/test/test_102_gemm_python_multitile_lds_cdna3.py
+++ b/contrib/kittens/test/test_102_gemm_python_multitile_lds_cdna3.py
@@ -634,6 +634,20 @@ class TestOperandPath:
         _run_multitile(cfg)
 
 
+class TestLLSched:
+    @pytest.mark.parametrize("ll_sched", [0, 1, 2, 3, 5], ids=lambda v: f"llsched{v}")
+    def test_correctness(self, ll_sched):
+        cfg = _make_instance(
+            [1, 1, 1],
+            [2, 2, 1],
+            [6, 4, 1],
+            k_mult=4,
+            pipeline_strategy=3,
+            ll_sched=ll_sched,
+        )
+        _run_multitile(cfg)
+
+
 # ---------------------------------------------------------------------------
 # Resource estimation accuracy tests
 # ---------------------------------------------------------------------------

--- a/contrib/kittens/test/test_102_gemm_python_multitile_lds_cdna4.py
+++ b/contrib/kittens/test/test_102_gemm_python_multitile_lds_cdna4.py
@@ -561,3 +561,18 @@ class TestCdna4Mfma:
             mcpu="gfx950",
         )
         _run_multitile(cfg)
+
+
+class TestLLSched:
+    @pytest.mark.parametrize("ll_sched", [0, 1, 2, 3, 5], ids=lambda v: f"llsched{v}")
+    def test_correctness(self, ll_sched):
+        cfg = _make_instance(
+            [1, 1, 1],
+            [2, 2, 1],
+            [6, 4, 1],
+            k_mult=4,
+            pipeline_strategy=3,
+            mcpu="gfx950",
+            ll_sched=ll_sched,
+        )
+        _run_multitile(cfg)

--- a/contrib/mlir-air/test/linalg-to-amdgcn.mlir
+++ b/contrib/mlir-air/test/linalg-to-amdgcn.mlir
@@ -59,8 +59,8 @@ module attributes {transform.with_named_sequence} {
           : (!aster_utils.any, index, index, index) -> !future_global_read
       %t0, %t1 = func.call @store_global_tile_to_lds_16x64_b(%lds_dst, %gfut)
           : (index, !future_global_read) -> (!lds_write_token, !lds_write_token)
-      amdgcn.wait deps %t0 : !lds_write_token
-      amdgcn.wait deps %t1 : !lds_write_token
+      %wf0 = amdgcn.wait deps %t0 : !lds_write_token -> !amdgcn.fence_token
+      %wf1 = amdgcn.wait deps %t1 : !lds_write_token -> !amdgcn.fence_token
       return
     }
 

--- a/examples/04_regalloc/kernel.mlir
+++ b/examples/04_regalloc/kernel.mlir
@@ -35,7 +35,7 @@ amdgcn.module @regalloc target = <gfx942> {
     %data_reg = amdgcn.alloca : !amdgcn.vgpr
     %c0 = arith.constant 0 : i32
     %data, %tok_ld = amdgcn.global_load_dword dest %data_reg addr %src offset d(%off_reg) + c(%c0) : outs(!amdgcn.vgpr) ins(!amdgcn.sgpr<[? : ? + 2]>, !amdgcn.vgpr<11>) mods(i32) -> !amdgcn.read_token<flat>
-    amdgcn.wait deps %tok_ld : !amdgcn.read_token<flat>
+    %wf0 = amdgcn.wait deps %tok_ld : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 
     // out[tid] = in[tid] + 42
     %c42 = arith.constant 42 : i32
@@ -44,7 +44,7 @@ amdgcn.module @regalloc target = <gfx942> {
 
     // Store result
     %tok_st = amdgcn.global_store_dword data %result addr %dst offset d(%off_reg) + c(%c0) : ins(!amdgcn.vgpr, !amdgcn.sgpr<[? : ? + 2]>, !amdgcn.vgpr<11>) mods(i32) -> !amdgcn.write_token<flat>
-    amdgcn.wait deps %tok_st : !amdgcn.write_token<flat>
+    %wf1 = amdgcn.wait deps %tok_st : !amdgcn.write_token<flat> -> !amdgcn.fence_token
 
     amdgcn.end_kernel
   }

--- a/include/aster/Dialect/AMDGCN/IR/AMDGCNAttrs.td
+++ b/include/aster/Dialect/AMDGCN/IR/AMDGCNAttrs.td
@@ -511,6 +511,17 @@ def NoMetadataOpsAttr : AMDGCN_Attr<
   }];
 }
 
+def NoDependencyTokensAttr : AMDGCN_Attr<
+    "NoDependencyTokens", "no_dependency_tokens",
+    [DeclareAttrInterfaceMethods<NormalFormAttrInterface, ["checkOperation"]>]> {
+  let summary = "Normal form: no dependency-token operands";
+  let description = [{
+    Verifies that no operation consumes a dependency token.
+    Token results on memory ops are not checked: they remain as unused results
+    and are not emitted.
+  }];
+}
+
 def AllInlinedAttr : AMDGCN_Attr<
     "AllInlined", "all_inlined",
     [DeclareAttrInterfaceMethods<NormalFormAttrInterface, ["checkOperation"]>]> {

--- a/include/aster/Dialect/AMDGCN/IR/AMDGCNOps.td
+++ b/include/aster/Dialect/AMDGCN/IR/AMDGCNOps.td
@@ -856,7 +856,8 @@ def WaitCountAttr :
 def AMDGCN_WaitOp : AMDGCN_Op<"wait", [
     DeclareOpInterfaceMethods<DependentOpInterface, ["getOutDependency"]>,
     DeclareOpInterfaceMethods<WaitCntOpInterface>,
-    DeclareOpInterfaceMethods<ISACompatibleOpInterface>
+    DeclareOpInterfaceMethods<ISACompatibleOpInterface>,
+    FenceOpInterface,
   ]> {
   let summary = "AMDGCN wait operation";
   let description = [{
@@ -868,7 +869,11 @@ def AMDGCN_WaitOp : AMDGCN_Op<"wait", [
     - `vm_cnt`: Wait for vector memory operations
     - `lgkm_cnt`: Wait for lds, gws and constant memory operations
 
-    NOTE: This operations is compatiable only with CDNA3 and CDNA4 targets.
+    Always produces an ordering-only fence_token (via FenceOpInterface) that
+    may be passed to FenceableOpInterface consumers or
+    `cross_wave_token_barrier`.
+
+    NOTE: This operations is compatible only with CDNA3 and CDNA4 targets.
     For gfx1250/gfx1251 use amdgcn.wait_gfx1250 (separate per-counter waits).
     TODO: Support RDNA4 counts, and other targets.
 
@@ -880,19 +885,36 @@ def AMDGCN_WaitOp : AMDGCN_Op<"wait", [
     %result, %tok1 = amdgcn.load global_load_dword dest %dest addr %addr2
         : dps(!amdgcn.vgpr_range<[? + 1]>) ins(!amdgcn.vgpr_range<[? + 2]>)
           -> !amdgcn.read_token<flat>
-    amdgcn.wait %tok0, %tok1 : !amdgcn.write_token<flat>, !amdgcn.read_token<flat>
+    %wf = amdgcn.wait deps %tok0, %tok1
+        : !amdgcn.write_token<flat>, !amdgcn.read_token<flat>
+        -> !amdgcn.fence_token
     ```
   }];
   let arguments = (ins
     Variadic<TokenDependencyTypeInterface>:$dependencies,
     WaitCountAttr:$vm_cnt, WaitCountAttr:$lgkm_cnt
   );
+  let results = (outs FenceToken:$fence_token);
   let assemblyFormat = [{
     oilist(`vm_cnt` $vm_cnt | `lgkm_cnt` $lgkm_cnt) (`deps` $dependencies^)?
-    attr-dict (`:` type($dependencies)^)?
+    attr-dict (`:` type($dependencies)^)? `->` type($fence_token)
   }];
+  let builders = [
+    OpBuilder<(ins "::mlir::ValueRange":$dependencies,
+                   "uint16_t":$vmCnt, "uint16_t":$lgkmCnt), [{
+      build($_builder, $_state, $_builder.getType<FenceTokenType>(),
+            dependencies, vmCnt, lgkmCnt);
+    }]>,
+    OpBuilder<(ins "::mlir::ValueRange":$dependencies), [{
+      build($_builder, $_state, $_builder.getType<FenceTokenType>(),
+            dependencies, kNoWaitCount, kNoWaitCount);
+    }]>
+  ];
   let extraClassDeclaration = [{
     static constexpr uint16_t kNoWaitCount = std::numeric_limits<uint16_t>::max();
+
+    /// The fence token produced by this op. Implements FenceOpInterface.
+    ::mlir::Value getProducedFenceToken() { return getFenceToken(); }
 
     /// Canonicalize the wait operation, this method removes duplicate operands,
     /// merges consecutive wait operations if possible. Returns an iterator to
@@ -917,7 +939,8 @@ def AMDGCN_WaitOp : AMDGCN_Op<"wait", [
 
     /// Check if the wait operation is a no-wait (has no dependencies).
     bool isNowait() {
-      return !hasAnyCount() && getDependencies().empty();
+      return !hasAnyCount() && getDependencies().empty() &&
+             getFenceToken().use_empty();
     }
   }];
   let hasCanonicalizeMethod = 1;
@@ -926,7 +949,8 @@ def AMDGCN_WaitOp : AMDGCN_Op<"wait", [
 def AMDGCN_WaitGfx1250Op : AMDGCN_Op<"wait_gfx1250", [
     DeclareOpInterfaceMethods<DependentOpInterface, ["getOutDependency"]>,
     DeclareOpInterfaceMethods<WaitCntOpInterface>,
-    DeclareOpInterfaceMethods<ISACompatibleOpInterface>
+    DeclareOpInterfaceMethods<ISACompatibleOpInterface>,
+    FenceOpInterface,
   ]> {
   let summary = "gfx1250 wait operation";
   let description = [{
@@ -947,12 +971,25 @@ def AMDGCN_WaitGfx1250Op : AMDGCN_Op<"wait_gfx1250", [
     - s_wait_dscnt
     - s_wait_kmcnt
     - s_wait_tensorcnt
+
+    Always produces an ordering-only fence_token (via FenceOpInterface) that
+    may be passed to FenceableOpInterface consumers or
+    `cross_wave_token_barrier`.
+
+    Example:
+    ```mlir
+    %tok = amdgcn.ds_write_b32 data %data addr %addr offset c(%c0)
+        : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
+    %wf = amdgcn.wait_gfx1250 deps %tok
+        : !amdgcn.write_token<shared> -> !amdgcn.fence_token
+    ```
   }];
   let arguments = (ins
     Variadic<TokenDependencyTypeInterface>:$dependencies,
     WaitCountAttr:$load_cnt, WaitCountAttr:$store_cnt, WaitCountAttr:$ds_cnt,
     WaitCountAttr:$km_cnt, WaitCountAttr:$tensor_cnt
   );
+  let results = (outs FenceToken:$fence_token);
   let assemblyFormat = [{
     oilist(
       `load_cnt` $load_cnt |
@@ -962,14 +999,40 @@ def AMDGCN_WaitGfx1250Op : AMDGCN_Op<"wait_gfx1250", [
       `tensor_cnt` $tensor_cnt
     )
     (`deps` $dependencies^)?
-    attr-dict (`:` type($dependencies)^)?
+    attr-dict (`:` type($dependencies)^)? `->` type($fence_token)
   }];
+  let builders = [
+    OpBuilder<(ins "::mlir::ValueRange":$dependencies,
+                   "uint16_t":$loadCnt, "uint16_t":$storeCnt, "uint16_t":$dsCnt,
+                   "uint16_t":$kmCnt, "uint16_t":$tensorCnt), [{
+      build($_builder, $_state, $_builder.getType<FenceTokenType>(),
+            dependencies, loadCnt, storeCnt, dsCnt, kmCnt, tensorCnt);
+    }]>,
+    OpBuilder<(ins "::mlir::ValueRange":$dependencies), [{
+      build($_builder, $_state, $_builder.getType<FenceTokenType>(),
+            dependencies, kNoWaitCount, kNoWaitCount, kNoWaitCount,
+            kNoWaitCount, kNoWaitCount);
+    }]>
+  ];
   let extraClassDeclaration = [{
     static constexpr uint16_t kNoWaitCount = std::numeric_limits<uint16_t>::max();
+
+    /// The fence token produced by this op. Implements FenceOpInterface.
+    ::mlir::Value getProducedFenceToken() { return getFenceToken(); }
 
     /// Canonicalize: remove duplicate deps, merge consecutive wait_gfx1250 ops.
     static FailureOr<Block::iterator> canonicalizeWait(WaitGfx1250Op op,
       RewriterBase &rewriter, llvm::SetVector<Value>& uniqueDeps);
+
+    /// Add dependencies to the wait operation.
+    bool addDependencies(ValueRange deps);
+
+    /// Remove dependencies from the wait operation. Returns true if any changes
+    /// were made.
+    bool removeDependencies(ValueRange deps);
+
+    /// Set the dependencies of the wait operation.
+    void setDependencies(ValueRange deps);
 
     /// Check if the wait operation waits for any memory subsystem.
     bool hasAnyCount() {
@@ -980,10 +1043,68 @@ def AMDGCN_WaitGfx1250Op : AMDGCN_Op<"wait_gfx1250", [
 
     /// Check if the wait operation is a no-wait (has no dependencies).
     bool isNowait() {
-      return !hasAnyCount() && getDependencies().empty();
+      return !hasAnyCount() && getDependencies().empty() &&
+             getFenceToken().use_empty();
     }
   }];
   let hasCanonicalizeMethod = 1;
+}
+
+//===----------------------------------------------------------------------===//
+// CrossWaveTokenBarrierOp
+//===----------------------------------------------------------------------===//
+
+def AMDGCN_CrossWaveTokenBarrierOp : AMDGCN_Op<"cross_wave_token_barrier", [
+    DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>,
+    BarrierOpInterface,
+    FenceOpInterface,
+  ]> {
+  let summary = "Cross-wave scheduling barrier carrying scheduling dependency tokens";
+  let description = [{
+    A cross-wave synchronization barrier that:
+      - synchronizes waves program points like a regular barrier and
+      - orders memory operations across a program point entirely through SSA
+        dependency tokens.
+
+    This operation is a relaxed synchronization mechanism that allows for
+    finer-grained barrier scheduling.
+
+    Operands: the variadic input dependency tokens name what must precede the
+    barrier. Typically this is the fence token produced by an `amdgcn.wait` so
+    the barrier follows the visibility point, pinning `write -> wait -> barrier`.
+
+    Results: the barrier produces a fence token. Operations that must be pinned
+    after the barrier take it via a FenceableOpInterface to form the
+    barrier -> consumer scheduling edge.
+
+    The fence token is ordering-only IR metadata and is dropped when legalizing
+    to a hardware s_barrier (CDNA3/4) or s_barrier_signal / s_barrier_wait
+    (GFX12.5+).
+
+    Example (write -> wait -> barrier -> read, all SSA):
+    ```mlir
+    %wt = amdgcn.ds_write_b32 data %d addr %a offset c(%c0)
+        : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
+
+    // The wait drains the write and produces a fence the barrier follows.
+    %wf = amdgcn.wait deps %wt : !amdgcn.write_token<shared> -> !amdgcn.fence_token
+    %bf = amdgcn.cross_wave_token_barrier deps %wf : !amdgcn.fence_token
+
+    // A consumer pins after the barrier via the optional fence_token operand.
+    %r, %t = amdgcn.ds_read_b32 dest %rd addr %a offset c(%c0)
+        : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32)
+        -> !amdgcn.read_token<shared> fence_token %bf : !amdgcn.fence_token
+    ```
+  }];
+  let arguments = (ins Variadic<TokenDependencyTypeInterface>:$dependencies);
+  let results = (outs FenceToken:$fence_token);
+  let assemblyFormat = [{
+    (`deps` $dependencies^ `:` type($dependencies))? attr-dict
+  }];
+  let extraClassDeclaration = [{
+    // The fence token produced by this op. Implements FenceOpInterface.
+    ::mlir::Value getProducedFenceToken() { return getFenceToken(); }
+  }];
 }
 
 #endif // ASTER_AMDGCN_OPS

--- a/include/aster/Dialect/AMDGCN/IR/AMDGCNTypeConstraints.td
+++ b/include/aster/Dialect/AMDGCN/IR/AMDGCNTypeConstraints.td
@@ -101,6 +101,12 @@ def TensorReadToken :
   CPPType<"::mlir::aster::amdgcn::ReadTokenType", "read token type">,
   InferrableType<"$_builder.getType<ReadTokenType>(MemoryInstructionKind::Tensor)">;
 
+// Ordering-only fence token. Produced by FenceOpInterface ops and consumed
+// by FenceableOpInterface ops.
+def FenceToken :
+  CPPType<"::mlir::aster::amdgcn::FenceTokenType", "fence token type">,
+  InferrableType<"$_builder.getType<FenceTokenType>()">;
+
 //===----------------------------------------------------------------------===//
 // Common type constraint classes
 //===----------------------------------------------------------------------===//

--- a/include/aster/Dialect/AMDGCN/IR/AMDGCNTypes.td
+++ b/include/aster/Dialect/AMDGCN/IR/AMDGCNTypes.td
@@ -353,4 +353,15 @@ def WriteTokenType : AMDGCN_Type<"WriteToken", "write_token",
   let assemblyFormat = "`<` $kind `>`";
 }
 
+def FenceTokenType : AMDGCN_Type<"FenceToken", "fence_token",
+    [TokenDependencyTypeInterface, MemRefElementTypeInterface]> {
+  let summary = "Fence token type";
+  let description = [{
+    Ordering-only SSA token for workgroup barrier synchronization, produced by
+    FenceOpInterface (e.g. cross_wave_token_barrier) and consumed by
+    FenceableOpInterface (e.g. LDS read).
+  }];
+  let assemblyFormat = "";
+}
+
 #endif // ASTER_AMDGCN_TYPES_TD

--- a/include/aster/Dialect/AMDGCN/IR/Instructions/DS.td
+++ b/include/aster/Dialect/AMDGCN/IR/Instructions/DS.td
@@ -97,7 +97,7 @@ def DsPermuteB32 : AMDISAInstruction<"ds_permute_b32", [FutureOpInterface]> {
 
 #ifndef DSREAD2INST_DEF
 #define DSREAD2INST_DEF
-class DSRead2Inst<string mnemonic, list<Type> dst0Type> : AMDISAInstruction<mnemonic, [DSRead2InstOpInterface]> {
+class DSRead2Inst<string mnemonic, list<Type> dst0Type> : AMDISAInstruction<mnemonic, [DSRead2InstOpInterface, FenceableOpInterface]> {
   let props = [IsDS];
   let archs = [CDNA3Isa, CDNA4Isa];
   let effects = [LDSRead];
@@ -110,7 +110,8 @@ class DSRead2Inst<string mnemonic, list<Type> dst0Type> : AMDISAInstruction<mnem
   let trailingArgs = (ins
     OffsetType<8>:$const_offset0,
     OffsetType<8>:$const_offset1,
-    GDS:$gds
+    GDS:$gds,
+    Optional<FenceToken>:$fence_token
   );
   let genInstAssemblyFormat = 0;
   let assemblyFormat = [{
@@ -119,6 +120,7 @@ class DSRead2Inst<string mnemonic, list<Type> dst0Type> : AMDISAInstruction<mnem
     `outs``(` type($dest) `)` `ins` `(` type($addr) `)`
     `mods` `(` type($const_offset0) `,` type($const_offset1) `)` `->`
     custom<LoadResults>(ref(type($dest)), type($dest_res), type($token))
+    (`fence_token` $fence_token^ `:` type($fence_token))?
   }];
   let trailingResults = (outs DSReadToken:$token);
   let asm_syntax = [
@@ -157,7 +159,7 @@ def DsRead2B64 : DSRead2Inst<"ds_read2_b64",
 
 #ifndef DSREADINST_DEF
 #define DSREADINST_DEF
-class DSReadInst<string mnemonic, list<Type> dst0Type> : AMDISAInstruction<mnemonic, [DSReadInstOpInterface]> {
+class DSReadInst<string mnemonic, list<Type> dst0Type> : AMDISAInstruction<mnemonic, [DSReadInstOpInterface, FenceableOpInterface]> {
   let props = [IsDS];
   let archs = [CDNA3Isa, CDNA4Isa];
   let effects = [LDSRead];
@@ -169,13 +171,15 @@ class DSReadInst<string mnemonic, list<Type> dst0Type> : AMDISAInstruction<mnemo
   );
   let trailingArgs = (ins
     OffsetType<16>:$const_offset,
-    GDS:$gds
+    GDS:$gds,
+    Optional<FenceToken>:$fence_token
   );
   let genInstAssemblyFormat = 0;
   let assemblyFormat = [{
     `dest` $dest `addr` $addr `offset` `c` `(`$const_offset`)` attr-dict `:`
     `outs``(` type($dest) `)` `ins` `(` type($addr) `)` `mods` `(` type($const_offset) `)` `->`
     custom<LoadResults>(ref(type($dest)), type($dest_res), type($token))
+    (`fence_token` $fence_token^ `:` type($fence_token))?
   }];
   let trailingResults = (outs DSReadToken:$token);
   let asm_syntax = [
@@ -200,7 +204,7 @@ def DsReadB128 : DSReadInst<"ds_read_b128",
 #define DSLOADINST_DEF
 // Plain gfx1250 DS load (M0-based), the ds_load_b* family.
 class DSLoadInst<string mnemonic, list<Type> dstType>
-    : AMDISAInstruction<mnemonic, [DSReadInstOpInterface]> {
+    : AMDISAInstruction<mnemonic, [DSReadInstOpInterface, FenceableOpInterface]> {
   let props = [IsDS];
   let archs = [GFX12_50Isa];
   let effects = [LDSRead];
@@ -212,13 +216,15 @@ class DSLoadInst<string mnemonic, list<Type> dstType>
   );
   let trailingArgs = (ins
     OffsetType<16>:$const_offset,
-    GDS:$gds
+    GDS:$gds,
+    Optional<FenceToken>:$fence_token
   );
   let genInstAssemblyFormat = 0;
   let assemblyFormat = [{
     `dest` $dest `addr` $addr `offset` `c` `(`$const_offset`)` attr-dict `:`
     `outs``(` type($dest) `)` `ins` `(` type($addr) `)` `mods` `(` type($const_offset) `)` `->`
     custom<LoadResults>(ref(type($dest)), type($dest_res), type($token))
+    (`fence_token` $fence_token^ `:` type($fence_token))?
   }];
   let trailingResults = (outs DSReadToken:$token);
   let asm_syntax = [

--- a/include/aster/Dialect/AMDGCN/IR/Instructions/SOP.td
+++ b/include/aster/Dialect/AMDGCN/IR/Instructions/SOP.td
@@ -579,7 +579,7 @@ def SSubbU32 : SOP2Out2In3Inst<"s_subb_u32"> {
 
 #ifndef SBARRIER_DEF
 #define SBARRIER_DEF
-def SBarrier : AMDISAInstruction<"s_barrier"> {
+def SBarrier : AMDISAInstruction<"s_barrier", [BarrierOpInterface]> {
   let props = [IsSALU, IsSOPP];
   let archs = [CDNA3Isa, CDNA4Isa];
   let description = [{

--- a/include/aster/Dialect/AMDGCN/IR/Instructions/VMem.td
+++ b/include/aster/Dialect/AMDGCN/IR/Instructions/VMem.td
@@ -162,6 +162,7 @@ class BufferLoadLDSInst<string mnemonic> : AMDISAInstruction<mnemonic, [BufferLo
     SC0:$sc0,
     SC1:$sc1
   );
+  // token: flat read token (vmcnt) that the wait consumes.
   let trailingResults = (outs FlatReadToken:$token);
   let genInstAssemblyFormat = 0;
   let assemblyFormat = [{
@@ -505,6 +506,7 @@ class GlobalLoadLdsInst<string mnemonic> : AMDISAInstruction<mnemonic, [GlobalLo
     SC0:$sc0,
     SC1:$sc1
   );
+  // token: flat read token (vmcnt) consumed by the wait.
   let trailingResults = (outs FlatReadToken:$token);
   let genInstAssemblyFormat = 0;
   let assemblyFormat = [{

--- a/include/aster/Dialect/AMDGCN/IR/OpAsmUtils.h
+++ b/include/aster/Dialect/AMDGCN/IR/OpAsmUtils.h
@@ -1,0 +1,42 @@
+//===- OpAsmUtils.h - AMDGCN assembly parse/print helpers -----*- C++ -*-===//
+//
+// Copyright 2025 The ASTER Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Shared custom assembly format helpers for TableGen-generated AMDGCN ops.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ASTER_DIALECT_AMDGCN_IR_OP_ASM_UTILS_H
+#define ASTER_DIALECT_AMDGCN_IR_OP_ASM_UTILS_H
+
+#include "aster/Dialect/AMDGCN/IR/AMDGCNAttrs.h"
+#include "aster/Interfaces/RegisterType.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/OpImplementation.h"
+
+namespace mlir::aster::amdgcn {
+
+ParseResult parseDimAttr(OpAsmParser &parser, DimAttr &attr);
+void printDimAttr(OpAsmPrinter &printer, Operation *, DimAttr attr);
+
+ParseResult parseLoadResults(OpAsmParser &parser, Type destType,
+                             Type &destResType, Type &tokenType);
+void printLoadResults(OpAsmPrinter &printer, Operation *, Type destType,
+                      Type destResType, Type tokenType);
+
+ParseResult
+parseAllocSize(OpAsmParser &parser,
+               std::optional<OpAsmParser::UnresolvedOperand> &dynamicSize,
+               IntegerAttr &staticSize);
+void printAllocSize(OpAsmPrinter &printer, Operation *op, Value dynamicSize,
+                    IntegerAttr staticSize);
+
+} // namespace mlir::aster::amdgcn
+
+#endif // ASTER_DIALECT_AMDGCN_IR_OP_ASM_UTILS_H

--- a/include/aster/Dialect/AMDGCN/IR/Utils.h
+++ b/include/aster/Dialect/AMDGCN/IR/Utils.h
@@ -94,6 +94,13 @@ bool isWave32(ISAVersion isa);
 /// True when `target` is modeled as wave32.
 bool isWave32(Target target);
 
+/// True when whole-workgroup barriers must use s_barrier_signal/s_barrier_wait
+/// instead of monolithic s_barrier (e.g. GFX12.5+).
+bool needsSplitBarriers(ISAVersion isa);
+
+/// True when `target` needs split barriers.
+bool needsSplitBarriers(Target target);
+
 /// True when the enclosing amdgcn.module target is wave32; false outside a
 /// module.
 bool isWave32(Operation *op);

--- a/include/aster/Dialect/AMDGCN/Scheduler/SchedulerCostModel.h
+++ b/include/aster/Dialect/AMDGCN/Scheduler/SchedulerCostModel.h
@@ -92,6 +92,10 @@ struct CDNA3Latencies {
   int lgkmBurstPenalty = 200;
   size_t xdlBurstLookback = 2;
   int xdlBurstPenalty = 350;
+  // Hard cap on consecutive MFMA (deterministic spread dial; 0 = disabled).
+  // When the trailing run of XDL ops already reaches xdlMaxRun, the next XDL is
+  // penalized so any ready non-XDL op wins (forcing interleaving).
+  int xdlMaxRun = 0;
 
   // -- Score: VALU/SALU <-> LGKM/VMEM adjacency NOP penalty ------------
   int adjacencyPenalty = 400;

--- a/include/aster/Interfaces/DependentOpInterface.td
+++ b/include/aster/Interfaces/DependentOpInterface.td
@@ -49,6 +49,61 @@ def DependentOpInterface : OpInterface<"DependentOpInterface"> {
   }];
 }
 
+def BarrierOpInterface : OpInterface<"BarrierOpInterface"> {
+  let cppNamespace = "::mlir::aster";
+  let description = [{
+    Interface for barrier operations.
+  }];
+}
+
+def FenceOpInterface : OpInterface<"FenceOpInterface"> {
+  let cppNamespace = "::mlir::aster";
+  let description = [{
+    Interface for operations that produce fence tokens. Wait ops and
+    cross_wave_token_barrier implement this; consumers take fence_token via
+    `FenceableOpInterface` to express single-thread operation
+    ordering and enforce multi-thread synchronization.
+  }];
+  let methods = [
+    InterfaceMethod<
+      "Get the fence token produced by this op",
+      "::mlir::Value", "getProducedFenceToken"
+    >,
+  ];
+}
+
+def FenceableOpInterface : OpInterface<"FenceableOpInterface"> {
+  let cppNamespace = "::mlir::aster";
+  let description = [{
+    Interface for operations that may consume an SSA fence token. This allows
+    pinning the op after a FenceOpInterface producer to express single-thread
+    operation ordering and enforce multi-thread synchronization.
+  }];
+  let methods = [
+    InterfaceMethod<
+      "Get the fence token consumed by this op.",
+      "::mlir::Value", "getFenceToken"
+    >,
+    InterfaceMethod<
+      "Get the mutable fence token operand.",
+      "::mlir::MutableOperandRange", "getFenceTokenMutable"
+    >,
+  ];
+  let extraSharedClassDeclaration = [{
+    /// True if this op carries an SSA fence token operand.
+    bool hasFenceToken() {
+      return $_op.getFenceToken() != nullptr;
+    }
+
+    /// Drop the optional fence_token operand. No-op if absent.
+    void eraseFence() {
+      if (!hasFenceToken())
+        return;
+      $_op.getFenceTokenMutable().clear();
+    }
+  }];
+}
+
 def FutureOpInterface : OpInterface<"FutureOpInterface"> {
   let cppNamespace = "::mlir::aster";
   let description = [{

--- a/lib/Dialect/AMDGCN/CodeGen/CodeGenPatterns.cpp
+++ b/lib/Dialect/AMDGCN/CodeGen/CodeGenPatterns.cpp
@@ -126,15 +126,27 @@ static Value getI32Constant(OpBuilder &builder, Location loc, int32_t value) {
 static FailureOr<Value> createDSRead(OpBuilder &rewriter, Location loc,
                                      Value dst, Value addr, int64_t numWords) {
   Value offset = getI32Constant(rewriter, loc, 0);
+  // Trailing optionals (gds, fence_token) must be passed explicitly: a codegen
+  // ds_read has no GDS flag and takes no fence token.
+  UnitAttr noGds = {};
+  Value noFenceToken = {};
   switch (numWords) {
   case 1:
-    return DsReadB32::create(rewriter, loc, dst, addr, offset).getDestRes();
+    return DsReadB32::create(rewriter, loc, dst, addr, offset, noGds,
+                             noFenceToken)
+        .getDestRes();
   case 2:
-    return DsReadB64::create(rewriter, loc, dst, addr, offset).getDestRes();
+    return DsReadB64::create(rewriter, loc, dst, addr, offset, noGds,
+                             noFenceToken)
+        .getDestRes();
   case 3:
-    return DsReadB96::create(rewriter, loc, dst, addr, offset).getDestRes();
+    return DsReadB96::create(rewriter, loc, dst, addr, offset, noGds,
+                             noFenceToken)
+        .getDestRes();
   case 4:
-    return DsReadB128::create(rewriter, loc, dst, addr, offset).getDestRes();
+    return DsReadB128::create(rewriter, loc, dst, addr, offset, noGds,
+                              noFenceToken)
+        .getDestRes();
   default:
     return failure();
   }

--- a/lib/Dialect/AMDGCN/IR/AMDGCN.cpp
+++ b/lib/Dialect/AMDGCN/IR/AMDGCN.cpp
@@ -10,6 +10,7 @@
 
 #include "aster/Dialect/AMDGCN/IR/AMDGCNOps.h"
 #include "aster/Dialect/AMDGCN/IR/AMDGCNVerifiers.h"
+#include "aster/Dialect/AMDGCN/IR/OpAsmUtils.h"
 #include "aster/Dialect/AMDGCN/IR/Utils.h"
 #include "aster/IR/ParsePrintUtils.h"
 #include "mlir/IR/DialectImplementation.h"
@@ -43,117 +44,6 @@ bool amdgcn::checkIntConst(Value value, ArrayRef<int64_t> values) {
   if (!matchPattern(value, m_ConstantInt(&apInt)))
     return false;
   return llvm::is_contained(values, apInt.getSExtValue());
-}
-
-//===----------------------------------------------------------------------===//
-// Internal functions
-//===----------------------------------------------------------------------===//
-
-/// Helper to get either the type of a Value or return the type itself.
-template <typename T, std::enable_if_t<std::is_base_of_v<Value, T>, int> = 0>
-static auto getTypeOrValue(T value) {
-  using Type = decltype(value.getType());
-  if (value == nullptr)
-    return Type();
-  return value.getType();
-}
-/// Helper to passthrough values that are not MLIR Values.
-template <typename T, std::enable_if_t<!std::is_base_of_v<Value, T>, int> = 0>
-static T &&getTypeOrValue(T &&value) {
-  return std::forward<T>(value);
-}
-
-//===----------------------------------------------------------------------===//
-// DimAttr Parsing/Printing
-//===----------------------------------------------------------------------===//
-
-/// Parse a DimAttr from a keyword (x, y, or z).
-static ParseResult parseDimAttr(OpAsmParser &parser, DimAttr &attr) {
-  StringRef keyword;
-  if (parser.parseKeyword(&keyword))
-    return failure();
-
-  auto dimOpt = symbolizeDim(keyword);
-  if (!dimOpt)
-    return parser.emitError(parser.getCurrentLocation(), "invalid dimension: ")
-           << keyword;
-
-  attr = DimAttr::get(parser.getBuilder().getContext(), *dimOpt);
-  return success();
-}
-
-/// Print a DimAttr as a keyword.
-static void printDimAttr(OpAsmPrinter &printer, Operation *, DimAttr attr) {
-  printer << stringifyDim(attr.getValue());
-}
-
-//===----------------------------------------------------------------------===//
-// Offset Parsing/Printing
-//===----------------------------------------------------------------------===//
-
-//===----------------------------------------------------------------------===//
-// LoadResults Parsing/Printing
-//===----------------------------------------------------------------------===//
-
-/// Parse the trailing results of a load instruction. The dest type has already
-/// been parsed and is passed by reference. The dest_res type is inferred to be
-/// the same as dest iff the register has value semantics. The token type is
-/// parsed from the input.
-static ParseResult parseLoadResults(OpAsmParser &parser, Type destType,
-                                    Type &destResType, Type &tokenType) {
-  auto regTy = dyn_cast<RegisterTypeInterface>(destType);
-  if (regTy && regTy.hasValueSemantics())
-    destResType = destType;
-  if (parser.parseType(tokenType))
-    return failure();
-  return success();
-}
-
-/// Print the trailing results of a load instruction. The dest_res type is
-/// inferred from dest and is not printed; only the token type is printed.
-static void printLoadResults(OpAsmPrinter &printer, Operation *, Type destType,
-                             Type destResType, Type tokenType) {
-  printer.printType(tokenType);
-}
-
-//===----------------------------------------------------------------------===//
-// AllocSize Parsing/Printing
-//===----------------------------------------------------------------------===//
-
-/// Parse a size that can be either static (integer) or dynamic (SSA value).
-/// Format: `<integer>` for static, `%operand` for dynamic.
-static ParseResult
-parseAllocSize(OpAsmParser &parser,
-               std::optional<OpAsmParser::UnresolvedOperand> &dynamicSize,
-               IntegerAttr &staticSize) {
-  // Try to parse an integer first (static size).
-  int64_t intVal;
-  auto intRes = parser.parseOptionalInteger(intVal);
-  if (intRes.has_value()) {
-    if (failed(*intRes))
-      return failure();
-    staticSize = parser.getBuilder().getI64IntegerAttr(intVal);
-    dynamicSize = std::nullopt;
-    return success();
-  }
-
-  // Otherwise, parse an operand (dynamic size).
-  OpAsmParser::UnresolvedOperand operand;
-  if (parser.parseOperand(operand))
-    return failure();
-  dynamicSize = operand;
-  staticSize = parser.getBuilder().getI64IntegerAttr(ShapedType::kDynamic);
-  return success();
-}
-
-/// Print a size that can be either static or dynamic.
-static void printAllocSize(OpAsmPrinter &printer, Operation *op,
-                           Value dynamicSize, IntegerAttr staticSize) {
-  if (ShapedType::isDynamic(staticSize.getInt())) {
-    printer.printOperand(dynamicSize);
-    return;
-  }
-  printer << staticSize.getInt();
 }
 
 //===----------------------------------------------------------------------===//
@@ -1171,51 +1061,3 @@ inferTypesImpl(MLIRContext *ctx, std::optional<Location> &loc,
 
 #define GET_OP_CLASSES
 #include "aster/Dialect/AMDGCN/IR/AMDGCNOps.cpp.inc"
-
-#define GET_OP_CLASSES
-#include "aster/Dialect/AMDGCN/IR/ControlFlow.cpp.inc"
-
-#define AMDGCN_GEN_INST_METHODS
-#include "aster/Dialect/AMDGCN/IR/ControlFlowInst.cpp.inc"
-
-#define GET_OP_CLASSES
-#include "aster/Dialect/AMDGCN/IR/DS.cpp.inc"
-
-#define AMDGCN_GEN_INST_METHODS
-#include "aster/Dialect/AMDGCN/IR/DSInst.cpp.inc"
-
-#define GET_OP_CLASSES
-#include "aster/Dialect/AMDGCN/IR/MMA.cpp.inc"
-
-#define AMDGCN_GEN_INST_METHODS
-#include "aster/Dialect/AMDGCN/IR/MMAInst.cpp.inc"
-
-#define GET_OP_CLASSES
-#include "aster/Dialect/AMDGCN/IR/WMMA.cpp.inc"
-
-#define AMDGCN_GEN_INST_METHODS
-#include "aster/Dialect/AMDGCN/IR/WMMAInst.cpp.inc"
-
-#define GET_OP_CLASSES
-#include "aster/Dialect/AMDGCN/IR/SMem.cpp.inc"
-
-#define AMDGCN_GEN_INST_METHODS
-#include "aster/Dialect/AMDGCN/IR/SMemInst.cpp.inc"
-
-#define GET_OP_CLASSES
-#include "aster/Dialect/AMDGCN/IR/SOP.cpp.inc"
-
-#define AMDGCN_GEN_INST_METHODS
-#include "aster/Dialect/AMDGCN/IR/SOPInst.cpp.inc"
-
-#define GET_OP_CLASSES
-#include "aster/Dialect/AMDGCN/IR/VMem.cpp.inc"
-
-#define AMDGCN_GEN_INST_METHODS
-#include "aster/Dialect/AMDGCN/IR/VMemInst.cpp.inc"
-
-#define GET_OP_CLASSES
-#include "aster/Dialect/AMDGCN/IR/VOP.cpp.inc"
-
-#define AMDGCN_GEN_INST_METHODS
-#include "aster/Dialect/AMDGCN/IR/VOPInst.cpp.inc"

--- a/lib/Dialect/AMDGCN/IR/AMDGCN.cpp
+++ b/lib/Dialect/AMDGCN/IR/AMDGCN.cpp
@@ -380,6 +380,14 @@ LogicalResult MakeBufferRsrcOp::verify() {
 // MakeRegisterRangeOp
 //===----------------------------------------------------------------------===//
 
+LogicalResult CrossWaveTokenBarrierOp::inferReturnTypes(
+    MLIRContext *context, std::optional<Location> location, ValueRange operands,
+    DictionaryAttr attributes, PropertyRef properties, RegionRange regions,
+    SmallVectorImpl<Type> &inferredReturnTypes) {
+  inferredReturnTypes.push_back(FenceTokenType::get(context));
+  return success();
+}
+
 LogicalResult MakeRegisterRangeOp::inferReturnTypes(
     MLIRContext *context, std::optional<Location> location, ValueRange operands,
     DictionaryAttr attributes, PropertyRef properties, RegionRange regions,
@@ -869,6 +877,7 @@ static LogicalResult canonicalizeWaitImpl(WaitOp waitOp, RewriterBase &rewriter,
 
     // Erase redundant wait ops.
     if (wait != waitOp) {
+      wait.getFenceToken().replaceAllUsesWith(waitOp.getFenceToken());
       rewriter.eraseOp(wait);
       changed = true;
     }
@@ -971,6 +980,38 @@ ArrayRef<ISAVersion> WaitGfx1250Op::getCompatibleISAVersions() {
   return versions;
 }
 
+bool WaitGfx1250Op::addDependencies(ValueRange deps) {
+  bool changed = false;
+  if (deps.empty())
+    return changed;
+  getDependenciesMutable().append(deps);
+  changed = true;
+  return changed;
+}
+
+bool WaitGfx1250Op::removeDependencies(ValueRange deps) {
+  bool changed = false;
+  if (deps.empty())
+    return changed;
+  MutableOperandRange operands = getDependenciesMutable();
+  llvm::SmallPtrSet<Value, 5> removeSet(deps.begin(), deps.end());
+  SmallVector<Value> remaining;
+  for (Value dep : operands.getAsOperandRange()) {
+    if (removeSet.contains(dep))
+      continue;
+    remaining.push_back(dep);
+  }
+  if (remaining.size() != operands.size()) {
+    operands.assign(remaining);
+    changed = true;
+  }
+  return changed;
+}
+
+void WaitGfx1250Op::setDependencies(ValueRange deps) {
+  getDependenciesMutable().assign(deps);
+}
+
 // Workgroup-cluster ops gfx1250 only for now.
 static ArrayRef<ISAVersion> clusterOpsISAVersions() {
   static ISAVersion versions[] = {ISAVersion::GFX12_50};
@@ -1031,6 +1072,7 @@ static LogicalResult canonicalizeWaitGfx1250Impl(WaitGfx1250Op waitOp,
     kmCnt = std::min(kmCnt, wait.getKmCnt());
     tensorCnt = std::min(tensorCnt, wait.getTensorCnt());
     if (wait != waitOp) {
+      wait.getFenceToken().replaceAllUsesWith(waitOp.getFenceToken());
       rewriter.eraseOp(wait);
       changed = true;
     }

--- a/lib/Dialect/AMDGCN/IR/AMDGCNAttrs.cpp
+++ b/lib/Dialect/AMDGCN/IR/AMDGCNAttrs.cpp
@@ -534,6 +534,28 @@ NoMetadataOpsAttr::checkOperation(Operation *op) const {
 }
 
 //===----------------------------------------------------------------------===//
+// NoDependencyTokensAttr
+//===----------------------------------------------------------------------===//
+
+DiagnosedSilenceableFailure
+NoDependencyTokensAttr::checkOperation(Operation *op) const {
+  AttrTypeAggregator agg;
+  op->walk([&](Operation *innerOp) {
+    for (Value operand : innerOp->getOperands()) {
+      if (!isa<TokenDependencyTypeInterface>(operand.getType()))
+        continue;
+      agg.merge(emitSilenceableFailure(innerOp)
+                << "normal form violation: dependency-token operands are "
+                   "disallowed but found one on: "
+                << innerOp->getName());
+      break;
+    }
+    return agg.stop ? WalkResult::interrupt() : WalkResult::advance();
+  });
+  return std::move(agg.overall);
+}
+
+//===----------------------------------------------------------------------===//
 // AllInlinedAttr
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/AMDGCN/IR/CMakeLists.txt
+++ b/lib/Dialect/AMDGCN/IR/CMakeLists.txt
@@ -3,8 +3,17 @@ add_mlir_dialect_library(AMDGCNDialect
   AMDGCNAttrs.cpp
   AMDGCNTypes.cpp
   AMDGCNVerifiers.cpp
+  ControlFlowOps.cpp
+  DSOps.cpp
   Hazards.cpp
+  MMAOps.cpp
+  OpAsmUtils.cpp
+  SMemOps.cpp
+  SOPOps.cpp
   Utils.cpp
+  VMemOps.cpp
+  VOPOps.cpp
+  WMMAOps.cpp
 
   DEPENDS
   KernelArgInterfaceIncGen

--- a/lib/Dialect/AMDGCN/IR/ControlFlowOps.cpp
+++ b/lib/Dialect/AMDGCN/IR/ControlFlowOps.cpp
@@ -1,0 +1,17 @@
+//===- ControlFlowOps.cpp - AMDGCN control-flow instructions --------------===//
+//
+// Copyright 2025 The ASTER Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "InstOpsCommon.h"
+
+#define GET_OP_CLASSES
+#include "aster/Dialect/AMDGCN/IR/ControlFlow.cpp.inc"
+
+#define AMDGCN_GEN_INST_METHODS
+#include "aster/Dialect/AMDGCN/IR/ControlFlowInst.cpp.inc"

--- a/lib/Dialect/AMDGCN/IR/DSOps.cpp
+++ b/lib/Dialect/AMDGCN/IR/DSOps.cpp
@@ -1,0 +1,18 @@
+//===- DSOps.cpp - AMDGCN DS instructions ---------------------------------===//
+//
+// Copyright 2025 The ASTER Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "InstOpsCommon.h"
+#include "aster/Dialect/AMDGCN/IR/OpAsmUtils.h"
+
+#define GET_OP_CLASSES
+#include "aster/Dialect/AMDGCN/IR/DS.cpp.inc"
+
+#define AMDGCN_GEN_INST_METHODS
+#include "aster/Dialect/AMDGCN/IR/DSInst.cpp.inc"

--- a/lib/Dialect/AMDGCN/IR/InstMethodUtils.h
+++ b/lib/Dialect/AMDGCN/IR/InstMethodUtils.h
@@ -1,0 +1,41 @@
+//===- InstMethodUtils.h - helpers for generated inst methods --*- C++ -*-===//
+//
+// Copyright 2025 The ASTER Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Shared helpers referenced by amdgcn-tblgen-generated inst method bodies.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ASTER_DIALECT_AMDGCN_IR_INST_METHOD_UTILS_H
+#define ASTER_DIALECT_AMDGCN_IR_INST_METHOD_UTILS_H
+
+#include "aster/Dialect/AMDGCN/IR/AMDGCNOps.h"
+#include "aster/IR/InstImpl.h"
+#include "aster/IR/ParsePrintUtils.h"
+#include "mlir/IR/Value.h"
+#include <type_traits>
+#include <utility>
+
+/// Helper to get either the type of a Value or return the type itself.
+template <typename T,
+          std::enable_if_t<std::is_base_of_v<mlir::Value, T>, int> = 0>
+inline auto getTypeOrValue(T value) {
+  using Type = decltype(value.getType());
+  if (value == nullptr)
+    return Type();
+  return value.getType();
+}
+/// Helper to passthrough values that are not MLIR Values.
+template <typename T,
+          std::enable_if_t<!std::is_base_of_v<mlir::Value, T>, int> = 0>
+inline T &&getTypeOrValue(T &&value) {
+  return std::forward<T>(value);
+}
+
+#endif // ASTER_DIALECT_AMDGCN_IR_INST_METHOD_UTILS_H

--- a/lib/Dialect/AMDGCN/IR/InstOpsCommon.h
+++ b/lib/Dialect/AMDGCN/IR/InstOpsCommon.h
@@ -1,0 +1,16 @@
+//===- InstOpsCommon.h - common includes for inst op translation units ----===//
+//
+// Copyright 2025 The ASTER Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ASTER_DIALECT_AMDGCN_IR_INST_OPS_COMMON_H
+#define ASTER_DIALECT_AMDGCN_IR_INST_OPS_COMMON_H
+
+#include "InstMethodUtils.h"
+
+#endif // ASTER_DIALECT_AMDGCN_IR_INST_OPS_COMMON_H

--- a/lib/Dialect/AMDGCN/IR/MMAOps.cpp
+++ b/lib/Dialect/AMDGCN/IR/MMAOps.cpp
@@ -1,0 +1,17 @@
+//===- MMAOps.cpp - AMDGCN MMA instructions -------------------------------===//
+//
+// Copyright 2025 The ASTER Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "InstOpsCommon.h"
+
+#define GET_OP_CLASSES
+#include "aster/Dialect/AMDGCN/IR/MMA.cpp.inc"
+
+#define AMDGCN_GEN_INST_METHODS
+#include "aster/Dialect/AMDGCN/IR/MMAInst.cpp.inc"

--- a/lib/Dialect/AMDGCN/IR/OpAsmUtils.cpp
+++ b/lib/Dialect/AMDGCN/IR/OpAsmUtils.cpp
@@ -1,0 +1,83 @@
+//===- OpAsmUtils.cpp - AMDGCN assembly parse/print helpers ---------------===//
+//
+// Copyright 2025 The ASTER Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "aster/Dialect/AMDGCN/IR/OpAsmUtils.h"
+#include "llvm/ADT/StringExtras.h"
+
+using namespace mlir;
+using namespace mlir::aster;
+using namespace mlir::aster::amdgcn;
+
+ParseResult amdgcn::parseDimAttr(OpAsmParser &parser, DimAttr &attr) {
+  StringRef keyword;
+  if (parser.parseKeyword(&keyword))
+    return failure();
+
+  auto dimOpt = symbolizeDim(keyword);
+  if (!dimOpt)
+    return parser.emitError(parser.getCurrentLocation(), "invalid dimension: ")
+           << keyword;
+
+  attr = DimAttr::get(parser.getBuilder().getContext(), *dimOpt);
+  return success();
+}
+
+void amdgcn::printDimAttr(OpAsmPrinter &printer, Operation *, DimAttr attr) {
+  printer << stringifyDim(attr.getValue());
+}
+
+ParseResult amdgcn::parseLoadResults(OpAsmParser &parser, Type destType,
+                                     Type &destResType, Type &tokenType) {
+  auto regTy = dyn_cast<RegisterTypeInterface>(destType);
+  if (regTy && regTy.hasValueSemantics())
+    destResType = destType;
+  if (parser.parseType(tokenType))
+    return failure();
+  return success();
+}
+
+void amdgcn::printLoadResults(OpAsmPrinter &printer, Operation *, Type destType,
+                              Type destResType, Type tokenType) {
+  (void)destType;
+  (void)destResType;
+  printer.printType(tokenType);
+}
+
+ParseResult amdgcn::parseAllocSize(
+    OpAsmParser &parser,
+    std::optional<OpAsmParser::UnresolvedOperand> &dynamicSize,
+    IntegerAttr &staticSize) {
+  int64_t intVal;
+  auto intRes = parser.parseOptionalInteger(intVal);
+  if (intRes.has_value()) {
+    if (failed(*intRes))
+      return failure();
+    staticSize = parser.getBuilder().getI64IntegerAttr(intVal);
+    dynamicSize = std::nullopt;
+    return success();
+  }
+
+  OpAsmParser::UnresolvedOperand operand;
+  if (parser.parseOperand(operand))
+    return failure();
+  dynamicSize = operand;
+  staticSize = parser.getBuilder().getI64IntegerAttr(ShapedType::kDynamic);
+  return success();
+}
+
+void amdgcn::printAllocSize(OpAsmPrinter &printer, Operation *op,
+                            Value dynamicSize, IntegerAttr staticSize) {
+  (void)op;
+  if (ShapedType::isDynamic(staticSize.getInt())) {
+    printer.printOperand(dynamicSize);
+    return;
+  }
+  printer << staticSize.getInt();
+}

--- a/lib/Dialect/AMDGCN/IR/SMemOps.cpp
+++ b/lib/Dialect/AMDGCN/IR/SMemOps.cpp
@@ -1,0 +1,18 @@
+//===- SMemOps.cpp - AMDGCN scalar memory instructions --------------------===//
+//
+// Copyright 2025 The ASTER Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "InstOpsCommon.h"
+#include "aster/Dialect/AMDGCN/IR/OpAsmUtils.h"
+
+#define GET_OP_CLASSES
+#include "aster/Dialect/AMDGCN/IR/SMem.cpp.inc"
+
+#define AMDGCN_GEN_INST_METHODS
+#include "aster/Dialect/AMDGCN/IR/SMemInst.cpp.inc"

--- a/lib/Dialect/AMDGCN/IR/SOPOps.cpp
+++ b/lib/Dialect/AMDGCN/IR/SOPOps.cpp
@@ -1,0 +1,18 @@
+//===- SOPOps.cpp - AMDGCN SOP instructions
+//---------------------------------===//
+//
+// Copyright 2025 The ASTER Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "InstOpsCommon.h"
+
+#define GET_OP_CLASSES
+#include "aster/Dialect/AMDGCN/IR/SOP.cpp.inc"
+
+#define AMDGCN_GEN_INST_METHODS
+#include "aster/Dialect/AMDGCN/IR/SOPInst.cpp.inc"

--- a/lib/Dialect/AMDGCN/IR/Utils.cpp
+++ b/lib/Dialect/AMDGCN/IR/Utils.cpp
@@ -163,6 +163,14 @@ bool mlir::aster::amdgcn::isWave32(Target target) {
   return isWave32(getIsaForTarget(target));
 }
 
+bool mlir::aster::amdgcn::needsSplitBarriers(ISAVersion isa) {
+  return isa == ISAVersion::GFX12_50;
+}
+
+bool mlir::aster::amdgcn::needsSplitBarriers(Target target) {
+  return needsSplitBarriers(getIsaForTarget(target));
+}
+
 bool mlir::aster::amdgcn::isWave32(Operation *op) {
   if (auto module = op->getParentOfType<amdgcn::ModuleOp>())
     return isWave32(module.getTarget());

--- a/lib/Dialect/AMDGCN/IR/VMemOps.cpp
+++ b/lib/Dialect/AMDGCN/IR/VMemOps.cpp
@@ -1,0 +1,18 @@
+//===- VMemOps.cpp - AMDGCN vector memory instructions --------------------===//
+//
+// Copyright 2025 The ASTER Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "InstOpsCommon.h"
+#include "aster/Dialect/AMDGCN/IR/OpAsmUtils.h"
+
+#define GET_OP_CLASSES
+#include "aster/Dialect/AMDGCN/IR/VMem.cpp.inc"
+
+#define AMDGCN_GEN_INST_METHODS
+#include "aster/Dialect/AMDGCN/IR/VMemInst.cpp.inc"

--- a/lib/Dialect/AMDGCN/IR/VOPOps.cpp
+++ b/lib/Dialect/AMDGCN/IR/VOPOps.cpp
@@ -1,0 +1,18 @@
+//===- VOPOps.cpp - AMDGCN VOP instructions
+//---------------------------------===//
+//
+// Copyright 2025 The ASTER Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "InstOpsCommon.h"
+
+#define GET_OP_CLASSES
+#include "aster/Dialect/AMDGCN/IR/VOP.cpp.inc"
+
+#define AMDGCN_GEN_INST_METHODS
+#include "aster/Dialect/AMDGCN/IR/VOPInst.cpp.inc"

--- a/lib/Dialect/AMDGCN/IR/WMMAOps.cpp
+++ b/lib/Dialect/AMDGCN/IR/WMMAOps.cpp
@@ -1,0 +1,17 @@
+//===- WMMAOps.cpp - AMDGCN WMMA instructions -----------------------------===//
+//
+// Copyright 2025 The ASTER Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "InstOpsCommon.h"
+
+#define GET_OP_CLASSES
+#include "aster/Dialect/AMDGCN/IR/WMMA.cpp.inc"
+
+#define AMDGCN_GEN_INST_METHODS
+#include "aster/Dialect/AMDGCN/IR/WMMAInst.cpp.inc"

--- a/lib/Dialect/AMDGCN/Scheduler/GraphBuilderAttrs.cpp
+++ b/lib/Dialect/AMDGCN/Scheduler/GraphBuilderAttrs.cpp
@@ -13,6 +13,7 @@
 #include "aster/Dialect/AMDGCN/IR/AMDGCNOps.h"
 #include "aster/Dialect/AMDGCN/IR/Interfaces/AMDGCNInterfaces.h"
 #include "aster/Dialect/AMDGCN/IR/Utils.h"
+#include "aster/Interfaces/DependentOpInterface.h"
 #include "aster/Interfaces/SchedInterfaces.h"
 #include "mlir/Analysis/DataFlowFramework.h"
 #include "mlir/Analysis/SliceAnalysis.h"
@@ -55,9 +56,11 @@ private:
   /// Handle a wait operation.
   void handleWaitOp(SchedGraph &graph, int64_t pos, WaitCntOpInterface wait);
 
-  /// Handle a barrier operation. With barriers we must add dependencies before
-  /// and after if the operation affects SALU or SGPRs.
-  void handleBarrier(SchedGraph &graph, int64_t pos, Operation *barrier);
+  /// Conservative pinning for hardware s_barrier.
+  void handleSBarrier(SchedGraph &graph, int64_t pos, SBarrier barrier);
+
+  /// Serialize barrier ops in program order.
+  void addBarrierSerializationEdges(SchedGraph &graph);
 
   /// Add serialization edges for i1-producing ops within a block.
   void addI1SerializationEdges(SchedGraph &graph);
@@ -223,8 +226,13 @@ void GraphBuilder::buildNonSSADeps(SchedGraph &graph) {
       continue;
     }
     if (auto barrierOp = dyn_cast<SBarrier>(op)) {
-      handleBarrier(graph, i, barrierOp);
+      handleSBarrier(graph, i, barrierOp);
       // Mark the sync point as processed.
+      i = -1;
+      continue;
+    }
+    // Cross-wave ordering is entirely SSA, nothing to add here.
+    if (isa<CrossWaveTokenBarrierOp>(op)) {
       i = -1;
       continue;
     }
@@ -232,6 +240,8 @@ void GraphBuilder::buildNonSSADeps(SchedGraph &graph) {
 
   // Erase all the processed sync points.
   llvm::erase(syncPoints, -1);
+
+  addBarrierSerializationEdges(graph);
 
   // Add fence edges for the remaining sync points: every preceding op in
   // the segment must precede the sync point, and every following op in the
@@ -266,10 +276,6 @@ static bool isTokenOfKind(Type type, MemoryInstructionKind kind) {
   if (auto wt = dyn_cast<WriteTokenType>(type))
     return wt.getKind() == kind;
   return false;
-}
-
-static bool isFlatToken(Type type) {
-  return isTokenOfKind(type, MemoryInstructionKind::Flat);
 }
 
 static bool isLgkmToken(Type type) {
@@ -352,8 +358,8 @@ void GraphBuilder::handleWaitOp(SchedGraph &graph, int64_t pos,
   }
 }
 
-void GraphBuilder::handleBarrier(SchedGraph &graph, int64_t pos,
-                                 Operation *barrier) {
+void GraphBuilder::handleSBarrier(SchedGraph &graph, int64_t pos,
+                                  SBarrier barrier) {
   // Direction depends on whether op is a predecessor or successor of the
   // barrier.
   auto addEdge = [&](Operation *op, int64_t i) {
@@ -363,12 +369,15 @@ void GraphBuilder::handleBarrier(SchedGraph &graph, int64_t pos,
       graph.addEdge(barrier, op);
   };
 
+  // TODO: Gradually phase off these heuristics as we encourage finer-grained
+  // barrier usage.
+
   // Iterate over all the operations in the graph.
   for (auto opIndex : llvm::enumerate(graph.getOps())) {
     Operation *op = opIndex.value();
     int64_t i = opIndex.index();
 
-    // Skip itself.
+    // Skip self.
     if (op == barrier)
       continue;
 
@@ -386,6 +395,7 @@ void GraphBuilder::handleBarrier(SchedGraph &graph, int64_t pos,
       addEdge(op, i);
       continue;
     }
+
     // Pin DS and VMEM ops to barriers (s_barrier is a memory fence).
     if (instOp.hasAnyProps({InstProp::Ds, InstProp::IsVmem})) {
       addEdge(op, i);
@@ -398,6 +408,17 @@ void GraphBuilder::handleBarrier(SchedGraph &graph, int64_t pos,
     });
     if (hasSGPROut)
       addEdge(op, i);
+  }
+}
+
+void GraphBuilder::addBarrierSerializationEdges(SchedGraph &graph) {
+  Operation *prevBarrier = nullptr;
+  for (Operation &op : *block) {
+    if (!isa<BarrierOpInterface>(op))
+      continue;
+    if (prevBarrier)
+      graph.addEdge(prevBarrier, &op);
+    prevBarrier = &op;
   }
 }
 

--- a/lib/Dialect/AMDGCN/Scheduler/SchedulerAttrs.cpp
+++ b/lib/Dialect/AMDGCN/Scheduler/SchedulerAttrs.cpp
@@ -14,6 +14,7 @@
 #include "aster/Dialect/AMDGCN/IR/Utils.h"
 #include "aster/Dialect/AMDGCN/Scheduler/Scheduler.h"
 #include "aster/Dialect/AMDGCN/Scheduler/SchedulerCostModel.h"
+#include "aster/Interfaces/DependentOpInterface.h"
 #include "aster/Interfaces/SchedInterfaces.h"
 #include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/IR/MLIRContext.h"
@@ -371,7 +372,7 @@ BarrierClosures BarrierClosures::create(const SchedGraph &schedGraph) {
   result.containingBarriers.resize(schedGraph.sizeNodes());
 
   for (int32_t b = 0; b < schedGraph.sizeNodes(); ++b) {
-    if (!isa<SBarrier>(schedGraph.getOp(b)))
+    if (!isa<BarrierOpInterface>(schedGraph.getOp(b)))
       continue;
     DenseSet<int32_t> closure = schedGraph.bfs(b, /*reverseOrder=*/true);
     int32_t memCount = 0;
@@ -387,7 +388,7 @@ BarrierClosures BarrierClosures::create(const SchedGraph &schedGraph) {
 }
 
 void BarrierClosures::markIssued(const SchedGraph &schedGraph, int32_t nodeId) {
-  if (isa<SBarrier>(schedGraph.getOp(nodeId))) {
+  if (isa<BarrierOpInterface>(schedGraph.getOp(nodeId))) {
     unscheduledMemPreds.erase(nodeId);
   } else if (isMemoryNode(schedGraph, nodeId)) {
     for (int32_t b : containingBarriers[nodeId]) {

--- a/lib/Dialect/AMDGCN/Scheduler/SchedulerAttrs.cpp
+++ b/lib/Dialect/AMDGCN/Scheduler/SchedulerAttrs.cpp
@@ -469,7 +469,17 @@ static int computeScore(QueueType qt, int64_t stall, const SchedState &s,
     score -= perOccPenalty * recentCount;
   }
 
-  // 3a. VALU/SALU <-> LGKM/VMEM adjacency requires an 8-cycle NOP.
+  // 3a. Hard cap on consecutive MFMA (deterministic spread dial).
+  if (qt == QueueType::XDL && L.xdlMaxRun > 0) {
+    int trailingXdl = 0;
+    for (auto it = recent.rbegin();
+         it != recent.rend() && *it == QueueType::XDL; ++it)
+      ++trailingXdl;
+    if (trailingXdl >= L.xdlMaxRun)
+      score -= 100000;
+  }
+
+  // 3b. VALU/SALU <-> LGKM/VMEM adjacency requires an 8-cycle NOP.
   QueueType prevKind = recent.empty() ? QueueType::Unknown : recent.back();
   if ((qt == QueueType::VALU &&
        (prevKind == QueueType::LGKM || prevKind == QueueType::VMEM)) ||
@@ -482,18 +492,18 @@ static int computeScore(QueueType qt, int64_t stall, const SchedState &s,
        prevKind == QueueType::SALU))
     score -= L.adjacencyPenalty;
 
-  // 3b. VMEM-load density cap on the L1/L2 read path; stores skip it.
+  // 3c. VMEM-load density cap on the L1/L2 read path; stores skip it.
   if (qt == QueueType::VMEM && !isVmemStore) {
     int vmemInWindow = static_cast<int>(llvm::count(recent, QueueType::VMEM));
     if (vmemInWindow >= L.vmemInWindowLimit)
       score -= L.vmemDensityPenalty;
   }
 
-  // 5. Fire XDL whose LGKM producer is waiting on it to drain.
+  // 4. Fire XDL whose LGKM producer is waiting on it to drain.
   if (qt == QueueType::XDL && consumerInReady)
     score += L.consumerReadyBonus;
 
-  // 6. Wait deferral: stall ~= max(0, latency - opsSince * hideTimePerOp).
+  // 5. Wait deferral: stall ~= max(0, latency - opsSince * hideTimePerOp).
   if (waitKind != 0 && qt == QueueType::Unknown) {
     auto opsSince = [&](QueueType q) -> int {
       for (size_t i = 0; i < recent.size(); ++i) {
@@ -514,19 +524,19 @@ static int computeScore(QueueType qt, int64_t stall, const SchedState &s,
     }
   }
 
-  // 7. VMCNT 4-bit saturation cap.
+  // 6. VMCNT 4-bit saturation cap.
   if (qt == QueueType::VMEM && s.outstandingVmem >= L.vmemSaturationThreshold)
     score -= L.vmemSaturationPenalty;
 
-  // 8. VMEM store bonus (uncapped; saturation penalty above damps it).
+  // 7. VMEM store bonus (uncapped; saturation penalty above damps it).
   if (isVmemStore && qt == QueueType::VMEM)
     score += L.vmemStoreBonus;
 
-  // 9. VMEM store-feeder bonus (any op transitively feeding a store).
+  // 8. VMEM store-feeder bonus (any op transitively feeding a store).
   if (isVmemStoreFeeder)
     score += L.vmemStoreFeederBonus;
 
-  // 10. XDL chain-continuation stall estimate (RAW on accumulator).
+  // 9. XDL chain-continuation stall estimate (RAW on accumulator).
   if (isXdlChainContinuation)
     score -= L.xdlChainStallEstimate;
 

--- a/lib/Dialect/AMDGCN/Scheduler/SchedulerCostModel.cpp
+++ b/lib/Dialect/AMDGCN/Scheduler/SchedulerCostModel.cpp
@@ -53,6 +53,44 @@ struct CDNA4Latencies : CDNA3Latencies {
   CDNA4Latencies() {}
 };
 
+/// MFMA interleaving control.
+struct CDNA3PresetMfmaInterleave1 : CDNA3PresetMfmaHiding {
+  CDNA3PresetMfmaInterleave1() { xdlBurstLookback = 4; }
+};
+struct CDNA4PresetMfmaInterleave1 : CDNA4Latencies {
+  CDNA4PresetMfmaInterleave1() { xdlBurstLookback = 4; }
+};
+struct CDNA3PresetMfmaInterleave2 : CDNA3PresetMfmaHiding {
+  CDNA3PresetMfmaInterleave2() { xdlBurstLookback = 4; }
+};
+struct CDNA4PresetMfmaInterleave2 : CDNA4Latencies {
+  CDNA4PresetMfmaInterleave2() { xdlBurstLookback = 4; }
+};
+struct CDNA3PresetMfmaInterleave3 : CDNA3PresetMfmaHiding {
+  CDNA3PresetMfmaInterleave3() { xdlMaxRun = 8; }
+};
+struct CDNA4PresetMfmaInterleave3 : CDNA4Latencies {
+  CDNA4PresetMfmaInterleave3() { xdlMaxRun = 8; }
+};
+struct CDNA3PresetMfmaInterleave4 : CDNA3PresetMfmaHiding {
+  CDNA3PresetMfmaInterleave4() { xdlMaxRun = 4; }
+};
+struct CDNA4PresetMfmaInterleave4 : CDNA4Latencies {
+  CDNA4PresetMfmaInterleave4() { xdlMaxRun = 4; }
+};
+struct CDNA3PresetMfmaInterleave5 : CDNA3PresetMfmaHiding {
+  CDNA3PresetMfmaInterleave5() {
+    xdlBurstLookback = 1;
+    xdlBurstPenalty = 100000;
+  }
+};
+struct CDNA4PresetMfmaInterleave5 : CDNA4Latencies {
+  CDNA4PresetMfmaInterleave5() {
+    xdlBurstLookback = 1;
+    xdlBurstPenalty = 100000;
+  }
+};
+
 /// Per-opcode XDL exec latency from CDNA3 ISA Table 28 (MI300 manual p.42)
 /// and CDNA4 ISA Table 28 (gfx950 manual p.43).
 /// Returns 0 if the opcode is not an XDL instruction we model specifically.
@@ -138,13 +176,37 @@ QueueType classifyOp(Operation *op) {
 ///
 /// `preset` selects a pre-tuned magic-number set:
 ///   1 = mfma-hiding default
-///   2..N = future presets (add a new struct above + a new case here).
+///   2..4 = progressively more MFMA interleaving (wider XDL burst lookback)
+///   5 = maximal MFMA spread (<=1 consecutive MFMA if non-MFMA work is ready)
 CDNA3Latencies latencies(ISAVersion isa, int preset) {
-  if (isa == ISAVersion::CDNA4 || isa == ISAVersion::GFX12_50)
-    return CDNA4Latencies(); // GFX12.5: CDNA4 placeholder until profiled.
+  if (isa == ISAVersion::CDNA4 || isa == ISAVersion::GFX12_50) {
+    // GFX12.5: CDNA4 placeholder until profiled.
+    switch (preset) {
+    case 1:
+      return CDNA4PresetMfmaInterleave1();
+    case 2:
+      return CDNA4PresetMfmaInterleave2();
+    case 3:
+      return CDNA4PresetMfmaInterleave3();
+    case 4:
+      return CDNA4PresetMfmaInterleave4();
+    case 5:
+      return CDNA4PresetMfmaInterleave5();
+    default:
+      return CDNA4Latencies();
+    }
+  }
   switch (preset) {
   case 1:
-    return CDNA3PresetMfmaHiding();
+    return CDNA3PresetMfmaInterleave1();
+  case 2:
+    return CDNA3PresetMfmaInterleave2();
+  case 3:
+    return CDNA3PresetMfmaInterleave3();
+  case 4:
+    return CDNA3PresetMfmaInterleave4();
+  case 5:
+    return CDNA3PresetMfmaInterleave5();
   default:
     return CDNA3PresetMfmaHiding();
   }

--- a/lib/Dialect/AMDGCN/Transforms/ConvertWaits.cpp
+++ b/lib/Dialect/AMDGCN/Transforms/ConvertWaits.cpp
@@ -13,6 +13,7 @@
 #include "aster/Dialect/AMDGCN/IR/AMDGCNTypes.h"
 #include "aster/Dialect/AMDGCN/IR/Utils.h"
 #include "aster/Dialect/AMDGCN/Transforms/Passes.h"
+#include "aster/Interfaces/DependentOpInterface.h"
 #include "mlir/Analysis/DataFlow/Utils.h"
 #include "mlir/Dialect/UB/IR/UBOps.h"
 #include "mlir/IR/Builders.h"
@@ -50,7 +51,8 @@ public:
 /// store+ds) fuse into the combined s_wait_{load,store}cnt_dscnt form; loadcnt
 /// takes priority for the ds pairing; km and tensor never fuse.
 static void rewriteGfx1250Wait(IRRewriter &rewriter, Operation *waitOpOp,
-                               const WaitCnt &counts) {
+                               const WaitCnt &counts,
+                               SmallVectorImpl<Operation *> &toErase) {
   Location loc = waitOpOp->getLoc();
   const WaitCntGfx1250 &c = std::get<WaitCntGfx1250>(counts);
   auto get = [&](WaitCounterKind s) { return c.getCount(s); };
@@ -78,28 +80,32 @@ static void rewriteGfx1250Wait(IRRewriter &rewriter, Operation *waitOpOp,
   if (present(get(WaitCounterKind::Tensor)))
     SWaitTensorcnt::create(rewriter, loc)
         .setCount(get(WaitCounterKind::Tensor));
-  rewriter.eraseOp(waitOpOp);
+  toErase.push_back(waitOpOp);
 }
 
 /// Rewrite a CDNA wait op to a single s_waitcnt with merged vm/lgkm counts.
 static void rewriteCdnaWait(IRRewriter &rewriter, Operation *waitOpOp,
-                            const WaitCnt &counts) {
+                            const WaitCnt &counts,
+                            SmallVectorImpl<Operation *> &toErase) {
   auto present = [](int32_t c) { return c < TokenState::kMaxPosition; };
   const WaitCntCdna3 &c = std::get<WaitCntCdna3>(counts);
   int32_t vm = c.vmcnt;
   int32_t lgkm = c.lgkmcnt;
   bool hasVm = present(vm), hasLgkm = present(lgkm);
+  // Create the s_waitcnt without optional fence_token then mark the wait for
+  // erasure.
   if (!hasVm && !hasLgkm) {
-    rewriter.eraseOp(waitOpOp);
+    toErase.push_back(waitOpOp);
     return;
   }
-  auto newWait = rewriter.replaceOpWithNewOp<SWaitcnt>(waitOpOp);
+  auto newWait = SWaitcnt::create(rewriter, waitOpOp->getLoc());
   if (hasVm)
     newWait.setVmcnt(
         std::min(static_cast<int32_t>(newWait.getVmcnt()) - 1, vm));
   if (hasLgkm)
     newWait.setLgkmcnt(
         std::min(static_cast<int32_t>(newWait.getLgkmcnt()) - 1, lgkm));
+  toErase.push_back(waitOpOp);
 }
 
 /// Run the wait analysis on `root` with `model`, then rewrite every wait op
@@ -113,20 +119,42 @@ static LogicalResult convertWaitsOn(Operation *root, ISAVersion isaVersion,
     root->emitError() << "failed to run wait analysis";
     return failure();
   }
+  // Note: FenceToken return values disappear during legalization; strip
+  // consumer fence_token operands before erasing wait/barrier producers.
+  SmallVector<Operation *> toErase;
   IRRewriter rewriter(root->getContext());
   root->walk([&](WaitCntOpInterface waitOp) {
-    Operation *waitOpOp = waitOp.getOperation();
     const auto *afterState =
-        solver.lookupState<WaitState>(solver.getProgramPointAfter(waitOpOp));
+        solver.lookupState<WaitState>(solver.getProgramPointAfter(waitOp));
     assert(afterState &&
            "expected valid wait analysis states before and after wait op");
     OpBuilder::InsertionGuard guard(rewriter);
-    rewriter.setInsertionPoint(waitOpOp);
-    if (isa<WaitGfx1250Op>(waitOpOp))
-      rewriteGfx1250Wait(rewriter, waitOpOp, afterState->waitOpInfo->counts);
+    rewriter.setInsertionPoint(waitOp);
+    const WaitCnt &counts = afterState->waitOpInfo->counts;
+    if (isa<WaitGfx1250Op>(waitOp))
+      rewriteGfx1250Wait(rewriter, waitOp, counts, toErase);
     else
-      rewriteCdnaWait(rewriter, waitOpOp, afterState->waitOpInfo->counts);
+      rewriteCdnaWait(rewriter, waitOp, counts, toErase);
   });
+  root->walk([&](CrossWaveTokenBarrierOp barrier) {
+    rewriter.setInsertionPoint(barrier);
+    if (needsSplitBarriers(isaVersion)) {
+      SBarrierSignal::create(rewriter, barrier.getLoc(),
+                             static_cast<uint16_t>(-1));
+      SBarrierWait::create(rewriter, barrier.getLoc(),
+                           static_cast<uint16_t>(-1));
+    } else {
+      SBarrier::create(rewriter, barrier.getLoc());
+    }
+    toErase.push_back(barrier);
+  });
+  root->walk([&](FenceableOpInterface fenceable) {
+    if (!fenceable.hasFenceToken())
+      return;
+    rewriter.modifyOpInPlace(fenceable, [&]() { fenceable.eraseFence(); });
+  });
+  for (Operation *op : llvm::reverse(toErase))
+    rewriter.eraseOp(op);
   return success();
 }
 

--- a/lib/Dialect/AMDGCN/Transforms/ToAMDGCNPatterns.cpp
+++ b/lib/Dialect/AMDGCN/Transforms/ToAMDGCNPatterns.cpp
@@ -894,19 +894,29 @@ LogicalResult LoadOpPattern::matchAndRewrite(lsir::LoadOp op,
                                          "for load from shared memory space");
     }
     offset = getI32Constant(rewriter, loc, off);
+    // Trailing optionals (gds, fence_token): no GDS flag, no fence token.
+    UnitAttr noGds = {};
+    Value noFenceToken = {};
     switch (numWords) {
     case 1:
-      result = DsReadB32::create(rewriter, loc, dst, addr, offset).getDestRes();
+      result = DsReadB32::create(rewriter, loc, dst, addr, offset, noGds,
+                                 noFenceToken)
+                   .getDestRes();
       break;
     case 2:
-      result = DsReadB64::create(rewriter, loc, dst, addr, offset).getDestRes();
+      result = DsReadB64::create(rewriter, loc, dst, addr, offset, noGds,
+                                 noFenceToken)
+                   .getDestRes();
       break;
     case 3:
-      result = DsReadB96::create(rewriter, loc, dst, addr, offset).getDestRes();
+      result = DsReadB96::create(rewriter, loc, dst, addr, offset, noGds,
+                                 noFenceToken)
+                   .getDestRes();
       break;
     case 4:
-      result =
-          DsReadB128::create(rewriter, loc, dst, addr, offset).getDestRes();
+      result = DsReadB128::create(rewriter, loc, dst, addr, offset, noGds,
+                                  noFenceToken)
+                   .getDestRes();
       break;
     default:
       return rewriter.notifyMatchFailure(

--- a/lib/Target/ASM/TranslateModule.cpp
+++ b/lib/Target/ASM/TranslateModule.cpp
@@ -624,8 +624,14 @@ LogicalResult mlir::aster::amdgcn::target::translateModule(
   // automatically, making the CF/LSIR allow-list from that verifier redundant.
   AllRegistersAllocatedAttr allocated =
       AllRegistersAllocatedAttr::get(module.getContext());
+  // Dependency tokens are IR-only scheduling/wait metadata; no token consumer
+  // (amdgcn.wait, amdgcn.cross_wave_token_barrier) may survive to assembly.
+  NoDependencyTokensAttr noTokens =
+      NoDependencyTokensAttr::get(module.getContext());
   for (KernelOp kernel : module.getOps<KernelOp>()) {
     if (failed(allocated.checkOperation(kernel).checkAndReport()))
+      return failure();
+    if (failed(noTokens.checkOperation(kernel).checkAndReport()))
       return failure();
     if (failed(check64BitImmediates(kernel)))
       return failure();

--- a/mlir_kernels/library/common/futures.mlir
+++ b/mlir_kernels/library/common/futures.mlir
@@ -22,7 +22,7 @@ amdgcn.library @common_futures isa = [#amdgcn.isa<cdna3>] {
 
   func.func private @get_global_load_value_vx2(%future: !future_global_read_any) -> !vx2 {
     %value_any, %token = aster_utils.struct_extract %future ["value", "token"] : !future_global_read_any -> !aster_utils.any, !amdgcn.read_token<flat>
-    amdgcn.wait deps %token : !amdgcn.read_token<flat>
+    %wf0 = amdgcn.wait deps %token : !amdgcn.read_token<flat> -> !amdgcn.fence_token
     %value = aster_utils.from_any %value_any : !vx2
     return %value : !vx2
   }
@@ -32,14 +32,14 @@ amdgcn.library @common_futures isa = [#amdgcn.isa<cdna3>] {
     %future = memref.load %futures[%idx] : memref<?x!future_global_read_any>
     %value_any, %token = aster_utils.struct_extract %future ["value", "token"]
       : !future_global_read_any -> !aster_utils.any, !amdgcn.read_token<flat>
-    amdgcn.wait deps %token : !amdgcn.read_token<flat>
+    %wf1 = amdgcn.wait deps %token : !amdgcn.read_token<flat> -> !amdgcn.fence_token
     %value = aster_utils.from_any %value_any : !vx2
     return %value : !vx2
   }
 
   func.func private @get_lds_read_value_vx2(%future: !future_lds_read_any) -> !vx2 {
     %value_any, %token = aster_utils.struct_extract %future ["value", "token"] : !future_lds_read_any -> !aster_utils.any, !amdgcn.read_token<shared>
-    amdgcn.wait deps %token : !amdgcn.read_token<shared>
+    %wf2 = amdgcn.wait deps %token : !amdgcn.read_token<shared> -> !amdgcn.fence_token
     %value = aster_utils.from_any %value_any : !vx2
     return %value : !vx2
   }
@@ -49,20 +49,20 @@ amdgcn.library @common_futures isa = [#amdgcn.isa<cdna3>] {
     %future = memref.load %futures[%idx] : memref<?x!future_lds_read_any>
     %value_any, %token = aster_utils.struct_extract %future ["value", "token"]
       : !future_lds_read_any -> !aster_utils.any, !amdgcn.read_token<shared>
-    amdgcn.wait deps %token : !amdgcn.read_token<shared>
+    %wf3 = amdgcn.wait deps %token : !amdgcn.read_token<shared> -> !amdgcn.fence_token
     %value = aster_utils.from_any %value_any : !vx2
     return %value : !vx2
   }
 
   func.func private @get_global_load_value_vx4(%future: !future_global_read_any) -> !vx4 {
     %value_any, %token = aster_utils.struct_extract %future ["value", "token"] : !future_global_read_any -> !aster_utils.any, !amdgcn.read_token<flat>
-    amdgcn.wait deps %token : !amdgcn.read_token<flat>
+    %wf4 = amdgcn.wait deps %token : !amdgcn.read_token<flat> -> !amdgcn.fence_token
     %value = aster_utils.from_any %value_any : !vx4
     return %value : !vx4
   }
 
   func.func private @wait_lds_write(%token: !future_lds_write) {
-    amdgcn.wait deps %token : !amdgcn.write_token<shared>
+    %wf5 = amdgcn.wait deps %token : !amdgcn.write_token<shared> -> !amdgcn.fence_token
     return
   }
 }

--- a/mlir_kernels/test/unit/test_loops.mlir
+++ b/mlir_kernels/test/unit/test_loops.mlir
@@ -4,11 +4,11 @@ amdgcn.module @test_uniform_loop target = <gfx942> {
   kernel @test_uniform_loop arguments <[#amdgcn.buffer_arg<address_space = generic, access = read_only>, #amdgcn.buffer_arg<address_space = generic>]> {
     %0 = load_arg 0 : !amdgcn.sgpr<[? + 2]>
     %1 = load_arg 1 : !amdgcn.sgpr<[? + 2]>
-    wait lgkm_cnt 0
+    %wf0 = wait lgkm_cnt 0 -> !amdgcn.fence_token
     %2 = alloca : !amdgcn.sgpr
     %c0_i32_mig1 = arith.constant 0 : i32
     %result, %token = amdgcn.s_load_dword dest %2 addr %0 offset c(%c0_i32_mig1) : outs(!amdgcn.sgpr) ins(!amdgcn.sgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<constant>
-    wait deps %token : !amdgcn.read_token<constant>
+    %wf1 = wait deps %token : !amdgcn.read_token<constant> -> !amdgcn.fence_token
     %3 = lsir.from_reg %result : !amdgcn.sgpr -> i32
     %c0_i32 = arith.constant 0 : i32
     %c1_i32 = arith.constant 1 : i32

--- a/mlir_kernels/test/unit/test_scf_pipeline.mlir
+++ b/mlir_kernels/test/unit/test_scf_pipeline.mlir
@@ -12,7 +12,7 @@ amdgcn.module @test_two_stage_no_iv target = <gfx942> {
     #amdgcn.buffer_arg<address_space = generic, access = read_write>
   ]> {
     %out_ptr = load_arg 0 : !sx2
-    wait lgkm_cnt 0
+    %wf = wait lgkm_cnt 0 -> !amdgcn.fence_token
 
     %s_store = alloca : !v
 
@@ -49,7 +49,7 @@ amdgcn.module @test_two_stage_iv_s0_only target = <gfx942> {
     #amdgcn.buffer_arg<address_space = generic, access = read_write>
   ]> {
     %out_ptr = load_arg 0 : !sx2
-    wait lgkm_cnt 0
+    %wf = wait lgkm_cnt 0 -> !amdgcn.fence_token
 
     %s_store = alloca : !v
 
@@ -87,7 +87,7 @@ amdgcn.module @test_two_stage_iv_dep target = <gfx942> {
     #amdgcn.buffer_arg<address_space = generic, access = read_write>
   ]> {
     %out_ptr = load_arg 0 : !sx2
-    wait lgkm_cnt 0
+    %wf = wait lgkm_cnt 0 -> !amdgcn.fence_token
 
     %s_val = alloca : !v
     %s_off = alloca : !v
@@ -135,7 +135,7 @@ amdgcn.module @test_five_stage target = <gfx942> {
     #amdgcn.buffer_arg<address_space = generic, access = read_write>
   ]> {
     %out_ptr = load_arg 0 : !sx2
-    wait lgkm_cnt 0
+    %wf = wait lgkm_cnt 0 -> !amdgcn.fence_token
 
     %s0 = alloca : !v
     %s1 = alloca : !v

--- a/mlir_kernels/test/unit/test_scf_pipeline_gaps.mlir
+++ b/mlir_kernels/test/unit/test_scf_pipeline_gaps.mlir
@@ -7,7 +7,7 @@ amdgcn.module @test_gap_0_2 target = <gfx942> {
     #amdgcn.buffer_arg<address_space = generic, access = read_write>
   ]> {
     %out_ptr = load_arg 0 : !sx2
-    wait lgkm_cnt 0
+    %wf = wait lgkm_cnt 0 -> !amdgcn.fence_token
 
     %s_val = alloca : !v
     %s_off = alloca : !v
@@ -44,7 +44,7 @@ amdgcn.module @test_gap_0_3 target = <gfx942> {
     #amdgcn.buffer_arg<address_space = generic, access = read_write>
   ]> {
     %out_ptr = load_arg 0 : !sx2
-    wait lgkm_cnt 0
+    %wf = wait lgkm_cnt 0 -> !amdgcn.fence_token
 
     %s_val = alloca : !v
     %s_off = alloca : !v
@@ -81,7 +81,7 @@ amdgcn.module @test_gap_0_2_5 target = <gfx942> {
     #amdgcn.buffer_arg<address_space = generic, access = read_write>
   ]> {
     %out_ptr = load_arg 0 : !sx2
-    wait lgkm_cnt 0
+    %wf = wait lgkm_cnt 0 -> !amdgcn.fence_token
 
     %s0 = alloca : !v
     %s2 = alloca : !v
@@ -123,7 +123,7 @@ amdgcn.module @test_gap_0_2_iter_args target = <gfx942> {
     #amdgcn.buffer_arg<address_space = generic, access = read_write>
   ]> {
     %out = load_arg 0 : !sx2
-    wait lgkm_cnt 0
+    %wf = wait lgkm_cnt 0 -> !amdgcn.fence_token
 
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index

--- a/mlir_kernels/test/unit/test_scf_pipeline_iter_args.mlir
+++ b/mlir_kernels/test/unit/test_scf_pipeline_iter_args.mlir
@@ -11,7 +11,7 @@ amdgcn.module @test_iter_args_scalar_no_iv target = <gfx942> {
     #amdgcn.buffer_arg<address_space = generic, access = read_write>
   ]> {
     %out = load_arg 0 : !sx2
-    wait lgkm_cnt 0
+    %wf = wait lgkm_cnt 0 -> !amdgcn.fence_token
 
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
@@ -49,7 +49,7 @@ amdgcn.module @test_iter_args_scalar_with_iv target = <gfx942> {
     #amdgcn.buffer_arg<address_space = generic, access = read_write>
   ]> {
     %out = load_arg 0 : !sx2
-    wait lgkm_cnt 0
+    %wf = wait lgkm_cnt 0 -> !amdgcn.fence_token
 
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
@@ -85,7 +85,7 @@ amdgcn.module @test_iter_args_vgpr_no_iv target = <gfx942> {
     #amdgcn.buffer_arg<address_space = generic, access = read_write>
   ]> {
     %out = load_arg 0 : !sx2
-    wait lgkm_cnt 0
+    %wf = wait lgkm_cnt 0 -> !amdgcn.fence_token
 
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
@@ -133,7 +133,7 @@ amdgcn.module @test_iter_args_vgpr_with_iv target = <gfx942> {
     #amdgcn.buffer_arg<address_space = generic, access = read_write>
   ]> {
     %out = load_arg 0 : !sx2
-    wait lgkm_cnt 0
+    %wf = wait lgkm_cnt 0 -> !amdgcn.fence_token
 
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
@@ -177,7 +177,7 @@ amdgcn.module @test_iter_args_vgpr_with_iv target = <gfx942> {
 amdgcn.module @test_scf_pipeline_iter_args target = <gfx942> {
   kernel @test_iter_args arguments <[#amdgcn.buffer_arg<address_space = generic>]> {
     %out = load_arg 0 : !amdgcn.sgpr<[? + 2]>
-    wait lgkm_cnt 0
+    %wf = wait lgkm_cnt 0 -> !amdgcn.fence_token
 
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index

--- a/mlir_kernels/test/unit/test_scf_pipeline_lds.mlir
+++ b/mlir_kernels/test/unit/test_scf_pipeline_lds.mlir
@@ -7,7 +7,7 @@ amdgcn.module @test_lds_passthrough target = <gfx942> {
     #amdgcn.buffer_arg<address_space = generic, access = read_write>
   ]> attributes {shared_memory_size = 1024 : i32} {
     %out_ptr = load_arg 0 : !sx2
-    wait lgkm_cnt 0
+    %wf = wait lgkm_cnt 0 -> !amdgcn.fence_token
 
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
@@ -29,11 +29,11 @@ amdgcn.module @test_lds_passthrough target = <gfx942> {
       %wtok = amdgcn.ds_write_b32 data %val addr %lds_addr offset c(%c0_i32) {sched.stage = 0 : i32} : ins(!v, !v) mods(i32) -> !amdgcn.write_token<shared>
 
       // Stage 1: wait, read back, store to output[0]
-      amdgcn.wait deps %wtok {sched.stage = 1 : i32} : !amdgcn.write_token<shared>
+      %wf0 = amdgcn.wait deps %wtok {sched.stage = 1 : i32} : !amdgcn.write_token<shared> -> !amdgcn.fence_token
       %r_dest = amdgcn.alloca {sched.stage = 1 : i32} : !v
       %c0_i32_mig1 = arith.constant 0 : i32
       %from_lds, %rtok = amdgcn.ds_read_b32 dest %r_dest addr %lds_addr offset c(%c0_i32_mig1) {sched.stage = 1 : i32} : outs(!v) ins(!v) mods(i32) -> !amdgcn.read_token<shared>
-      amdgcn.wait deps %rtok {sched.stage = 1 : i32} : !amdgcn.read_token<shared>
+      %wf1 = amdgcn.wait deps %rtok {sched.stage = 1 : i32} : !amdgcn.read_token<shared> -> !amdgcn.fence_token
 
       // Store to output[0] -- use zero offset for all lanes
       %off_reg = lsir.to_reg %c0_i32 {sched.stage = 1 : i32} : i32 -> !v
@@ -54,7 +54,7 @@ amdgcn.module @test_lds_iv_dep target = <gfx942> {
     #amdgcn.buffer_arg<address_space = generic, access = read_write>
   ]> attributes {shared_memory_size = 1024 : i32} {
     %out_ptr = load_arg 0 : !sx2
-    wait lgkm_cnt 0
+    %wf = wait lgkm_cnt 0 -> !amdgcn.fence_token
 
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
@@ -78,11 +78,11 @@ amdgcn.module @test_lds_iv_dep target = <gfx942> {
       %wtok = amdgcn.ds_write_b32 data %val_reg addr %lds_addr offset c(%c0_i32) {sched.stage = 0 : i32} : ins(!v, !v) mods(i32) -> !amdgcn.write_token<shared>
 
       // Stage 1: wait, read from LDS, store to output[i]
-      amdgcn.wait deps %wtok {sched.stage = 1 : i32} : !amdgcn.write_token<shared>
+      %wf2 = amdgcn.wait deps %wtok {sched.stage = 1 : i32} : !amdgcn.write_token<shared> -> !amdgcn.fence_token
       %r_dest = amdgcn.alloca {sched.stage = 1 : i32} : !v
       %c0_i32_mig2 = arith.constant 0 : i32
       %from_lds, %rtok = amdgcn.ds_read_b32 dest %r_dest addr %lds_addr offset c(%c0_i32_mig2) {sched.stage = 1 : i32} : outs(!v) ins(!v) mods(i32) -> !amdgcn.read_token<shared>
-      amdgcn.wait deps %rtok {sched.stage = 1 : i32} : !amdgcn.read_token<shared>
+      %wf3 = amdgcn.wait deps %rtok {sched.stage = 1 : i32} : !amdgcn.read_token<shared> -> !amdgcn.fence_token
 
       // Store to output[i*4] (byte offset)
       %i_i32_s1 = arith.index_cast %i {sched.stage = 1 : i32} : index to i32
@@ -109,7 +109,7 @@ amdgcn.module @test_lds_six_stage target = <gfx942> {
   ]> attributes {shared_memory_size = 4096 : i32} {
     %in_ptr = load_arg 0 : !sx2
     %out_ptr = load_arg 1 : !sx2
-    wait lgkm_cnt 0
+    %wf = wait lgkm_cnt 0 -> !amdgcn.fence_token
 
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
@@ -137,27 +137,27 @@ amdgcn.module @test_lds_six_stage target = <gfx942> {
       %lds_b_addr = lsir.to_reg %lds_b_off {sched.stage = 0 : i32} : i32 -> !v
 
       // Stage 1: wait for global_load, ds_write to LDS_A
-      amdgcn.wait deps %gltok {sched.stage = 1 : i32} : !amdgcn.read_token<flat>
+      %wf4 = amdgcn.wait deps %gltok {sched.stage = 1 : i32} : !amdgcn.read_token<flat> -> !amdgcn.fence_token
       %wtok_a = amdgcn.ds_write_b32 data %from_global addr %lds_a_addr offset c(%c0_i32) {sched.stage = 1 : i32} : ins(!v, !v) mods(i32) -> !amdgcn.write_token<shared>
 
       // Stage 2: ds_read from LDS_A
-      amdgcn.wait deps %wtok_a {sched.stage = 2 : i32} : !amdgcn.write_token<shared>
+      %wf5 = amdgcn.wait deps %wtok_a {sched.stage = 2 : i32} : !amdgcn.write_token<shared> -> !amdgcn.fence_token
       %d_ra = amdgcn.alloca {sched.stage = 2 : i32} : !v
       %c0_i32_mig3 = arith.constant 0 : i32
       %from_a, %rtok_a = amdgcn.ds_read_b32 dest %d_ra addr %lds_a_addr offset c(%c0_i32_mig3) {sched.stage = 2 : i32} : outs(!v) ins(!v) mods(i32) -> !amdgcn.read_token<shared>
 
       // Stage 3: ds_write to LDS_B
-      amdgcn.wait deps %rtok_a {sched.stage = 3 : i32} : !amdgcn.read_token<shared>
+      %wf6 = amdgcn.wait deps %rtok_a {sched.stage = 3 : i32} : !amdgcn.read_token<shared> -> !amdgcn.fence_token
       %wtok_b = amdgcn.ds_write_b32 data %from_a addr %lds_b_addr offset c(%c0_i32) {sched.stage = 3 : i32} : ins(!v, !v) mods(i32) -> !amdgcn.write_token<shared>
 
       // Stage 4: ds_read from LDS_B
-      amdgcn.wait deps %wtok_b {sched.stage = 4 : i32} : !amdgcn.write_token<shared>
+      %wf7 = amdgcn.wait deps %wtok_b {sched.stage = 4 : i32} : !amdgcn.write_token<shared> -> !amdgcn.fence_token
       %d_rb = amdgcn.alloca {sched.stage = 4 : i32} : !v
       %c0_i32_mig4 = arith.constant 0 : i32
       %from_b, %rtok_b = amdgcn.ds_read_b32 dest %d_rb addr %lds_b_addr offset c(%c0_i32_mig4) {sched.stage = 4 : i32} : outs(!v) ins(!v) mods(i32) -> !amdgcn.read_token<shared>
 
       // Stage 5: global_store to output[i*4], dealloc both LDS
-      amdgcn.wait deps %rtok_b {sched.stage = 5 : i32} : !amdgcn.read_token<shared>
+      %wf8 = amdgcn.wait deps %rtok_b {sched.stage = 5 : i32} : !amdgcn.read_token<shared> -> !amdgcn.fence_token
       %i_i32_s5 = arith.index_cast %i {sched.stage = 5 : i32} : index to i32
       %off_s5 = arith.muli %i_i32_s5, %c4_i32 {sched.stage = 5 : i32} : i32
       %off_reg_s5 = lsir.to_reg %off_s5 {sched.stage = 5 : i32} : i32 -> !v
@@ -179,7 +179,7 @@ amdgcn.module @test_lds_accum target = <gfx942> {
     #amdgcn.buffer_arg<address_space = generic, access = read_write>
   ]> attributes {shared_memory_size = 1024 : i32} {
     %out_ptr = load_arg 0 : !sx2
-    wait lgkm_cnt 0
+    %wf = wait lgkm_cnt 0 -> !amdgcn.fence_token
 
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
@@ -206,11 +206,11 @@ amdgcn.module @test_lds_accum target = <gfx942> {
       %wtok = amdgcn.ds_write_b32 data %val addr %lds_addr offset c(%c0_i32) {sched.stage = 0 : i32} : ins(!v, !v) mods(i32) -> !amdgcn.write_token<shared>
 
       // Stage 1: read from LDS, accumulate
-      amdgcn.wait deps %wtok {sched.stage = 1 : i32} : !amdgcn.write_token<shared>
+      %wf9 = amdgcn.wait deps %wtok {sched.stage = 1 : i32} : !amdgcn.write_token<shared> -> !amdgcn.fence_token
       %r_dest = amdgcn.alloca {sched.stage = 1 : i32} : !v
       %c0_i32_mig5 = arith.constant 0 : i32
       %from_lds, %rtok = amdgcn.ds_read_b32 dest %r_dest addr %lds_addr offset c(%c0_i32_mig5) {sched.stage = 1 : i32} : outs(!v) ins(!v) mods(i32) -> !amdgcn.read_token<shared>
-      amdgcn.wait deps %rtok {sched.stage = 1 : i32} : !amdgcn.read_token<shared>
+      %wf10 = amdgcn.wait deps %rtok {sched.stage = 1 : i32} : !amdgcn.read_token<shared> -> !amdgcn.fence_token
 
       %new_acc = amdgcn.v_add_u32 outs(%d_add)
         ins(%acc, %from_lds) {sched.stage = 1 : i32} : outs(!v) ins(!v, !v)

--- a/mlir_kernels/test/unit/test_struct_promotability.mlir
+++ b/mlir_kernels/test/unit/test_struct_promotability.mlir
@@ -54,7 +54,7 @@ amdgcn.module @test_struct_promotability target = #amdgcn.target<gfx942> {
     %value_any, %token = aster_utils.struct_extract %loaded_future ["value", "token"] : !future_global_read_any -> !aster_utils.any, !amdgcn.read_token<flat>
 
     // Wait on token
-    amdgcn.wait deps %token : !amdgcn.read_token<flat>
+    %wf0 = amdgcn.wait deps %token : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 
     // Convert value back and store to output
     %value = aster_utils.from_any %value_any : !vx2

--- a/python/aster/dialects/kernel_builder.py
+++ b/python/aster/dialects/kernel_builder.py
@@ -24,10 +24,11 @@ The returned module can be passed directly to aster.compiler compile_kernel_modu
 from __future__ import annotations
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import List, Optional, Union
+from typing import List, Optional, TypeAlias, Union
 
 from aster import ir
 from aster.layout import Layout, Swizzle, SwizzledLayout
+from aster.layout.values import LayoutValues
 from aster.dialects import arith
 from aster.dialects import affine as affined
 from aster.dialects import func as funcd
@@ -93,6 +94,7 @@ from aster.dialects._amdgcn_ops_gen import (
     s_barrier_wait,
     s_mov_b32,
     s_nop,
+    cross_wave_token_barrier as _CrossWaveTokenBarrierOp,
     v_accvgpr_write,
 )
 from aster.dialects import lsir as lsird
@@ -104,6 +106,12 @@ from aster.dialects.amdgcn import (
     get_kernel_arguments,
 )
 from aster.dialects import ptr as ptrd
+
+# Wait arguments to wait_deps / cross_wave_token_barrier:
+#   - a LayoutValues with flattened token_values(), or
+#   - a list/tuple of tokens, or
+#   - a bare ir.Value token.
+WaitArg: TypeAlias = Union[LayoutValues, list[ir.Value], tuple[ir.Value, ...], ir.Value]
 
 
 def _i16(value: int, ctx: ir.Context) -> ir.IntegerAttr:
@@ -224,6 +232,8 @@ class KernelBuilder:
         self.flat_write_tok = ir.Type.parse("!amdgcn.write_token<flat>")
         self.lds_read_tok = ir.Type.parse("!amdgcn.read_token<shared>")
         self.lds_write_tok = ir.Type.parse("!amdgcn.write_token<shared>")
+        # Ordering-only fence token produced by FenceOpInterface.
+        self.fence_tok = ir.Type.parse("!amdgcn.fence_token")
 
     # ---------------------------------------------------------------------------
     # Pipeline stage annotation
@@ -1200,7 +1210,12 @@ class KernelBuilder:
         "ds_read_b128": DsReadB128,
     }
 
-    def _ds_read(self, opcode, dest, addr, const_offset=None):
+    def _ds_read(self, opcode, dest, addr, const_offset=None, fence_token=None):
+        """DS read operation.
+
+        fence_token optionally pins this read after a
+        cross_wave_token_barrier.
+        """
         if const_offset is None:
             const_offset = self.constant_i32(0)
         addr = self._ds_addr(addr)
@@ -1209,6 +1224,7 @@ class KernelBuilder:
             dest=dest,
             addr=addr,
             const_offset=const_offset,
+            fence_token=fence_token,
             loc=self._loc,
             ip=self._kip,
         )
@@ -1226,17 +1242,29 @@ class KernelBuilder:
         """DS write 128-bit (4 dwords) to LDS."""
         return self._ds_write("ds_write_b128", data, addr, const_offset)
 
-    def ds_read_b32(self, addr, const_offset=None) -> tuple[ir.Value, ir.Value]:
+    def ds_read_b32(
+        self, addr, const_offset=None, fence_token=None
+    ) -> tuple[ir.Value, ir.Value]:
         """DS read 32-bit (1 dword) from LDS."""
-        return self._ds_read("ds_read_b32", self.alloca_vgpr(), addr, const_offset)
+        return self._ds_read(
+            "ds_read_b32", self.alloca_vgpr(), addr, const_offset, fence_token
+        )
 
-    def ds_read_b64(self, addr, const_offset=None) -> tuple[ir.Value, ir.Value]:
+    def ds_read_b64(
+        self, addr, const_offset=None, fence_token=None
+    ) -> tuple[ir.Value, ir.Value]:
         """DS read 64-bit (2 dwords) from LDS."""
-        return self._ds_read("ds_read_b64", self.alloc_vgprx2(), addr, const_offset)
+        return self._ds_read(
+            "ds_read_b64", self.alloc_vgprx2(), addr, const_offset, fence_token
+        )
 
-    def ds_read_b128(self, addr, const_offset=None) -> tuple[ir.Value, ir.Value]:
+    def ds_read_b128(
+        self, addr, const_offset=None, fence_token=None
+    ) -> tuple[ir.Value, ir.Value]:
         """DS read 128-bit (4 dwords) from LDS."""
-        return self._ds_read("ds_read_b128", self.alloc_vgprx4(), addr, const_offset)
+        return self._ds_read(
+            "ds_read_b128", self.alloc_vgprx4(), addr, const_offset, fence_token
+        )
 
     _DS_STORE_OPS = {
         "ds_store_b64": DsStoreB64,
@@ -1427,7 +1455,7 @@ class KernelBuilder:
             voffset: Per-lane dynamic offset (VGPR).
             const_offset: Optional constant offset (i32).
         Returns:
-            Read token for vmcnt tracking.
+            Flat read token for vmcnt tracking.
         """
         if const_offset is None:
             const_offset = self.constant_i32(0)
@@ -1454,6 +1482,7 @@ class KernelBuilder:
         """G2S: buffer_load_dword with LDS flag (32-bit per lane).
 
         Same as g2s_buffer_load_dwordx4 but loads only 32 bits per lane.
+        Returns the flat read token.
         """
         if const_offset is None:
             const_offset = self.constant_i32(0)
@@ -1476,22 +1505,66 @@ class KernelBuilder:
     # ---------------------------------------------------------------------------
     # Synchronization
     # ---------------------------------------------------------------------------
+    def _flatten_wait_args(self, tokens: tuple[WaitArg, ...]) -> list[ir.Value]:
+        flat: list[ir.Value] = []
+        for tok in tokens:
+            if isinstance(tok, LayoutValues):
+                flat.extend(tok.token_values())
+            elif isinstance(tok, (list, tuple)):
+                flat.extend(tok)
+            else:
+                flat.append(tok)
+        return flat
 
-    def wait_deps(self, *tokens):
-        """Wait for dependency tokens (CDNA3/4: amdgcn.wait)."""
-        WaitOp(dependencies=list(tokens), loc=self._loc, ip=self._kip)
+    def wait_deps(self, *tokens: WaitArg) -> ir.Value:
+        """Wait for dependency tokens (CDNA3/4: amdgcn.wait).
 
-    def wait_deps_gfx1250(self, *tokens):
-        """Wait for dependency tokens (gfx1250: amdgcn.wait_gfx1250)."""
-        WaitGfx1250Op(dependencies=list(tokens), loc=self._loc, ip=self._kip)
+        Returns the fence_token produced by the wait.
+        """
+        op = WaitOp(
+            self.fence_tok,
+            dependencies=self._flatten_wait_args(tokens),
+            loc=self._loc,
+            ip=self._kip,
+        )
+        return op.fence_token
 
-    def wait_vmcnt(self, count: int = 0):
+    def wait_deps_gfx1250(self, *tokens: WaitArg) -> ir.Value:
+        """Wait for dependency tokens (gfx1250: amdgcn.wait_gfx1250).
+
+        Returns the fence_token produced by the wait.
+        """
+        op = WaitGfx1250Op(
+            self.fence_tok,
+            dependencies=self._flatten_wait_args(tokens),
+            loc=self._loc,
+            ip=self._kip,
+        )
+        return op.fence_token
+
+    def wait_vmcnt(self, count: int = 0) -> None:
         """Insert s_waitcnt vmcnt=count."""
         SWaitcnt(vmcnt=_i8(count, self._ctx), loc=self._loc, ip=self._kip)
 
-    def wait_lgkmcnt(self, count: int = 0):
+    def wait_lgkmcnt(self, count: int = 0) -> None:
         """Insert s_waitcnt lgkmcnt=count."""
         SWaitcnt(lgkmcnt=_i8(count, self._ctx), loc=self._loc, ip=self._kip)
+
+    def s_barrier(self) -> None:
+        """Insert a workgroup synchronization barrier."""
+        s_barrier(loc=self._loc, ip=self._kip)
+
+    def cross_wave_token_barrier(self, *deps: WaitArg) -> ir.Value:
+        """Emit amdgcn.cross_wave_token_barrier with flattened deps.
+
+        Returns a fence_token on which later memory ops can pin.
+        """
+        op = _CrossWaveTokenBarrierOp(
+            dependencies=self._flatten_wait_args(deps),
+            loc=self._loc,
+            ip=self._kip,
+        )
+        return op
 
     # ---------------------------------------------------------------------------
     # LDS allocation
@@ -1966,10 +2039,6 @@ class KernelBuilder:
     # ---------------------------------------------------------------------------
     # Barrier
     # ---------------------------------------------------------------------------
-
-    def s_barrier(self):
-        """Insert s_barrier for workgroup synchronization (CDNA only)."""
-        s_barrier(loc=self._loc, ip=self._kip)
 
     def s_barrier_signal(self, barrier_id: int = -1):
         """Signal arrival on a GFX12.5 workgroup barrier object."""

--- a/python/aster/dialects/kernel_builder_with_layouts.py
+++ b/python/aster/dialects/kernel_builder_with_layouts.py
@@ -129,25 +129,6 @@ class _TileTransfer:
 class KernelBuilderWithLayouts(KernelBuilder):
     """KernelBuilder with layout-first tile operations."""
 
-    def _flatten_wait_args(self, tokens: tuple[WaitArg, ...]) -> list[ir.Value]:
-        flat: list[ir.Value] = []
-        for tok in tokens:
-            if isinstance(tok, LayoutValues):
-                flat.extend(tok.token_values())
-            elif isinstance(tok, (list, tuple)):
-                flat.extend(tok)
-            else:
-                flat.append(tok)
-        return flat
-
-    def wait_deps(self, *tokens: WaitArg) -> None:
-        """Wait for dependency tokens (CDNA3/4)."""
-        super().wait_deps(*self._flatten_wait_args(tokens))
-
-    def wait_deps_gfx1250(self, *tokens: WaitArg) -> None:
-        """Wait for dependency tokens (gfx1250)."""
-        super().wait_deps_gfx1250(*self._flatten_wait_args(tokens))
-
     def _filter_layout_by_axes(
         self, layout: Layout, axes: tuple[Symbol, ...]
     ) -> Layout:
@@ -211,8 +192,12 @@ class KernelBuilderWithLayouts(KernelBuilder):
         buffer: Optional[TransferTileBuffer] = None,
         *,
         nt: bool = True,
+        fence_token: Optional[ir.Value] = None,
     ) -> _TileTransfer:
-        """Emit one tiled hardware transfer at tensor.ptr + tensor.offset."""
+        """Emit one tiled hardware transfer at tensor.ptr + tensor.offset.
+
+        fence_token: is an optional fence_token to pin the memory operations onto.
+        """
         copy_atom = tc.copy
         swizzle = tc.swizzle
         offsets = self.thread_value_offsets(tc.pid, tc.thread_layout, tc.value_layout)
@@ -222,6 +207,9 @@ class KernelBuilderWithLayouts(KernelBuilder):
         payloads: list[Any | None] = []
         tokens: list[Any] = []
         if src is MemSpace.GLOBAL and dst is MemSpace.REG:
+            assert fence_token is None, (
+                "global->reg transfer does not support fence_token"
+            )
             if buffer is not None:
                 # SRD bound handles ragged tail.
                 for voff in offsets:
@@ -243,6 +231,9 @@ class KernelBuilderWithLayouts(KernelBuilder):
                     payloads.append(rd)
                     tokens.append(tok)
         elif src is MemSpace.REG and dst is MemSpace.GLOBAL:
+            assert fence_token is None, (
+                "reg->global transfer does not support fence_token"
+            )
             assert data is not None, "reg->global transfer needs data"
             if not isinstance(data, (list, tuple)):
                 data = [data]
@@ -265,6 +256,7 @@ class KernelBuilderWithLayouts(KernelBuilder):
                     payloads.append(None)
                     tokens.append(tok)
         elif src is MemSpace.REG and dst is MemSpace.LDS:
+            assert fence_token is None, "reg->lds transfer does not support fence_token"
             assert data is not None, "reg->lds transfer needs data"
             if not isinstance(data, (list, tuple)):
                 data = [data]
@@ -280,7 +272,7 @@ class KernelBuilderWithLayouts(KernelBuilder):
         elif src is MemSpace.LDS and dst is MemSpace.REG:
             for voff in offsets:
                 addr = self._addr(tensor.ptr, tensor.byte_offset(self, voff), swizzle)
-                rd, tok = op(addr)
+                rd, tok = op(addr, fence_token=fence_token)
                 payloads.append(rd)
                 tokens.append(tok)
         else:
@@ -296,10 +288,13 @@ class KernelBuilderWithLayouts(KernelBuilder):
         data: Optional[LayoutValues] = None,
         buffer: Optional[TransferTileBuffer] = None,
         nt: bool = True,
+        fence_token: Optional[ir.Value] = None,
     ) -> LayoutValues:
         """Emit one transfer per unrolled tile coordinate and value coordinate.
 
         Use slice to bind some axes before calling this API.
+
+        fence_token: is an optional fence_token to pin the memory operations onto.
         """
         L = tensor.layout
         assert L is not None and L.axes is not None, (
@@ -338,7 +333,12 @@ class KernelBuilderWithLayouts(KernelBuilder):
             )
             sub_tensor = Tensor(tensor.ptr, tile_off)
             transfer = self._emit_transfer_tile(
-                tc, sub_tensor, data=per_tile_payloads(coords), buffer=buffer, nt=nt
+                tc,
+                sub_tensor,
+                data=per_tile_payloads(coords),
+                buffer=buffer,
+                nt=nt,
+                fence_token=fence_token,
             )
             flat_payloads.extend(transfer.payloads)
             flat_tokens.extend(transfer.tokens)
@@ -528,9 +528,12 @@ class KernelBuilderWithLayouts(KernelBuilder):
         data: Any = None,
         buffer: Optional[TransferTileBuffer] = None,
         nt: bool = True,
+        fence_token: Optional[ir.Value] = None,
     ) -> LayoutValues:
         """Emit hardware transfers for one tiled copy at ``tensor``'s offset."""
-        transfer = self._emit_transfer_tile(tc, tensor, data=data, buffer=buffer, nt=nt)
+        transfer = self._emit_transfer_tile(
+            tc, tensor, data=data, buffer=buffer, nt=nt, fence_token=fence_token
+        )
         return LayoutValues.from_flat(
             tc.value_layout,
             payloads=transfer.payloads,
@@ -618,11 +621,14 @@ class KernelBuilderWithLayouts(KernelBuilder):
         swizzle: Swizzle,
         tile_layout: Layout,
         read_fn,
+        fence_token: Optional[ir.Value] = None,
     ) -> list[tuple[ir.Value, ir.Value]]:
         """Read MFMA fragments from LDS with swizzle.
 
-        read_fn(addr) -> (data, tok). Returns a list of (data, tok)
-        pairs, one per sub-tile.
+        read_fn(addr, fence_token=fence_token) -> (data, tok).
+        fence_token: is an optional fence_token to pin the memory operations onto.
+
+        Returns a list of (data, tok) pairs, one per sub-tile.
         """
         d0, d1 = ir.AffineExpr.get_dim(0), ir.AffineExpr.get_dim(1)
         n_subs = tile_layout.size()
@@ -634,7 +640,7 @@ class KernelBuilderWithLayouts(KernelBuilder):
             frag_off = self.affine_apply(d0 + sub_off, [frag_off])
             swizzled = self.apply_swizzle(frag_off, swizzle)
             addr = self.affine_apply(d0 + d1, [lds_base, swizzled])
-            results.append(read_fn(addr))
+            results.append(read_fn(addr, fence_token=fence_token))
         return results
 
     def store_multi_fragment_to_global(

--- a/test/Dialect/AMDGCN/Analysis/gfx1250-wait-analysis.mlir
+++ b/test/Dialect/AMDGCN/Analysis/gfx1250-wait-analysis.mlir
@@ -7,7 +7,7 @@ amdgcn.module @gfx1250_tests target = #amdgcn.target<gfx1250> {
 // CHECK:       Op: %[[TOK:.*]] = amdgcn.tensor_load_to_lds
 // CHECK:       	WAIT STATE BEFORE: <Empty>
 // CHECK:       	WAIT STATE AFTER: unhandled tokens = [{%[[TOK]], {{[0-9]*}}, 0, tensor}]
-// CHECK:       Op: amdgcn.wait_gfx1250 deps %[[TOK]] : !amdgcn.read_token<tensor>
+// CHECK:       Op: %{{.*}} = amdgcn.wait_gfx1250 deps %[[TOK]] : !amdgcn.read_token<tensor> -> !amdgcn.fence_token
 // CHECK:       	WAIT STATE BEFORE: unhandled tokens = [{%[[TOK]], {{[0-9]*}}, 0, tensor}]
 // CHECK:       	WAIT STATE AFTER: unhandled tokens = [], wait information = {counts: {load_cnt: nowait, store_cnt: nowait, ds_cnt: nowait, km_cnt: nowait, tensor_cnt: 0}, waited_tokens: [], implied_tokens: [{%[[TOK]], {{[0-9]*}}, 0, tensor}]}
 // CHECK:       Op: func.return
@@ -20,7 +20,7 @@ func.func @test_tensor_load_wait() {
   %d3 = lsir.alloca : !amdgcn.sgpr<[20 : 24]>
   %tok = amdgcn.tensor_load_to_lds desc0 %d0 desc1 %d1 desc2 %d2 desc3 %d3
       : ins(!amdgcn.sgpr<[0 : 4]>, !amdgcn.sgpr<[8 : 16]>, !amdgcn.sgpr<[16 : 20]>, !amdgcn.sgpr<[20 : 24]>) -> !amdgcn.read_token<tensor>
-  amdgcn.wait_gfx1250 deps %tok : !amdgcn.read_token<tensor>
+  %wf0 = amdgcn.wait_gfx1250 deps %tok : !amdgcn.read_token<tensor> -> !amdgcn.fence_token
   return
 }
 
@@ -28,7 +28,7 @@ func.func @test_tensor_load_wait() {
 // CHECK:       Op: %[[TOK:.*]] = amdgcn.ds_load_b128
 // CHECK:       	WAIT STATE BEFORE: <Empty>
 // CHECK:       	WAIT STATE AFTER: unhandled tokens = [{%[[TOK]], {{[0-9]*}}, 0, ds}]
-// CHECK:       Op: amdgcn.wait_gfx1250 deps %[[TOK]] : !amdgcn.read_token<shared>
+// CHECK:       Op: %{{.*}} = amdgcn.wait_gfx1250 deps %[[TOK]] : !amdgcn.read_token<shared> -> !amdgcn.fence_token
 // CHECK:       	WAIT STATE BEFORE: unhandled tokens = [{%[[TOK]], {{[0-9]*}}, 0, ds}]
 // CHECK:       	WAIT STATE AFTER: unhandled tokens = [], wait information = {counts: {load_cnt: nowait, store_cnt: nowait, ds_cnt: 0, km_cnt: nowait, tensor_cnt: nowait}, waited_tokens: [], implied_tokens: [{%[[TOK]], {{[0-9]*}}, 0, ds}]}
 // CHECK:       Op: func.return
@@ -39,7 +39,7 @@ func.func @test_ds_load_wait(%addr: !amdgcn.vgpr) {
   %c0 = arith.constant 0 : i32
   %tok = amdgcn.ds_load_b128 dest %dst addr %addr offset c(%c0)
       : outs(!amdgcn.vgpr<[0 : 4]>) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
-  amdgcn.wait_gfx1250 deps %tok : !amdgcn.read_token<shared>
+  %wf1 = amdgcn.wait_gfx1250 deps %tok : !amdgcn.read_token<shared> -> !amdgcn.fence_token
   return
 }
 
@@ -47,7 +47,7 @@ func.func @test_ds_load_wait(%addr: !amdgcn.vgpr) {
 // CHECK:       Op: %[[R:.*]], %[[TOK:.*]] = amdgcn.global_load_dword
 // CHECK:       	WAIT STATE BEFORE: <Empty>
 // CHECK:       	WAIT STATE AFTER: unhandled tokens = [{%[[TOK]], {{[0-9]*}}, 0, load}]
-// CHECK:       Op: amdgcn.wait_gfx1250 deps %[[TOK]] : !amdgcn.read_token<flat>
+// CHECK:       Op: %{{.*}} = amdgcn.wait_gfx1250 deps %[[TOK]] : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // CHECK:       	WAIT STATE BEFORE: unhandled tokens = [{%[[TOK]], {{[0-9]*}}, 0, load}]
 // CHECK:       	WAIT STATE AFTER: unhandled tokens = [], wait information = {counts: {load_cnt: 0, store_cnt: nowait, ds_cnt: nowait, km_cnt: nowait, tensor_cnt: nowait}, waited_tokens: [], implied_tokens: [{%[[TOK]], {{[0-9]*}}, 0, load}]}
 // CHECK:       Op: func.return
@@ -57,7 +57,7 @@ func.func @test_global_load_wait(%addr: !amdgcn.vgpr<[? + 2]>, %dst: !amdgcn.vgp
   %c0 = arith.constant 0 : i32
   %res, %tok = amdgcn.global_load_dword dest %dst addr %addr offset c(%c0)
       : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
-  amdgcn.wait_gfx1250 deps %tok : !amdgcn.read_token<flat>
+  %wf2 = amdgcn.wait_gfx1250 deps %tok : !amdgcn.read_token<flat> -> !amdgcn.fence_token
   return
 }
 
@@ -66,7 +66,7 @@ func.func @test_global_load_wait(%addr: !amdgcn.vgpr<[? + 2]>, %dst: !amdgcn.vgp
 // CHECK:       	WAIT STATE AFTER: unhandled tokens = [{%[[DS_TOK]], {{[0-9]*}}, 0, ds}]
 // CHECK:       Op: %{{.*}}, %[[KM_TOK:.*]] = amdgcn.s_load_dword
 // CHECK:       	WAIT STATE AFTER: unhandled tokens = [{%[[KM_TOK]], {{[0-9]*}}, 0, scalar_read}, {%[[DS_TOK]], {{[0-9]*}}, 0, ds}]
-// CHECK:       Op: amdgcn.wait_gfx1250 deps %[[KM_TOK]] : !amdgcn.read_token<constant>
+// CHECK:       Op: %{{.*}} = amdgcn.wait_gfx1250 deps %[[KM_TOK]] : !amdgcn.read_token<constant> -> !amdgcn.fence_token
 // CHECK:       	WAIT STATE BEFORE: unhandled tokens = [{%[[KM_TOK]], {{[0-9]*}}, 0, scalar_read}, {%[[DS_TOK]], {{[0-9]*}}, 0, ds}]
 // CHECK:       	WAIT STATE AFTER: unhandled tokens = [{%[[DS_TOK]], {{[0-9]*}}, 0, ds}], wait information = {counts: {load_cnt: nowait, store_cnt: nowait, ds_cnt: nowait, km_cnt: 0, tensor_cnt: nowait}, waited_tokens: [], implied_tokens: [{%[[KM_TOK]], {{[0-9]*}}, 0, scalar_read}]}
 func.func @test_km_wait_does_not_drain_ds(%ds_addr: !amdgcn.vgpr, %km_addr: !amdgcn.sgpr<[? + 2]>) {
@@ -76,7 +76,7 @@ func.func @test_km_wait_does_not_drain_ds(%ds_addr: !amdgcn.vgpr, %km_addr: !amd
   %ds_tok = amdgcn.ds_load_b128 dest %ds_dst addr %ds_addr offset c(%c0_i32_mig29) : outs(!amdgcn.vgpr<[0 : 4]>) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
   %km_r, %km_tok = amdgcn.s_load_dword dest %km_dst addr %km_addr offset c(%c0_i32_mig29) : outs(!amdgcn.sgpr) ins(!amdgcn.sgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<constant>
   // On gfx1250 km and ds are independent counters: a km wait must not drain ds.
-  amdgcn.wait_gfx1250 deps %km_tok : !amdgcn.read_token<constant>
+  %wf3 = amdgcn.wait_gfx1250 deps %km_tok : !amdgcn.read_token<constant> -> !amdgcn.fence_token
   return
 }
 
@@ -85,7 +85,7 @@ func.func @test_km_wait_does_not_drain_ds(%ds_addr: !amdgcn.vgpr, %km_addr: !amd
 // CHECK:       	WAIT STATE AFTER: unhandled tokens = [{%[[DS_TOK]], {{[0-9]*}}, 0, ds}]
 // CHECK:       Op: %[[TEN_TOK:.*]] = amdgcn.tensor_load_to_lds
 // CHECK:       	WAIT STATE AFTER: unhandled tokens = [{%[[DS_TOK]], {{[0-9]*}}, 0, ds}, {%[[TEN_TOK]], {{[0-9]*}}, 0, tensor}]
-// CHECK:       Op: amdgcn.wait_gfx1250 deps %[[TEN_TOK]] : !amdgcn.read_token<tensor>
+// CHECK:       Op: %{{.*}} = amdgcn.wait_gfx1250 deps %[[TEN_TOK]] : !amdgcn.read_token<tensor> -> !amdgcn.fence_token
 // CHECK:       	WAIT STATE BEFORE: unhandled tokens = [{%[[DS_TOK]], {{[0-9]*}}, 0, ds}, {%[[TEN_TOK]], {{[0-9]*}}, 0, tensor}]
 // CHECK:       	WAIT STATE AFTER: unhandled tokens = [{%[[DS_TOK]], {{[0-9]*}}, 0, ds}], wait information = {counts: {load_cnt: nowait, store_cnt: nowait, ds_cnt: nowait, km_cnt: nowait, tensor_cnt: 0}, waited_tokens: [], implied_tokens: [{%[[TEN_TOK]], {{[0-9]*}}, 0, tensor}]}
 func.func @test_tensor_wait_does_not_drain_ds(%ds_addr: !amdgcn.vgpr) {
@@ -98,7 +98,7 @@ func.func @test_tensor_wait_does_not_drain_ds(%ds_addr: !amdgcn.vgpr) {
   %ds_tok = amdgcn.ds_load_b128 dest %ds_dst addr %ds_addr offset c(%c0_i32_mig30) : outs(!amdgcn.vgpr<[0 : 4]>) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
   %tensor_tok = amdgcn.tensor_load_to_lds desc0 %d0 desc1 %d1 desc2 %d2 desc3 %d3 : ins(!amdgcn.sgpr<[0 : 4]>, !amdgcn.sgpr<[8 : 16]>, !amdgcn.sgpr<[16 : 20]>, !amdgcn.sgpr<[20 : 24]>) -> !amdgcn.read_token<tensor>
   // On gfx1250 tensor and ds are independent counters: a tensor wait must not drain ds.
-  amdgcn.wait_gfx1250 deps %tensor_tok : !amdgcn.read_token<tensor>
+  %wf4 = amdgcn.wait_gfx1250 deps %tensor_tok : !amdgcn.read_token<tensor> -> !amdgcn.fence_token
   return
 }
 

--- a/test/Dialect/AMDGCN/Analysis/wait-analysis.mlir
+++ b/test/Dialect/AMDGCN/Analysis/wait-analysis.mlir
@@ -8,16 +8,16 @@ amdgcn.module @test_wait_analysis target = #amdgcn.target<gfx942> {
 // CHECK:       Op: %[[R_0:.*]], %[[R_1:.*]] = amdgcn.global_load_dword dest %[[R_2:.*]] addr %[[R_3:.*]] offset c(%{{.*}}) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
 // CHECK:       	WAIT STATE BEFORE: <Empty>
 // CHECK:       	WAIT STATE AFTER: unhandled tokens = [{%[[R_1]], {{[0-9]*}}, 0, vm}]
-// CHECK:       Op: amdgcn.wait deps %[[R_1]] : !amdgcn.read_token<flat>
+// CHECK:       Op: %{{.*}} = amdgcn.wait deps %[[R_1]] : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // CHECK:       	WAIT STATE BEFORE: unhandled tokens = [{%[[R_1]], {{[0-9]*}}, 0, vm}]
 // CHECK:       	WAIT STATE AFTER: unhandled tokens = [], wait information = {counts: {vm_cnt: 0, lgkm_cnt: nowait}, waited_tokens: [], implied_tokens: [{%[[R_1]], {{[0-9]*}}, 0, vm}]}
-// CHECK:       Op: amdgcn.wait deps %[[R_1]] : !amdgcn.read_token<flat>
+// CHECK:       Op: %{{.*}} = amdgcn.wait deps %[[R_1]] : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // CHECK:       	WAIT STATE BEFORE: unhandled tokens = [], wait information = {counts: {vm_cnt: 0, lgkm_cnt: nowait}, waited_tokens: [], implied_tokens: [{%[[R_1]], {{[0-9]*}}, 0, vm}]}
 // CHECK:       	WAIT STATE AFTER: unhandled tokens = [], wait information = {counts: {vm_cnt: nowait, lgkm_cnt: nowait}, waited_tokens: [], implied_tokens: []}
 // CHECK:       Op: %[[R_4:.*]] = amdgcn.global_store_dword data %[[R_0]] addr %[[R_3]] offset c(%{{.*}}) : ins(!amdgcn.vgpr, !amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.write_token<flat>
 // CHECK:       	WAIT STATE BEFORE: unhandled tokens = [], wait information = {counts: {vm_cnt: nowait, lgkm_cnt: nowait}, waited_tokens: [], implied_tokens: []}
 // CHECK:       	WAIT STATE AFTER: unhandled tokens = [{%[[R_4]], {{[0-9]*}}, 0, vm}]
-// CHECK:       Op: amdgcn.wait deps %[[R_4]], %[[R_1]] : !amdgcn.write_token<flat>, !amdgcn.read_token<flat>
+// CHECK:       Op: %{{.*}} = amdgcn.wait deps %[[R_4]], %[[R_1]] : !amdgcn.write_token<flat>, !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // CHECK:       	WAIT STATE BEFORE: unhandled tokens = [{%[[R_4]], {{[0-9]*}}, 0, vm}]
 // CHECK:       	WAIT STATE AFTER: unhandled tokens = [], wait information = {counts: {vm_cnt: 0, lgkm_cnt: nowait}, waited_tokens: [], implied_tokens: [{%[[R_4]], {{[0-9]*}}, 0, vm}]}
 // CHECK:       Op: func.return
@@ -30,11 +30,11 @@ func.func @test_duplicated_waits() {
   %3 = amdgcn.alloca : !amdgcn.vgpr
   %c0_i32_mig1 = arith.constant 0 : i32
   %result, %token = amdgcn.global_load_dword dest %3 addr %2 offset c(%c0_i32_mig1) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
-  amdgcn.wait deps %token : !amdgcn.read_token<flat>
+  %wf0 = amdgcn.wait deps %token : !amdgcn.read_token<flat> -> !amdgcn.fence_token
   // Wait again on the same token, so the second wait is redundant.
-  amdgcn.wait deps %token : !amdgcn.read_token<flat>
+  %wf1 = amdgcn.wait deps %token : !amdgcn.read_token<flat> -> !amdgcn.fence_token
   %5 = amdgcn.global_store_dword data %result addr %2 offset c(%c0_i32_mig1) : ins(!amdgcn.vgpr, !amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.write_token<flat>
-  amdgcn.wait deps %5, %token : !amdgcn.write_token<flat>, !amdgcn.read_token<flat>
+  %wf2 = amdgcn.wait deps %5, %token : !amdgcn.write_token<flat>, !amdgcn.read_token<flat> -> !amdgcn.fence_token
   return
 }
 
@@ -54,7 +54,7 @@ func.func @test_duplicated_waits() {
 // CHECK:       Op: %[[R_8:.*]]:3 = scf.for %[[R_9:.*]] = %[[R_10:.*]] to %[[R_11:.*]] step %[[R_12:.*]] iter_args(%[[R_13:.*]] = %[[R_2]], %[[R_14:.*]] = %[[R_5]], %[[R_15:.*]] = %[[R_7]]) -> (!amdgcn.read_token<flat>, !amdgcn.read_token<flat>, !amdgcn.read_token<flat>) {...}
 // CHECK:       	WAIT STATE BEFORE: unhandled tokens = [{%[[R_2]], {{[0-9]*}}, 2, vm}, {%[[R_5]], {{[0-9]*}}, 1, vm}, {%[[R_7]], {{[0-9]*}}, 0, vm}]
 // CHECK:       	WAIT STATE AFTER: unhandled tokens = [{%[[R_5]], {{[0-9]*}}, 2, vm}, {%[[R_7]], {{[0-9]*}}, 1, vm}, {%[[R_16:.*]], {{[0-9]*}}, 0, vm}, {%[[R_17:.*]], {{[0-9]*}}, 2, vm}, {%[[R_18:.*]], {{[0-9]*}}, 1, vm}]
-// CHECK:       Op: amdgcn.wait deps %[[R_13]] : !amdgcn.read_token<flat>
+// CHECK:       Op: %{{.*}} = amdgcn.wait deps %[[R_13]] : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // CHECK:       	WAIT STATE BEFORE: unhandled tokens = [{%[[R_2]], {{[0-9]*}}, 2, vm}, {%[[R_5]], {{[0-9]*}}, 1, vm}, {%[[R_7]], {{[0-9]*}}, 0, vm}, {%[[R_13]], {{[0-9]*}}, 2, vm}, {%[[R_14]], {{[0-9]*}}, 1, vm}, {%[[R_15]], {{[0-9]*}}, 0, vm}]
 // CHECK:       	WAIT STATE AFTER: unhandled tokens = [{%[[R_5]], {{[0-9]*}}, 1, vm}, {%[[R_7]], {{[0-9]*}}, 0, vm}, {%[[R_14]], {{[0-9]*}}, 1, vm}, {%[[R_15]], {{[0-9]*}}, 0, vm}], wait information = {counts: {vm_cnt: 2, lgkm_cnt: nowait}, waited_tokens: [{%[[R_13]], {{[0-9]*}}, 2, vm}], implied_tokens: [{%[[R_2]], {{[0-9]*}}, 2, vm}, {%[[R_13]], {{[0-9]*}}, 2, vm}]}
 // CHECK:       Op: %{{.*}} = arith.constant 0 : i32
@@ -66,7 +66,7 @@ func.func @test_duplicated_waits() {
 // CHECK:       Op: scf.yield %[[R_14]], %[[R_15]], %[[R_20]] : !amdgcn.read_token<flat>, !amdgcn.read_token<flat>, !amdgcn.read_token<flat>
 // CHECK:       	WAIT STATE BEFORE: unhandled tokens = [{%[[R_5]], {{[0-9]*}}, 2, vm}, {%[[R_7]], {{[0-9]*}}, 1, vm}, {%[[R_14]], {{[0-9]*}}, 2, vm}, {%[[R_15]], {{[0-9]*}}, 1, vm}, {%[[R_20]], {{[0-9]*}}, 0, vm}]
 // CHECK:       	WAIT STATE AFTER: unhandled tokens = [{%[[R_5]], {{[0-9]*}}, 2, vm}, {%[[R_7]], {{[0-9]*}}, 1, vm}, {%[[R_14]], {{[0-9]*}}, 2, vm}, {%[[R_15]], {{[0-9]*}}, 1, vm}, {%[[R_20]], {{[0-9]*}}, 0, vm}]
-// CHECK:       Op: amdgcn.wait deps %[[R_16]] : !amdgcn.read_token<flat>
+// CHECK:       Op: %{{.*}} = amdgcn.wait deps %[[R_16]] : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // CHECK:       	WAIT STATE BEFORE: unhandled tokens = [{%[[R_5]], {{[0-9]*}}, 2, vm}, {%[[R_7]], {{[0-9]*}}, 1, vm}, {%[[R_16]], {{[0-9]*}}, 0, vm}, {%[[R_17]], {{[0-9]*}}, 2, vm}, {%[[R_18]], {{[0-9]*}}, 1, vm}]
 // CHECK:       	WAIT STATE AFTER: unhandled tokens = [], wait information = {counts: {vm_cnt: 0, lgkm_cnt: nowait}, waited_tokens: [], implied_tokens: [{%[[R_5]], {{[0-9]*}}, 2, vm}, {%[[R_7]], {{[0-9]*}}, 1, vm}, {%[[R_16]], {{[0-9]*}}, 0, vm}, {%[[R_17]], {{[0-9]*}}, 2, vm}, {%[[R_18]], {{[0-9]*}}, 1, vm}]}
 // CHECK:       Op: func.return
@@ -86,12 +86,12 @@ func.func @test_pipelined_pattern(%arg0: !amdgcn.vgpr<[? + 2]>) {
   %result_2, %token_3 = amdgcn.global_load_dword dest %0 addr %arg0 offset c(%c0_i32_mig4) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
   // There's always at least 2 outstanding loads in the pipeline.
   %2:3 = scf.for %arg1 = %c0 to %c4 step %c1 iter_args(%arg2 = %token, %arg3 = %token_1, %arg4 = %token_3) -> (!amdgcn.read_token<flat>, !amdgcn.read_token<flat>, !amdgcn.read_token<flat>) {
-    amdgcn.wait deps %arg2 : !amdgcn.read_token<flat>
+    %wf3 = amdgcn.wait deps %arg2 : !amdgcn.read_token<flat> -> !amdgcn.fence_token
     %c0_i32_mig5 = arith.constant 0 : i32
     %result_4, %token_5 = amdgcn.global_load_dword dest %0 addr %arg0 offset c(%c0_i32_mig5) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
     scf.yield %arg3, %arg4, %token_5 : !amdgcn.read_token<flat>, !amdgcn.read_token<flat>, !amdgcn.read_token<flat>
   }
-  amdgcn.wait deps %2#2 : !amdgcn.read_token<flat>
+  %wf4 = amdgcn.wait deps %2#2 : !amdgcn.read_token<flat> -> !amdgcn.fence_token
   return
 }
 
@@ -138,7 +138,7 @@ func.func @test_escaped_waits_1(%arg0: !amdgcn.vgpr<[? + 2]>) {
 // CHECK:       Op: scf.yield
 // CHECK:       	WAIT STATE BEFORE: unhandled tokens = [{%[[R_3]], {{[0-9]*}}, 0, vm}]
 // CHECK:       	WAIT STATE AFTER: unhandled tokens = [{%[[R_3]], {{[0-9]*}}, 0, vm}]
-// CHECK:       Op: amdgcn.wait vm_cnt 0 lgkm_cnt 0
+// CHECK:       Op: %{{.*}} = amdgcn.wait vm_cnt 0 lgkm_cnt 0 -> !amdgcn.fence_token
 // CHECK:       	WAIT STATE BEFORE: unhandled tokens = [{<escaped>, 0, vm}]
 // CHECK:       	WAIT STATE AFTER: unhandled tokens = [], wait information = {counts: {vm_cnt: 0, lgkm_cnt: 0}, waited_tokens: [], implied_tokens: [{<escaped>, 0, vm}]}
 // CHECK:       Op: func.return
@@ -152,7 +152,7 @@ func.func @test_escaped_waits_2(%arg0: !amdgcn.vgpr<[? + 2]>, %arg1: i1) {
     %result, %token = amdgcn.global_load_dword dest %0 addr %arg0 offset c(%c0_i32_mig7) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
   }
   // Catch escaped token with a full wait.
-  amdgcn.wait vm_cnt 0 lgkm_cnt 0
+  %wf5 = amdgcn.wait vm_cnt 0 lgkm_cnt 0 -> !amdgcn.fence_token
   return
 }
 
@@ -175,7 +175,7 @@ func.func @test_escaped_waits_2(%arg0: !amdgcn.vgpr<[? + 2]>, %arg1: i1) {
 // CHECK:       Op: scf.yield %[[R_4]] : !amdgcn.read_token<flat>
 // CHECK:       	WAIT STATE BEFORE: unhandled tokens = [{%[[R_4]], {{[0-9]*}}, 0, vm}]
 // CHECK:       	WAIT STATE AFTER: unhandled tokens = [{%[[R_4]], {{[0-9]*}}, 0, vm}]
-// CHECK:       Op: amdgcn.wait deps %[[R_2]] : !amdgcn.read_token<flat>
+// CHECK:       Op: %{{.*}} = amdgcn.wait deps %[[R_2]] : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // CHECK:       	WAIT STATE BEFORE: unhandled tokens = [{%[[R_2]], {{[0-9]*}}, 0, vm}]
 // CHECK:       	WAIT STATE AFTER: unhandled tokens = [], wait information = {counts: {vm_cnt: 0, lgkm_cnt: nowait}, waited_tokens: [], implied_tokens: [{%[[R_2]], {{[0-9]*}}, 0, vm}]}
 // CHECK:       Op: func.return
@@ -194,7 +194,7 @@ func.func @test_if_flow_1(%arg0: !amdgcn.vgpr<[? + 2]>, %arg1: i1) {
     %result, %token = amdgcn.global_load_dword dest %1 addr %arg0 offset c(%c0_i32_mig9) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
     scf.yield %token : !amdgcn.read_token<flat>
   }
-  amdgcn.wait deps %2 : !amdgcn.read_token<flat>
+  %wf6 = amdgcn.wait deps %2 : !amdgcn.read_token<flat> -> !amdgcn.fence_token
   return
 }
 
@@ -223,7 +223,7 @@ func.func @test_if_flow_1(%arg0: !amdgcn.vgpr<[? + 2]>, %arg1: i1) {
 // CHECK:       Op: scf.yield %[[R_4]] : !amdgcn.read_token<flat>
 // CHECK:       	WAIT STATE BEFORE: unhandled tokens = [{%[[R_4]], {{[0-9]*}}, 0, vm}]
 // CHECK:       	WAIT STATE AFTER: unhandled tokens = [{%[[R_4]], {{[0-9]*}}, 0, vm}]
-// CHECK:       Op: amdgcn.wait deps %[[R_2]] : !amdgcn.read_token<flat>
+// CHECK:       Op: %{{.*}} = amdgcn.wait deps %[[R_2]] : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // CHECK:       	WAIT STATE BEFORE: unhandled tokens = [{%[[R_2]], {{[0-9]*}}, 0, vm}, {<escaped>, 1, vm}]
 // CHECK:       	WAIT STATE AFTER: unhandled tokens = [], wait information = {counts: {vm_cnt: 0, lgkm_cnt: nowait}, waited_tokens: [], implied_tokens: [{%[[R_2]], {{[0-9]*}}, 0, vm}, {<escaped>, 1, vm}]}
 // CHECK:       Op: func.return
@@ -246,7 +246,7 @@ func.func @test_if_flow_2(%arg0: !amdgcn.vgpr<[? + 2]>, %arg1: i1) {
     %result, %token = amdgcn.global_load_dword dest %1 addr %arg0 offset c(%c0_i32_mig13) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
     scf.yield %token : !amdgcn.read_token<flat>
   }
-  amdgcn.wait deps %2 : !amdgcn.read_token<flat>
+  %wf7 = amdgcn.wait deps %2 : !amdgcn.read_token<flat> -> !amdgcn.fence_token
   return
 }
 
@@ -278,7 +278,7 @@ func.func @test_if_flow_2(%arg0: !amdgcn.vgpr<[? + 2]>, %arg1: i1) {
 // CHECK:       Op: scf.yield %[[R_4]] : !amdgcn.read_token<flat>
 // CHECK:       	WAIT STATE BEFORE: unhandled tokens = [{%[[R_4]], {{[0-9]*}}, 1, vm}, {%[[R_7]], {{[0-9]*}}, 0, vm}]
 // CHECK:       	WAIT STATE AFTER: unhandled tokens = [{%[[R_4]], {{[0-9]*}}, 1, vm}, {%[[R_7]], {{[0-9]*}}, 0, vm}]
-// CHECK:       Op: amdgcn.wait deps %[[R_2]] : !amdgcn.read_token<flat>
+// CHECK:       Op: %{{.*}} = amdgcn.wait deps %[[R_2]] : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // CHECK:       	WAIT STATE BEFORE: unhandled tokens = [{%[[R_2]], {{[0-9]*}}, 1, vm}, {<escaped>, 0, vm}]
 // CHECK:       	WAIT STATE AFTER: unhandled tokens = [{<escaped>, 0, vm}], wait information = {counts: {vm_cnt: 1, lgkm_cnt: nowait}, waited_tokens: [{%[[R_2]], {{[0-9]*}}, 1, vm}], implied_tokens: [{%[[R_2]], {{[0-9]*}}, 1, vm}]}
 // CHECK:       Op: func.return
@@ -303,7 +303,7 @@ func.func @test_if_flow_3(%arg0: !amdgcn.vgpr<[? + 2]>, %arg1: i1) {
     %result_0, %token_1 = amdgcn.global_load_dword dest %0 addr %arg0 offset c(%c0_i32_mig18) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
     scf.yield %token : !amdgcn.read_token<flat>
   }
-  amdgcn.wait deps %2 : !amdgcn.read_token<flat>
+  %wf8 = amdgcn.wait deps %2 : !amdgcn.read_token<flat> -> !amdgcn.fence_token
   return
 }
 
@@ -320,10 +320,10 @@ func.func @test_if_flow_3(%arg0: !amdgcn.vgpr<[? + 2]>, %arg1: i1) {
 // CHECK:       Op: %[[R_6:.*]], %[[R_7:.*]] = amdgcn.global_load_dword dest %[[R_3]] addr %[[R_0]] offset c(%{{.*}}) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
 // CHECK:       	WAIT STATE BEFORE: unhandled tokens = [{%[[R_2]], {{[0-9]*}}, 1, vm}, {%[[R_5]], {{[0-9]*}}, 0, vm}]
 // CHECK:       	WAIT STATE AFTER: unhandled tokens = [{%[[R_2]], {{[0-9]*}}, 2, vm}, {%[[R_5]], {{[0-9]*}}, 1, vm}, {%[[R_7]], {{[0-9]*}}, 0, vm}]
-// CHECK:       Op: amdgcn.wait deps %[[R_2]] : !amdgcn.read_token<flat>
+// CHECK:       Op: %{{.*}} = amdgcn.wait deps %[[R_2]] : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // CHECK:       	WAIT STATE BEFORE: unhandled tokens = [{%[[R_2]], {{[0-9]*}}, 2, vm}, {%[[R_5]], {{[0-9]*}}, 1, vm}, {%[[R_7]], {{[0-9]*}}, 0, vm}]
 // CHECK:       	WAIT STATE AFTER: unhandled tokens = [{%[[R_5]], {{[0-9]*}}, 1, vm}, {%[[R_7]], {{[0-9]*}}, 0, vm}], wait information = {counts: {vm_cnt: 2, lgkm_cnt: nowait}, waited_tokens: [{%[[R_2]], {{[0-9]*}}, 2, vm}], implied_tokens: [{%[[R_2]], {{[0-9]*}}, 2, vm}]}
-// CHECK:       Op: amdgcn.wait deps %[[R_7]] : !amdgcn.read_token<flat>
+// CHECK:       Op: %{{.*}} = amdgcn.wait deps %[[R_7]] : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // CHECK:       	WAIT STATE BEFORE: unhandled tokens = [{%[[R_5]], {{[0-9]*}}, 1, vm}, {%[[R_7]], {{[0-9]*}}, 0, vm}], wait information = {counts: {vm_cnt: 2, lgkm_cnt: nowait}, waited_tokens: [{%[[R_2]], {{[0-9]*}}, 2, vm}], implied_tokens: [{%[[R_2]], {{[0-9]*}}, 2, vm}]}
 // CHECK:       	WAIT STATE AFTER: unhandled tokens = [], wait information = {counts: {vm_cnt: 0, lgkm_cnt: nowait}, waited_tokens: [], implied_tokens: [{%[[R_5]], {{[0-9]*}}, 1, vm}, {%[[R_7]], {{[0-9]*}}, 0, vm}]}
 // CHECK:       Op: func.return
@@ -342,8 +342,8 @@ func.func @test_passthrough_pattern(%arg0: !amdgcn.vgpr<[? + 2]>) {
   %c0_i32_mig21 = arith.constant 0 : i32
   %result_2, %token_3 = amdgcn.global_load_dword dest %0 addr %arg0 offset c(%c0_i32_mig21) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
   // Test the first wait passes through loads.
-  amdgcn.wait deps %token : !amdgcn.read_token<flat>
-  amdgcn.wait deps %token_3 : !amdgcn.read_token<flat>
+  %wf9 = amdgcn.wait deps %token : !amdgcn.read_token<flat> -> !amdgcn.fence_token
+  %wf10 = amdgcn.wait deps %token_3 : !amdgcn.read_token<flat> -> !amdgcn.fence_token
   return
 }
 
@@ -360,7 +360,7 @@ func.func @test_passthrough_pattern(%arg0: !amdgcn.vgpr<[? + 2]>) {
 // CHECK:       Op: %[[R_9:.*]], %[[R_10:.*]] = amdgcn.global_load_dword dest %[[R_8]] addr %[[R_2]] offset c(%{{.*}}) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
 // CHECK:       	WAIT STATE BEFORE: unhandled tokens = [{%[[R_7]], {{[0-9]*}}, 0, lgkm}, {%[[R_4]], {{[0-9]*}}, 1, scalar_read}]
 // CHECK:       	WAIT STATE AFTER: unhandled tokens = [{%[[R_10]], {{[0-9]*}}, 0, vm}, {%[[R_7]], {{[0-9]*}}, 0, lgkm}, {%[[R_4]], {{[0-9]*}}, 1, scalar_read}]
-// CHECK:       Op: amdgcn.wait deps %[[R_4]] : !amdgcn.read_token<constant>
+// CHECK:       Op: %{{.*}} = amdgcn.wait deps %[[R_4]] : !amdgcn.read_token<constant> -> !amdgcn.fence_token
 // CHECK:       	WAIT STATE BEFORE: unhandled tokens = [{%[[R_10]], {{[0-9]*}}, 0, vm}, {%[[R_7]], {{[0-9]*}}, 0, lgkm}, {%[[R_4]], {{[0-9]*}}, 1, scalar_read}]
 // CHECK:       	WAIT STATE AFTER: unhandled tokens = [{%[[R_10]], {{[0-9]*}}, 0, vm}], wait information = {counts: {vm_cnt: nowait, lgkm_cnt: 0}, waited_tokens: [], implied_tokens: [{%[[R_7]], {{[0-9]*}}, 0, lgkm}, {%[[R_4]], {{[0-9]*}}, 1, scalar_read}]}
 // CHECK:       Op: func.return
@@ -378,7 +378,7 @@ func.func @test_mixed_smem_dsmem(%arg0: !amdgcn.sgpr<[? + 2]>, %arg1: !amdgcn.vg
   %result_0, %token_1 = amdgcn.ds_read_b32 dest %1 addr %arg1 offset c(%c0_i32_mig1) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
   %c0_i32_mig22 = arith.constant 0 : i32
   %result_2, %token_3 = amdgcn.global_load_dword dest %1 addr %arg2 offset c(%c0_i32_mig22) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
-  amdgcn.wait deps %token : !amdgcn.read_token<constant>
+  %wf11 = amdgcn.wait deps %token : !amdgcn.read_token<constant> -> !amdgcn.fence_token
   return
 }
 
@@ -395,7 +395,7 @@ func.func @test_mixed_smem_dsmem(%arg0: !amdgcn.sgpr<[? + 2]>, %arg1: !amdgcn.vg
 // CHECK:       Op: %[[R_6:.*]], %[[R_7:.*]] = amdgcn.global_load_dword dest %[[R_3]] addr %[[R_0]] offset c(%{{.*}}) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
 // CHECK:       	WAIT STATE BEFORE: unhandled tokens = [{%[[R_2]], {{[0-9]*}}, 1, vm}, {%[[R_5]], {{[0-9]*}}, 0, vm}]
 // CHECK:       	WAIT STATE AFTER: unhandled tokens = [{%[[R_2]], {{[0-9]*}}, 2, vm}, {%[[R_5]], {{[0-9]*}}, 1, vm}, {%[[R_7]], {{[0-9]*}}, 0, vm}]
-// CHECK:       Op: amdgcn.wait vm_cnt 1 deps %[[R_2]] : !amdgcn.read_token<flat>
+// CHECK:       Op: %{{.*}} = amdgcn.wait vm_cnt 1 deps %[[R_2]] : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // CHECK:       	WAIT STATE BEFORE: unhandled tokens = [{%[[R_2]], {{[0-9]*}}, 2, vm}, {%[[R_5]], {{[0-9]*}}, 1, vm}, {%[[R_7]], {{[0-9]*}}, 0, vm}]
 // CHECK:       	WAIT STATE AFTER: unhandled tokens = [{%[[R_7]], {{[0-9]*}}, 0, vm}], wait information = {counts: {vm_cnt: 1, lgkm_cnt: nowait}, waited_tokens: [], implied_tokens: [{%[[R_2]], {{[0-9]*}}, 2, vm}, {%[[R_5]], {{[0-9]*}}, 1, vm}]}
 // CHECK:       Op: %{{.*}} = arith.constant 0 : i32
@@ -416,7 +416,7 @@ func.func @test_mixed_smem_dsmem(%arg0: !amdgcn.sgpr<[? + 2]>, %arg1: !amdgcn.vg
 // CHECK:       Op: %[[R_12:.*]], %[[R_13:.*]] = amdgcn.global_load_dword dest %[[R_3]] addr %[[R_0]] offset c(%{{.*}}) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
 // CHECK:       	WAIT STATE BEFORE: unhandled tokens = [{%[[R_7]], {{[0-9]*}}, 2, vm}, {%[[R_9]], {{[0-9]*}}, 1, vm}, {%[[R_11]], {{[0-9]*}}, 0, vm}]
 // CHECK:       	WAIT STATE AFTER: unhandled tokens = [{%[[R_7]], {{[0-9]*}}, 3, vm}, {%[[R_9]], {{[0-9]*}}, 2, vm}, {%[[R_11]], {{[0-9]*}}, 1, vm}, {%[[R_13]], {{[0-9]*}}, 0, vm}]
-// CHECK:       Op: amdgcn.wait vm_cnt 4 deps %[[R_9]] : !amdgcn.read_token<flat>
+// CHECK:       Op: %{{.*}} = amdgcn.wait vm_cnt 4 deps %[[R_9]] : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // CHECK:       	WAIT STATE BEFORE: unhandled tokens = [{%[[R_7]], {{[0-9]*}}, 3, vm}, {%[[R_9]], {{[0-9]*}}, 2, vm}, {%[[R_11]], {{[0-9]*}}, 1, vm}, {%[[R_13]], {{[0-9]*}}, 0, vm}]
 // CHECK:       	WAIT STATE AFTER: unhandled tokens = [{%[[R_11]], {{[0-9]*}}, 1, vm}, {%[[R_13]], {{[0-9]*}}, 0, vm}], wait information = {counts: {vm_cnt: 2, lgkm_cnt: nowait}, waited_tokens: [{%[[R_9]], {{[0-9]*}}, 2, vm}], implied_tokens: [{%[[R_7]], {{[0-9]*}}, 3, vm}, {%[[R_9]], {{[0-9]*}}, 2, vm}]}
 // CHECK:       Op: func.return
@@ -435,7 +435,7 @@ func.func @test_counts_strength(%arg0: !amdgcn.vgpr<[? + 2]>) {
   %c0_i32_mig25 = arith.constant 0 : i32
   %result_2, %token_3 = amdgcn.global_load_dword dest %0 addr %arg0 offset c(%c0_i32_mig25) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
   // Test that %token is not waited on as vm_cnt is stronger.
-  amdgcn.wait vm_cnt 1 deps %token : !amdgcn.read_token<flat>
+  %wf12 = amdgcn.wait vm_cnt 1 deps %token : !amdgcn.read_token<flat> -> !amdgcn.fence_token
   %c0_i32_mig26 = arith.constant 0 : i32
   %result_4, %token_5 = amdgcn.global_load_dword dest %0 addr %arg0 offset c(%c0_i32_mig26) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
   %c0_i32_mig27 = arith.constant 0 : i32
@@ -443,12 +443,12 @@ func.func @test_counts_strength(%arg0: !amdgcn.vgpr<[? + 2]>) {
   %c0_i32_mig28 = arith.constant 0 : i32
   %result_8, %token_9 = amdgcn.global_load_dword dest %0 addr %arg0 offset c(%c0_i32_mig28) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
   // Test the token has precedence over vm_cnt.
-  amdgcn.wait vm_cnt 4 deps %token_5 : !amdgcn.read_token<flat>
+  %wf13 = amdgcn.wait vm_cnt 4 deps %token_5 : !amdgcn.read_token<flat> -> !amdgcn.fence_token
   return
 }
 
 // CHECK-LABEL: Symbol: test_smem_zero
-// CHECK: amdgcn.wait deps
+// CHECK:       Op: %{{.*}} = amdgcn.wait deps %{{.*}} : !amdgcn.read_token<constant> -> !amdgcn.fence_token
 // CHECK-NEXT: WAIT STATE BEFORE: unhandled tokens = [{%{{.*}}, {{.*}}, 1, scalar_read}, {%{{.*}}, {{.*}}, 0, scalar_read}]
 // CHECK-NEXT: WAIT STATE AFTER: unhandled tokens = [], wait information = {counts: {vm_cnt: nowait, lgkm_cnt: 0}
 func.func @test_smem_zero(%arg0: !amdgcn.sgpr<[? + 2]>, %arg1: !amdgcn.vgpr, %arg2: !amdgcn.vgpr<[? + 2]>) {
@@ -459,7 +459,7 @@ func.func @test_smem_zero(%arg0: !amdgcn.sgpr<[? + 2]>, %arg1: !amdgcn.vgpr, %ar
   %dest_res, %token = amdgcn.s_load_dword dest %0 addr %arg0 offset c(%c0_i32_mig2) : outs(!amdgcn.sgpr) ins(!amdgcn.sgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<constant>
   %c0_i32_mig3 = arith.constant 0 : i32
   %dest_res1, %token_1 = amdgcn.s_load_dword dest %0 addr %arg0 offset c(%c0_i32_mig3) : outs(!amdgcn.sgpr) ins(!amdgcn.sgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<constant>
-  amdgcn.wait deps %token : !amdgcn.read_token<constant>
+  %wf14 = amdgcn.wait deps %token : !amdgcn.read_token<constant> -> !amdgcn.fence_token
   return
 }
 
@@ -468,7 +468,7 @@ func.func @test_smem_zero(%arg0: !amdgcn.sgpr<[? + 2]>, %arg1: !amdgcn.vgpr, %ar
 // CHECK:       	WAIT STATE AFTER: unhandled tokens = [{%[[LD_TOK]], {{[0-9]*}}, 0, vm}]
 // CHECK:       Op: %[[ST_TOK:.*]] = amdgcn.global_store_dword data %[[LD_R]]
 // CHECK:       	WAIT STATE AFTER: unhandled tokens = [{%[[LD_TOK]], {{[0-9]*}}, 1, vm}, {%[[ST_TOK]], {{[0-9]*}}, 0, vm}]
-// CHECK:       Op: amdgcn.wait deps %[[ST_TOK]] : !amdgcn.write_token<flat>
+// CHECK:       Op: %{{.*}} = amdgcn.wait deps %[[ST_TOK]] : !amdgcn.write_token<flat> -> !amdgcn.fence_token
 // CHECK:       	WAIT STATE AFTER: unhandled tokens = [], wait information = {counts: {vm_cnt: 0, lgkm_cnt: nowait}, waited_tokens: [], implied_tokens: [{%[[LD_TOK]], {{[0-9]*}}, 1, vm}, {%[[ST_TOK]], {{[0-9]*}}, 0, vm}]}
 func.func @test_flat_read_write_coincrement(%arg0: !amdgcn.vgpr<[? + 2]>) {
   %0 = amdgcn.alloca : !amdgcn.vgpr
@@ -478,22 +478,21 @@ func.func @test_flat_read_write_coincrement(%arg0: !amdgcn.vgpr<[? + 2]>) {
   // Store issued while the load is in flight: both share vm_cnt, so the load
   // token position co-increments.
   %st_tok = amdgcn.global_store_dword data %ld_r addr %arg0 offset c(%c0_i32_mig30) : ins(!amdgcn.vgpr, !amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.write_token<flat>
-  amdgcn.wait deps %st_tok : !amdgcn.write_token<flat>
+  %wf15 = amdgcn.wait deps %st_tok : !amdgcn.write_token<flat> -> !amdgcn.fence_token
   return
 }
 
 // CHECK-LABEL: test_cdna_store_only_dep
 // CHECK:       Op: %[[ST_TOK:.*]] = amdgcn.global_store_dword data %{{.*}}
 // CHECK:       	WAIT STATE AFTER: unhandled tokens = [{%[[ST_TOK]], {{[0-9]*}}, 0, vm}]
-// CHECK:       Op: amdgcn.wait deps %[[ST_TOK]] : !amdgcn.write_token<flat>
+// CHECK:       Op: %{{.*}} = amdgcn.wait deps %[[ST_TOK]] : !amdgcn.write_token<flat> -> !amdgcn.fence_token
 // CHECK:       	WAIT STATE AFTER: unhandled tokens = [], wait information = {counts: {vm_cnt: 0, lgkm_cnt: nowait}, waited_tokens: [], implied_tokens: [{%[[ST_TOK]], {{[0-9]*}}, 0, vm}]}
 func.func @test_cdna_store_only_dep(%arg0: !amdgcn.vgpr<[? + 2]>, %arg1: !amdgcn.vgpr) {
   %c0_i32_mig31 = arith.constant 0 : i32
   // Lone store dependency: the wait must resolve to vm_cnt (a write token routes
   // to vm, not lgkm), guarding the B5 double-collapse removal.
   %st_tok = amdgcn.global_store_dword data %arg1 addr %arg0 offset c(%c0_i32_mig31) : ins(!amdgcn.vgpr, !amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.write_token<flat>
-  amdgcn.wait deps %st_tok : !amdgcn.write_token<flat>
+  %wf16 = amdgcn.wait deps %st_tok : !amdgcn.write_token<flat> -> !amdgcn.fence_token
   return
 }
-
 }

--- a/test/Dialect/AMDGCN/IR/module-isa-compat-invalid.mlir
+++ b/test/Dialect/AMDGCN/IR/module-isa-compat-invalid.mlir
@@ -7,7 +7,7 @@ amdgcn.module @gfx1250_old_wait target = #amdgcn.target<gfx1250> {
     %c0 = arith.constant 0 : i32
     %r, %tok = amdgcn.global_load_dword dest %0 addr %arg0 offset c(%c0) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
     // expected-error @below {{'amdgcn.wait' op is not compatible with module target gfx1250}}
-    amdgcn.wait deps %tok : !amdgcn.read_token<flat>
+    %wf0 = amdgcn.wait deps %tok : !amdgcn.read_token<flat> -> !amdgcn.fence_token
     return
   }
 }
@@ -21,7 +21,7 @@ amdgcn.module @cdna3_new_wait target = #amdgcn.target<gfx942> {
     %c0 = arith.constant 0 : i32
     %r, %tok = amdgcn.global_load_dword dest %0 addr %arg0 offset c(%c0) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
     // expected-error @below {{'amdgcn.wait_gfx1250' op is not compatible with module target gfx942}}
-    amdgcn.wait_gfx1250 deps %tok : !amdgcn.read_token<flat>
+    %wf1 = amdgcn.wait_gfx1250 deps %tok : !amdgcn.read_token<flat> -> !amdgcn.fence_token
     return
   }
 }
@@ -35,7 +35,7 @@ amdgcn.module @cdna4_new_wait target = #amdgcn.target<gfx950> {
     %c0 = arith.constant 0 : i32
     %r, %tok = amdgcn.global_load_dword dest %0 addr %arg0 offset c(%c0) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
     // expected-error @below {{'amdgcn.wait_gfx1250' op is not compatible with module target gfx950}}
-    amdgcn.wait_gfx1250 deps %tok : !amdgcn.read_token<flat>
+    %wf2 = amdgcn.wait_gfx1250 deps %tok : !amdgcn.read_token<flat> -> !amdgcn.fence_token
     return
   }
 }

--- a/test/Dialect/AMDGCN/Transforms/backend-pipeline.mlir
+++ b/test/Dialect/AMDGCN/Transforms/backend-pipeline.mlir
@@ -7,7 +7,7 @@
 // CHECK:         v_mov_b32 outs(%[[V1]])
 // CHECK:         test_inst ins %[[V0]], %[[V1]]
 // CHECK-NOT:     alloca : !amdgcn.vgpr{{$}}
-// CHECK-NOT:     amdgcn.wait
+// CHECK-NOT:     amdgcn.wait -> !amdgcn.fence_token
 amdgcn.module @test_two_vgpr target = <gfx942> {
   amdgcn.kernel @two_vgpr_alloc {
     %a = amdgcn.alloca : !amdgcn.vgpr
@@ -31,7 +31,7 @@ amdgcn.module @test_two_vgpr target = <gfx942> {
 // CHECK:         s_waitcnt vmcnt = 0
 // CHECK:         global_store_dword
 // CHECK:         end_kernel
-// CHECK-NOT:     amdgcn.wait
+// CHECK-NOT:     amdgcn.wait -> !amdgcn.fence_token
 // CHECK-NOT:     alloca : !amdgcn.vgpr{{$}}
 // CHECK-NOT:     load_arg
 amdgcn.module @test_load_store target = <gfx942> {
@@ -45,7 +45,7 @@ amdgcn.module @test_load_store target = <gfx942> {
     %c0_i32_mig1 = arith.constant 0 : i32
     %voff = amdgcn.alloca : !amdgcn.vgpr
     %data_val, %tok = amdgcn.global_load_dword dest %data addr %src offset d(%voff) + c(%c0_i32_mig1) : outs(!amdgcn.vgpr) ins(!amdgcn.sgpr<[? : ? + 2]>, !amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<flat>
-    amdgcn.wait deps %tok : !amdgcn.read_token<flat>
+    %wf0 = amdgcn.wait deps %tok : !amdgcn.read_token<flat> -> !amdgcn.fence_token
     %voff2 = amdgcn.alloca : !amdgcn.vgpr
     %wtok = amdgcn.global_store_dword data %data_val addr %dst offset d(%voff2) + c(%c0_i32_mig1) : ins(!amdgcn.vgpr, !amdgcn.sgpr<[? : ? + 2]>, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<flat>
     amdgcn.end_kernel

--- a/test/Dialect/AMDGCN/Transforms/convert-waits-gfx1250-barrier.mlir
+++ b/test/Dialect/AMDGCN/Transforms/convert-waits-gfx1250-barrier.mlir
@@ -1,0 +1,33 @@
+// RUN: aster-opt %s --pass-pipeline='builtin.module(canonicalize,amdgcn.module(amdgcn-convert-waits))' | FileCheck %s
+
+// gfx1250 has no plain s_barrier: cross_wave_token_barrier lowers to the split
+// s_barrier_signal -1 / s_barrier_wait -1 pair. CDNA3 keeps a single s_barrier.
+
+// CHECK-LABEL:   func.func @gfx1250_cross_wave_barrier(
+//       CHECK:     amdgcn.s_barrier_signal -1
+//  CHECK-NEXT:     amdgcn.s_barrier_wait -1
+//   CHECK-NOT:     cross_wave_token_barrier
+amdgcn.module @convert_waits_gfx1250_mod target = #amdgcn.target<gfx1250> {
+func.func @gfx1250_cross_wave_barrier(%addr: !amdgcn.vgpr, %data: !amdgcn.vgpr) {
+  %c0 = arith.constant 0 : i32
+  %token = amdgcn.ds_write_b32 data %data addr %addr offset c(%c0) : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
+  %wf = amdgcn.wait_gfx1250 deps %token : !amdgcn.write_token<shared> -> !amdgcn.fence_token
+  %fence = amdgcn.cross_wave_token_barrier deps %wf : !amdgcn.fence_token
+  return
+}
+}
+
+// CHECK-LABEL:   func.func @cdna3_cross_wave_barrier(
+//   CHECK-NOT:     s_barrier_signal
+//   CHECK-NOT:     s_barrier_wait
+//       CHECK:     amdgcn.s_barrier
+//   CHECK-NOT:     cross_wave_token_barrier
+amdgcn.module @convert_waits_cdna3_mod target = <gfx942> {
+func.func @cdna3_cross_wave_barrier(%addr: !amdgcn.vgpr, %data: !amdgcn.vgpr) {
+  %c0 = arith.constant 0 : i32
+  %token = amdgcn.ds_write_b32 data %data addr %addr offset c(%c0) : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
+  %wf = amdgcn.wait deps %token : !amdgcn.write_token<shared> -> !amdgcn.fence_token
+  %fence = amdgcn.cross_wave_token_barrier deps %wf : !amdgcn.fence_token
+  return
+}
+}

--- a/test/Dialect/AMDGCN/Transforms/convert-waits.mlir
+++ b/test/Dialect/AMDGCN/Transforms/convert-waits.mlir
@@ -12,10 +12,10 @@ func.func @test_duplicated_waits() {
   %3 = amdgcn.alloca : !amdgcn.vgpr
   %c0_i32_mig1 = arith.constant 0 : i32
   %result, %token = amdgcn.global_load_dword dest %3 addr %2 offset c(%c0_i32_mig1) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
-  amdgcn.wait deps %token : !amdgcn.read_token<flat>
-  amdgcn.wait deps %token : !amdgcn.read_token<flat>
+  %wf0 = amdgcn.wait deps %token : !amdgcn.read_token<flat> -> !amdgcn.fence_token
+  %wf1 = amdgcn.wait deps %token : !amdgcn.read_token<flat> -> !amdgcn.fence_token
   %5 = amdgcn.global_store_dword data %result addr %2 offset c(%c0_i32_mig1) : ins(!amdgcn.vgpr, !amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.write_token<flat>
-  amdgcn.wait deps %5, %token : !amdgcn.write_token<flat>, !amdgcn.read_token<flat>
+  %wf2 = amdgcn.wait deps %5, %token : !amdgcn.write_token<flat>, !amdgcn.read_token<flat> -> !amdgcn.fence_token
   return
 }
 
@@ -38,12 +38,12 @@ func.func @test_pipelined_pattern(%arg0: !amdgcn.vgpr<[? + 2]>) {
   %c0_i32_mig4 = arith.constant 0 : i32
   %result_2, %token_3 = amdgcn.global_load_dword dest %0 addr %arg0 offset c(%c0_i32_mig4) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
   %2:3 = scf.for %arg1 = %c0 to %c4 step %c1 iter_args(%arg2 = %token, %arg3 = %token_1, %arg4 = %token_3) -> (!amdgcn.read_token<flat>, !amdgcn.read_token<flat>, !amdgcn.read_token<flat>) {
-    amdgcn.wait deps %arg2 : !amdgcn.read_token<flat>
+    %wf3 = amdgcn.wait deps %arg2 : !amdgcn.read_token<flat> -> !amdgcn.fence_token
     %c0_i32_mig5 = arith.constant 0 : i32
     %result_4, %token_5 = amdgcn.global_load_dword dest %0 addr %arg0 offset c(%c0_i32_mig5) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
     scf.yield %arg3, %arg4, %token_5 : !amdgcn.read_token<flat>, !amdgcn.read_token<flat>, !amdgcn.read_token<flat>
   }
-  amdgcn.wait deps %2#2 : !amdgcn.read_token<flat>
+  %wf4 = amdgcn.wait deps %2#2 : !amdgcn.read_token<flat> -> !amdgcn.fence_token
   return
 }
 
@@ -56,7 +56,7 @@ func.func @test_escaped_waits_1(%arg0: !amdgcn.vgpr<[? + 2]>, %arg1: i1) {
     %c0_i32_mig6 = arith.constant 0 : i32
     %result, %token = amdgcn.global_load_dword dest %0 addr %arg0 offset c(%c0_i32_mig6) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
   }
-  amdgcn.wait vm_cnt 63 lgkm_cnt 15
+  %wf5 = amdgcn.wait vm_cnt 63 lgkm_cnt 15 -> !amdgcn.fence_token
   return
 }
 
@@ -77,7 +77,7 @@ func.func @test_if_flow_1(%arg0: !amdgcn.vgpr<[? + 2]>, %arg1: i1) {
     %result, %token = amdgcn.global_load_dword dest %1 addr %arg0 offset c(%c0_i32_mig8) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
     scf.yield %token : !amdgcn.read_token<flat>
   }
-  amdgcn.wait deps %2 : !amdgcn.read_token<flat>
+  %wf6 = amdgcn.wait deps %2 : !amdgcn.read_token<flat> -> !amdgcn.fence_token
   return
 }
 
@@ -102,7 +102,7 @@ func.func @test_if_flow_2(%arg0: !amdgcn.vgpr<[? + 2]>, %arg1: i1) {
     %result, %token = amdgcn.global_load_dword dest %1 addr %arg0 offset c(%c0_i32_mig12) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
     scf.yield %token : !amdgcn.read_token<flat>
   }
-  amdgcn.wait deps %2 : !amdgcn.read_token<flat>
+  %wf7 = amdgcn.wait deps %2 : !amdgcn.read_token<flat> -> !amdgcn.fence_token
   return
 }
 
@@ -129,7 +129,7 @@ func.func @test_if_flow_3(%arg0: !amdgcn.vgpr<[? + 2]>, %arg1: i1) {
     %result_0, %token_1 = amdgcn.global_load_dword dest %0 addr %arg0 offset c(%c0_i32_mig17) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
     scf.yield %token : !amdgcn.read_token<flat>
   }
-  amdgcn.wait deps %2 : !amdgcn.read_token<flat>
+  %wf8 = amdgcn.wait deps %2 : !amdgcn.read_token<flat> -> !amdgcn.fence_token
   return
 }
 
@@ -148,8 +148,8 @@ func.func @test_passthrough_pattern(%arg0: !amdgcn.vgpr<[? + 2]>) {
   %result_0, %token_1 = amdgcn.global_load_dword dest %0 addr %arg0 offset c(%c0_i32_mig19) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
   %c0_i32_mig20 = arith.constant 0 : i32
   %result_2, %token_3 = amdgcn.global_load_dword dest %0 addr %arg0 offset c(%c0_i32_mig20) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
-  amdgcn.wait deps %token : !amdgcn.read_token<flat>
-  amdgcn.wait deps %token_3 : !amdgcn.read_token<flat>
+  %wf9 = amdgcn.wait deps %token : !amdgcn.read_token<flat> -> !amdgcn.fence_token
+  %wf10 = amdgcn.wait deps %token_3 : !amdgcn.read_token<flat> -> !amdgcn.fence_token
   return
 }
 
@@ -166,7 +166,7 @@ func.func @test_mixed_smem_dsmem(%arg0: !amdgcn.sgpr<[? + 2]>, %arg1: !amdgcn.vg
   %result_0, %token_1 = amdgcn.ds_read_b32 dest %1 addr %arg1 offset c(%c0_i32_mig1) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
   %c0_i32_mig21 = arith.constant 0 : i32
   %result_2, %token_3 = amdgcn.global_load_dword dest %1 addr %arg2 offset c(%c0_i32_mig21) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
-  amdgcn.wait deps %token : !amdgcn.read_token<constant>
+  %wf11 = amdgcn.wait deps %token : !amdgcn.read_token<constant> -> !amdgcn.fence_token
   return
 }
 
@@ -183,8 +183,8 @@ func.func @test_mixed_smem_dsmem_vmem(%arg0: !amdgcn.sgpr<[? + 2]>, %arg1: !amdg
   %result_0, %token_1 = amdgcn.ds_read_b32 dest %1 addr %arg1 offset c(%c0_i32_mig2) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
   %c0_i32_mig22 = arith.constant 0 : i32
   %result_2, %token_3 = amdgcn.global_load_dword dest %1 addr %arg2 offset c(%c0_i32_mig22) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
-  amdgcn.wait deps %token : !amdgcn.read_token<constant>
-  amdgcn.wait deps %token_3 : !amdgcn.read_token<flat>
+  %wf12 = amdgcn.wait deps %token : !amdgcn.read_token<constant> -> !amdgcn.fence_token
+  %wf13 = amdgcn.wait deps %token_3 : !amdgcn.read_token<flat> -> !amdgcn.fence_token
   return
 }
 
@@ -203,14 +203,14 @@ func.func @test_counts_strength(%arg0: !amdgcn.vgpr<[? + 2]>) {
   %result_0, %token_1 = amdgcn.global_load_dword dest %0 addr %arg0 offset c(%c0_i32_mig24) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
   %c0_i32_mig25 = arith.constant 0 : i32
   %result_2, %token_3 = amdgcn.global_load_dword dest %0 addr %arg0 offset c(%c0_i32_mig25) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
-  amdgcn.wait vm_cnt 1 deps %token : !amdgcn.read_token<flat>
+  %wf14 = amdgcn.wait vm_cnt 1 deps %token : !amdgcn.read_token<flat> -> !amdgcn.fence_token
   %c0_i32_mig26 = arith.constant 0 : i32
   %result_4, %token_5 = amdgcn.global_load_dword dest %0 addr %arg0 offset c(%c0_i32_mig26) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
   %c0_i32_mig27 = arith.constant 0 : i32
   %result_6, %token_7 = amdgcn.global_load_dword dest %0 addr %arg0 offset c(%c0_i32_mig27) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
   %c0_i32_mig28 = arith.constant 0 : i32
   %result_8, %token_9 = amdgcn.global_load_dword dest %0 addr %arg0 offset c(%c0_i32_mig28) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
-  amdgcn.wait vm_cnt 4 deps %token_5 : !amdgcn.read_token<flat>
+  %wf15 = amdgcn.wait vm_cnt 4 deps %token_5 : !amdgcn.read_token<flat> -> !amdgcn.fence_token
   return
 }
 
@@ -231,13 +231,13 @@ func.func @test_mixed_iter_args(%arg0: !amdgcn.vgpr<[? + 2]>) -> index {
   %c0_i32_mig29 = arith.constant 0 : i32
   %result, %token = amdgcn.global_load_dword dest %0 addr %arg0 offset c(%c0_i32_mig29) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
   %out:2 = scf.for %i = %c0 to %c4 step %c1 iter_args(%tok = %token, %acc = %c0) -> (!amdgcn.read_token<flat>, index) {
-    amdgcn.wait deps %tok : !amdgcn.read_token<flat>
+    %wf16 = amdgcn.wait deps %tok : !amdgcn.read_token<flat> -> !amdgcn.fence_token
     %c0_i32_mig30 = arith.constant 0 : i32
     %result2, %token2 = amdgcn.global_load_dword dest %0 addr %arg0 offset c(%c0_i32_mig30) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
     %new_acc = arith.addi %acc, %c1 : index
     scf.yield %token2, %new_acc : !amdgcn.read_token<flat>, index
   }
-  amdgcn.wait deps %out#0 : !amdgcn.read_token<flat>
+  %wf17 = amdgcn.wait deps %out#0 : !amdgcn.read_token<flat> -> !amdgcn.fence_token
   return %out#1 : index
 }
 
@@ -259,12 +259,12 @@ func.func @cf_args(%arg0: !amdgcn.vgpr<[? + 2]>, %cond: i1)  -> !amdgcn.read_tok
   %result, %token = amdgcn.global_load_dword dest %0 addr %arg0 offset c(%c0_i32_mig31) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
   cf.cond_br %cond, ^bb1(%token : !amdgcn.read_token<flat>), ^bb2(%token : !amdgcn.read_token<flat>)
 ^bb1(%1: !amdgcn.read_token<flat>):
-  amdgcn.wait deps %1 : !amdgcn.read_token<flat>
+  %wf18 = amdgcn.wait deps %1 : !amdgcn.read_token<flat> -> !amdgcn.fence_token
   %c0_i32_mig32 = arith.constant 0 : i32
   %result_0, %token_1 = amdgcn.global_load_dword dest %0 addr %arg0 offset c(%c0_i32_mig32) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
   cf.cond_br %cond, ^bb1(%token_1 : !amdgcn.read_token<flat>), ^bb2 (%token_1 : !amdgcn.read_token<flat>)
 ^bb2(%2: !amdgcn.read_token<flat>):
-  amdgcn.wait deps %2 : !amdgcn.read_token<flat>
+  %wf19 = amdgcn.wait deps %2 : !amdgcn.read_token<flat> -> !amdgcn.fence_token
   %3 = scf.if %cond -> (!amdgcn.read_token<flat>) {
     %c0_i32_mig33 = arith.constant 0 : i32
     %result_2, %token_2 = amdgcn.global_load_dword dest %0 addr %arg0 offset c(%c0_i32_mig33) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
@@ -287,7 +287,7 @@ func.func @cf_args(%arg0: !amdgcn.vgpr<[? + 2]>, %cond: i1)  -> !amdgcn.read_tok
 // CHECK:           return
 func.func @wait_on_poison_read_token() {
   %poison = ub.poison : !amdgcn.read_token<flat>
-  amdgcn.wait deps %poison : !amdgcn.read_token<flat>
+  %wf20 = amdgcn.wait deps %poison : !amdgcn.read_token<flat> -> !amdgcn.fence_token
   return
 }
 
@@ -297,7 +297,7 @@ func.func @wait_on_poison_read_token() {
 // CHECK:           return
 func.func @wait_on_poison_write_token() {
   %poison = ub.poison : !amdgcn.write_token<flat>
-  amdgcn.wait deps %poison : !amdgcn.write_token<flat>
+  %wf21 = amdgcn.wait deps %poison : !amdgcn.write_token<flat> -> !amdgcn.fence_token
   return
 }
 
@@ -307,7 +307,7 @@ func.func @wait_on_poison_write_token() {
 func.func @wait_on_poison_lgkm() {
   %poison_const = ub.poison : !amdgcn.read_token<constant>
   %poison_shared = ub.poison : !amdgcn.read_token<shared>
-  amdgcn.wait deps %poison_const, %poison_shared : !amdgcn.read_token<constant>, !amdgcn.read_token<shared>
+  %wf22 = amdgcn.wait deps %poison_const, %poison_shared : !amdgcn.read_token<constant>, !amdgcn.read_token<shared> -> !amdgcn.fence_token
   return
 }
 
@@ -319,7 +319,7 @@ func.func @wait_on_mixed_real_and_poison(%arg0: !amdgcn.vgpr<[? + 2]>) {
   %c0_i32_mig35 = arith.constant 0 : i32
   %result, %token = amdgcn.global_load_dword dest %0 addr %arg0 offset c(%c0_i32_mig35) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
   %poison = ub.poison : !amdgcn.read_token<flat>
-  amdgcn.wait deps %token, %poison : !amdgcn.read_token<flat>, !amdgcn.read_token<flat>
+  %wf23 = amdgcn.wait deps %token, %poison : !amdgcn.read_token<flat>, !amdgcn.read_token<flat> -> !amdgcn.fence_token
   return
 }
 
@@ -336,12 +336,12 @@ func.func @for_with_poison_init(%arg0: !amdgcn.vgpr<[? + 2]>) {
   %c4 = arith.constant 4 : index
   %poison = ub.poison : !amdgcn.read_token<flat>
   %out = scf.for %i = %c0 to %c4 step %c1 iter_args(%tok = %poison) -> (!amdgcn.read_token<flat>) {
-    amdgcn.wait deps %tok : !amdgcn.read_token<flat>
+    %wf24 = amdgcn.wait deps %tok : !amdgcn.read_token<flat> -> !amdgcn.fence_token
     %c0_i32_mig36 = arith.constant 0 : i32
     %result, %token = amdgcn.global_load_dword dest %0 addr %arg0 offset c(%c0_i32_mig36) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
     scf.yield %token : !amdgcn.read_token<flat>
   }
-  amdgcn.wait deps %out : !amdgcn.read_token<flat>
+  %wf25 = amdgcn.wait deps %out : !amdgcn.read_token<flat> -> !amdgcn.fence_token
   return
 }
 
@@ -373,12 +373,52 @@ func.func @test_wait_canonicalization(%addr: !amdgcn.vgpr) {
   %c0_i32_mig6 = arith.constant 0 : i32
   %result_3, %token_3 = amdgcn.ds_read_b32 dest %1 addr %addr offset c(%c0_i32_mig6) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
   // These 2 waits can be canonicalized into a single wait with lgkmcnt = 2.
-  amdgcn.wait deps %token : !amdgcn.read_token<shared>
-  amdgcn.wait deps %token_1 : !amdgcn.read_token<shared>
+  %wf26 = amdgcn.wait deps %token : !amdgcn.read_token<shared> -> !amdgcn.fence_token
+  %wf27 = amdgcn.wait deps %token_1 : !amdgcn.read_token<shared> -> !amdgcn.fence_token
   amdgcn.test_inst : () -> ()
-  amdgcn.wait deps %token_2 : !amdgcn.read_token<shared>
+  %wf28 = amdgcn.wait deps %token_2 : !amdgcn.read_token<shared> -> !amdgcn.fence_token
   amdgcn.test_inst : () -> ()
-  amdgcn.wait deps %token_3 : !amdgcn.read_token<shared>
+  %wf29 = amdgcn.wait deps %token_3 : !amdgcn.read_token<shared> -> !amdgcn.fence_token
+  return
+}
+
+// CHECK-LABEL:   func.func @test_cross_wave_token_barrier_legalized(
+// CHECK:           amdgcn.s_waitcnt lgkmcnt = 0
+// CHECK-NEXT:      amdgcn.s_barrier
+// CHECK-NOT:       cross_wave_token_barrier
+func.func @test_cross_wave_token_barrier_legalized(%addr: !amdgcn.vgpr, %data: !amdgcn.vgpr) {
+  %c0_i32_mig7 = arith.constant 0 : i32
+  %token = amdgcn.ds_write_b32 data %data addr %addr offset c(%c0_i32_mig7) : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
+  %wf30 = amdgcn.wait deps %token : !amdgcn.write_token<shared> -> !amdgcn.fence_token
+  %fence = amdgcn.cross_wave_token_barrier deps %wf30 : !amdgcn.fence_token
+  return
+}
+
+// CHECK-LABEL:   func.func @test_cross_wave_token_barrier_after_legalized(
+// CHECK:           amdgcn.s_barrier
+// CHECK:           amdgcn.ds_read_b32
+// CHECK-NOT:       fence_token
+// CHECK-NOT:       cross_wave_token_barrier
+func.func @test_cross_wave_token_barrier_after_legalized(%dst: !amdgcn.vgpr, %addr: !amdgcn.vgpr, %data: !amdgcn.vgpr) {
+  %c0 = arith.constant 0 : i32
+  %token = amdgcn.ds_write_b32 data %data addr %addr offset c(%c0) : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
+  %fence = amdgcn.cross_wave_token_barrier deps %token : !amdgcn.write_token<shared>
+  %r, %t = amdgcn.ds_read_b32 dest %dst addr %addr offset c(%c0) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared> fence_token %fence : !amdgcn.fence_token
+  return
+}
+
+// CHECK-LABEL:   func.func @test_wait_fence_to_barrier_legalized(
+// CHECK:           amdgcn.s_waitcnt lgkmcnt = 0
+// CHECK:           amdgcn.s_barrier
+// CHECK:           amdgcn.ds_read_b32
+// CHECK-NOT:       fence_token
+// CHECK-NOT:       cross_wave_token_barrier
+func.func @test_wait_fence_to_barrier_legalized(%dst: !amdgcn.vgpr, %addr: !amdgcn.vgpr, %data: !amdgcn.vgpr) {
+  %c0 = arith.constant 0 : i32
+  %token = amdgcn.ds_write_b32 data %data addr %addr offset c(%c0) : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
+  %wfence = amdgcn.wait deps %token : !amdgcn.write_token<shared> -> !amdgcn.fence_token
+  %bfence = amdgcn.cross_wave_token_barrier deps %wfence : !amdgcn.fence_token
+  %r, %t = amdgcn.ds_read_b32 dest %dst addr %addr offset c(%c0) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared> fence_token %bfence : !amdgcn.fence_token
   return
 }
 }

--- a/test/Dialect/AMDGCN/Transforms/hoist-iter-arg-waits.mlir
+++ b/test/Dialect/AMDGCN/Transforms/hoist-iter-arg-waits.mlir
@@ -3,7 +3,7 @@
 
 // HOIST-LABEL: func.func @hoist_pure_iter_arg_wait
 // HOIST:       scf.for {{.*}} iter_args(%[[TOK:.*]] = %{{.*}}, %[[DATA:.*]] = %{{.*}})
-// HOIST-NEXT:    amdgcn.wait deps %[[TOK]] : !amdgcn.read_token<flat>
+// HOIST-NEXT:    %{{.*}} = amdgcn.wait deps %[[TOK]] : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // HOIST:         amdgcn.global_load_dword
 // HOIST:         amdgcn.test_inst
 // HOIST:         scf.yield
@@ -21,12 +21,12 @@ func.func @hoist_pure_iter_arg_wait(%addr: !amdgcn.vgpr<[? + 2]>) {
       -> (!amdgcn.read_token<flat>, !amdgcn.vgpr) {
     %c0_i32_mig2 = arith.constant 0 : i32
     %new_data, %new_tok = amdgcn.global_load_dword dest %dest addr %addr offset c(%c0_i32_mig2) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
-    amdgcn.wait deps %iter_tok : !amdgcn.read_token<flat>
+    %wf0 = amdgcn.wait deps %iter_tok : !amdgcn.read_token<flat> -> !amdgcn.fence_token
     %result = amdgcn.test_inst outs %s_compute ins %iter_data
       : (!amdgcn.vgpr, !amdgcn.vgpr) -> !amdgcn.vgpr
     scf.yield %new_tok, %new_data : !amdgcn.read_token<flat>, !amdgcn.vgpr
   }
-  amdgcn.wait deps %res#0 : !amdgcn.read_token<flat>
+  %wf1 = amdgcn.wait deps %res#0 : !amdgcn.read_token<flat> -> !amdgcn.fence_token
   %final = amdgcn.test_inst outs %s_compute ins %res#1
     : (!amdgcn.vgpr, !amdgcn.vgpr) -> !amdgcn.vgpr
   return
@@ -34,9 +34,9 @@ func.func @hoist_pure_iter_arg_wait(%addr: !amdgcn.vgpr<[? + 2]>) {
 
 // HOIST-LABEL: func.func @clone_mixed_dep_wait
 // HOIST:       scf.for {{.*}} iter_args(%[[ITOK:.*]] = %{{.*}}, %[[IDATA:.*]] = %{{.*}})
-// HOIST-NEXT:    amdgcn.wait deps %[[ITOK]] : !amdgcn.read_token<flat>
+// HOIST-NEXT:    %{{.*}} = amdgcn.wait deps %[[ITOK]] : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // HOIST:         %[[ND:.*]], %[[NT:.*]] = amdgcn.global_load_dword
-// HOIST:         amdgcn.wait deps %[[NT]] : !amdgcn.read_token<flat>
+// HOIST:         %{{.*}} = amdgcn.wait deps %[[NT]] : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // HOIST:         amdgcn.test_inst
 // HOIST:         scf.yield
 
@@ -54,13 +54,12 @@ func.func @clone_mixed_dep_wait(%addr: !amdgcn.vgpr<[? + 2]>) {
       -> (!amdgcn.read_token<flat>, !amdgcn.vgpr) {
     %c0_i32_mig4 = arith.constant 0 : i32
     %new_data, %new_tok = amdgcn.global_load_dword dest %dest2 addr %addr offset c(%c0_i32_mig4) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
-    amdgcn.wait deps %iter_tok, %new_tok
-      : !amdgcn.read_token<flat>, !amdgcn.read_token<flat>
+    %wf2 = amdgcn.wait deps %iter_tok, %new_tok : !amdgcn.read_token<flat>, !amdgcn.read_token<flat> -> !amdgcn.fence_token
     %result = amdgcn.test_inst outs %s_compute ins %iter_data
       : (!amdgcn.vgpr, !amdgcn.vgpr) -> !amdgcn.vgpr
     scf.yield %new_tok, %new_data : !amdgcn.read_token<flat>, !amdgcn.vgpr
   }
-  amdgcn.wait deps %res#0 : !amdgcn.read_token<flat>
+  %wf3 = amdgcn.wait deps %res#0 : !amdgcn.read_token<flat> -> !amdgcn.fence_token
   %final = amdgcn.test_inst outs %s_compute ins %res#1
     : (!amdgcn.vgpr, !amdgcn.vgpr) -> !amdgcn.vgpr
   return
@@ -68,8 +67,8 @@ func.func @clone_mixed_dep_wait(%addr: !amdgcn.vgpr<[? + 2]>) {
 
 // HOIST-LABEL: func.func @hoist_multiple_waits
 // HOIST:       scf.for {{.*}} iter_args(
-// HOIST-NEXT:    amdgcn.wait deps %{{.*}} : !amdgcn.write_token<shared>
-// HOIST-NEXT:    amdgcn.wait deps %{{.*}} : !amdgcn.write_token<shared>
+// HOIST-NEXT:    %{{.*}} = amdgcn.wait deps %{{.*}} : !amdgcn.write_token<shared> -> !amdgcn.fence_token
+// HOIST-NEXT:    %{{.*}} = amdgcn.wait deps %{{.*}} : !amdgcn.write_token<shared> -> !amdgcn.fence_token
 // HOIST:         amdgcn.ds_write_b32
 // HOIST:         amdgcn.ds_read_b32
 // HOIST:         amdgcn.test_inst
@@ -77,7 +76,7 @@ func.func @clone_mixed_dep_wait(%addr: !amdgcn.vgpr<[? + 2]>) {
 
 // MERGE-LABEL: func.func @hoist_multiple_waits
 // MERGE:       scf.for {{.*}} iter_args(
-// MERGE-NEXT:    amdgcn.wait deps %{{.*}}, %{{.*}} : !amdgcn.write_token<shared>, !amdgcn.write_token<shared>
+// MERGE-NEXT:    %{{.*}} = amdgcn.wait deps %{{.*}}, %{{.*}} : !amdgcn.write_token<shared>, !amdgcn.write_token<shared> -> !amdgcn.fence_token
 // MERGE:         amdgcn.ds_write_b32
 // MERGE:         amdgcn.ds_read_b32
 // MERGE:         amdgcn.test_inst
@@ -96,18 +95,17 @@ func.func @hoist_multiple_waits(%data_in: !amdgcn.vgpr, %lds_addr_a: !amdgcn.vgp
       iter_args(%iter_wtok_a = %wtok_a, %iter_wtok_b = %wtok_b)
       -> (!amdgcn.write_token<shared>, !amdgcn.write_token<shared>) {
     %new_wtok_a = amdgcn.ds_write_b32 data %data_in addr %lds_addr_a offset c(%c0_i32) : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
-    amdgcn.wait deps %iter_wtok_a : !amdgcn.write_token<shared>
+    %wf4 = amdgcn.wait deps %iter_wtok_a : !amdgcn.write_token<shared> -> !amdgcn.fence_token
     %c0_i32_mig1 = arith.constant 0 : i32
     %read_data, %rtok = amdgcn.ds_read_b32 dest %s_read addr %lds_addr_a offset c(%c0_i32_mig1) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
     %new_wtok_b = amdgcn.ds_write_b32 data %data_in addr %lds_addr_b offset c(%c0_i32) : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
-    amdgcn.wait deps %iter_wtok_b : !amdgcn.write_token<shared>
+    %wf5 = amdgcn.wait deps %iter_wtok_b : !amdgcn.write_token<shared> -> !amdgcn.fence_token
     %result = amdgcn.test_inst outs %s_out ins %read_data
       : (!amdgcn.vgpr, !amdgcn.vgpr) -> !amdgcn.vgpr
     scf.yield %new_wtok_a, %new_wtok_b
       : !amdgcn.write_token<shared>, !amdgcn.write_token<shared>
   }
-  amdgcn.wait deps %res#0, %res#1
-    : !amdgcn.write_token<shared>, !amdgcn.write_token<shared>
+  %wf6 = amdgcn.wait deps %res#0, %res#1 : !amdgcn.write_token<shared>, !amdgcn.write_token<shared> -> !amdgcn.fence_token
   return
 }
 
@@ -115,7 +113,7 @@ func.func @hoist_multiple_waits(%data_in: !amdgcn.vgpr, %lds_addr_a: !amdgcn.vgp
 // HOIST-LABEL: func.func @no_hoist_intra_only_wait
 // HOIST:       scf.for {{.*}} iter_args(%[[TOK:.*]] = %{{.*}}, %[[DATA:.*]] = %{{.*}})
 // HOIST:         %[[ND:.*]], %[[NT:.*]] = amdgcn.global_load_dword
-// HOIST-NEXT:    amdgcn.wait deps %[[NT]] : !amdgcn.read_token<flat>
+// HOIST-NEXT:    %{{.*}} = amdgcn.wait deps %[[NT]] : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // HOIST:         scf.yield
 
 func.func @no_hoist_intra_only_wait(%addr: !amdgcn.vgpr<[? + 2]>) {
@@ -132,21 +130,21 @@ func.func @no_hoist_intra_only_wait(%addr: !amdgcn.vgpr<[? + 2]>) {
     // Wait depends only on intra-iteration token -- must stay after load
     %c0_i32_mig6 = arith.constant 0 : i32
     %new_data, %new_tok = amdgcn.global_load_dword dest %dest addr %addr offset c(%c0_i32_mig6) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
-    amdgcn.wait deps %new_tok : !amdgcn.read_token<flat>
+    %wf7 = amdgcn.wait deps %new_tok : !amdgcn.read_token<flat> -> !amdgcn.fence_token
     %result = amdgcn.test_inst outs %s_compute ins %new_data
       : (!amdgcn.vgpr, !amdgcn.vgpr) -> !amdgcn.vgpr
     scf.yield %new_tok, %new_data : !amdgcn.read_token<flat>, !amdgcn.vgpr
   }
-  amdgcn.wait deps %res#0 : !amdgcn.read_token<flat>
+  %wf8 = amdgcn.wait deps %res#0 : !amdgcn.read_token<flat> -> !amdgcn.fence_token
   return
 }
 
 // Nested loop: inner loop's iter_arg wait must not be hoisted to outer loop.
 // HOIST-LABEL: func.func @no_hoist_across_nested_loops
 // HOIST:       scf.for
-// HOIST-NEXT:    amdgcn.wait deps %{{.*}} : !amdgcn.read_token<flat>
+// HOIST-NEXT:    %{{.*}} = amdgcn.wait deps %{{.*}} : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // HOIST:         scf.for
-// HOIST-NEXT:      amdgcn.wait deps %{{.*}} : !amdgcn.write_token<shared>
+// HOIST-NEXT:      %{{.*}} = amdgcn.wait deps %{{.*}} : !amdgcn.write_token<shared> -> !amdgcn.fence_token
 // HOIST:           scf.yield
 // HOIST:         scf.yield
 
@@ -165,25 +163,25 @@ func.func @no_hoist_across_nested_loops(%addr: !amdgcn.vgpr<[? + 2]>, %lds_addr:
       -> (!amdgcn.read_token<flat>, !amdgcn.vgpr) {
     %c0_i32_mig8 = arith.constant 0 : i32
     %new_data, %new_tok = amdgcn.global_load_dword dest %dest addr %addr offset c(%c0_i32_mig8) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
-    amdgcn.wait deps %outer_tok : !amdgcn.read_token<flat>
+    %wf9 = amdgcn.wait deps %outer_tok : !amdgcn.read_token<flat> -> !amdgcn.fence_token
     // Inner loop with its own iter_arg token
     %init_wtok = amdgcn.ds_write_b32 data %outer_data addr %lds_addr offset c(%c0_i32) : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
     %inner_res = scf.for %j = %c0 to %c4 step %c1
         iter_args(%inner_wtok = %init_wtok) -> (!amdgcn.write_token<shared>) {
-      amdgcn.wait deps %inner_wtok : !amdgcn.write_token<shared>
+      %wf10 = amdgcn.wait deps %inner_wtok : !amdgcn.write_token<shared> -> !amdgcn.fence_token
       %new_inner_wtok = amdgcn.ds_write_b32 data %outer_data addr %lds_addr offset c(%c0_i32) : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
       scf.yield %new_inner_wtok : !amdgcn.write_token<shared>
     }
     scf.yield %new_tok, %new_data : !amdgcn.read_token<flat>, !amdgcn.vgpr
   }
-  amdgcn.wait deps %res#0 : !amdgcn.read_token<flat>
+  %wf11 = amdgcn.wait deps %res#0 : !amdgcn.read_token<flat> -> !amdgcn.fence_token
   return
 }
 
 // Barrier with no waits after it is moved after the hoisted waits.
 // HOIST-LABEL: func.func @hoist_barrier_after_waits
 // HOIST:       scf.for {{.*}} iter_args(%[[TOK:.*]] = %{{.*}}, %[[DATA:.*]] = %{{.*}})
-// HOIST-NEXT:    amdgcn.wait deps %[[TOK]] : !amdgcn.write_token<shared>
+// HOIST-NEXT:    %{{.*}} = amdgcn.wait deps %[[TOK]] : !amdgcn.write_token<shared> -> !amdgcn.fence_token
 // HOIST-NEXT:    amdgcn.s_barrier
 // HOIST:         %{{.*}}, %{{.*}} = amdgcn.ds_read_b32
 // HOIST:         amdgcn.ds_write_b32
@@ -201,7 +199,7 @@ func.func @hoist_barrier_after_waits(%data_in: !amdgcn.vgpr, %lds_addr: !amdgcn.
   %res:2 = scf.for %i = %c1 to %c4 step %c1
       iter_args(%iter_wtok = %init_wtok, %iter_data = %init_data)
       -> (!amdgcn.write_token<shared>, !amdgcn.vgpr) {
-    amdgcn.wait deps %iter_wtok : !amdgcn.write_token<shared>
+    %wf12 = amdgcn.wait deps %iter_wtok : !amdgcn.write_token<shared> -> !amdgcn.fence_token
     amdgcn.s_barrier
     %c0_i32_mig3 = arith.constant 0 : i32
     %read_data, %rtok = amdgcn.ds_read_b32 dest %s_read addr %lds_addr offset c(%c0_i32_mig3) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
@@ -209,17 +207,17 @@ func.func @hoist_barrier_after_waits(%data_in: !amdgcn.vgpr, %lds_addr: !amdgcn.
     scf.yield %new_wtok, %read_data
       : !amdgcn.write_token<shared>, !amdgcn.vgpr
   }
-  amdgcn.wait deps %res#0 : !amdgcn.write_token<shared>
+  %wf13 = amdgcn.wait deps %res#0 : !amdgcn.write_token<shared> -> !amdgcn.fence_token
   return
 }
 
 // Barrier with a wait AFTER it must NOT be moved.
 // HOIST-LABEL: func.func @no_move_barrier_with_wait_after
 // HOIST:       scf.for {{.*}} iter_args(%[[TOK:.*]] = %{{.*}}, %[[DATA:.*]] = %{{.*}})
-// HOIST-NEXT:    amdgcn.wait deps %[[TOK]] : !amdgcn.write_token<shared>
+// HOIST-NEXT:    %{{.*}} = amdgcn.wait deps %[[TOK]] : !amdgcn.write_token<shared> -> !amdgcn.fence_token
 // HOIST:         amdgcn.ds_write_b32
 // HOIST-NEXT:    amdgcn.s_barrier
-// HOIST:         amdgcn.wait deps %{{.*}} : !amdgcn.read_token<shared>
+// HOIST:         %{{.*}} = amdgcn.wait deps %{{.*}} : !amdgcn.read_token<shared> -> !amdgcn.fence_token
 // HOIST:         scf.yield
 
 func.func @no_move_barrier_with_wait_after(%data_in: !amdgcn.vgpr, %lds_addr: !amdgcn.vgpr) {
@@ -234,16 +232,16 @@ func.func @no_move_barrier_with_wait_after(%data_in: !amdgcn.vgpr, %lds_addr: !a
   %res:2 = scf.for %i = %c1 to %c4 step %c1
       iter_args(%iter_wtok = %init_wtok, %iter_data = %init_data)
       -> (!amdgcn.write_token<shared>, !amdgcn.vgpr) {
-    amdgcn.wait deps %iter_wtok : !amdgcn.write_token<shared>
+    %wf14 = amdgcn.wait deps %iter_wtok : !amdgcn.write_token<shared> -> !amdgcn.fence_token
     %new_wtok = amdgcn.ds_write_b32 data %data_in addr %lds_addr offset c(%c0_i32) : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
     amdgcn.s_barrier
     %c0_i32_mig5 = arith.constant 0 : i32
     %read_data, %rtok = amdgcn.ds_read_b32 dest %s_read addr %lds_addr offset c(%c0_i32_mig5) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
-    amdgcn.wait deps %rtok : !amdgcn.read_token<shared>
+    %wf15 = amdgcn.wait deps %rtok : !amdgcn.read_token<shared> -> !amdgcn.fence_token
     scf.yield %new_wtok, %read_data
       : !amdgcn.write_token<shared>, !amdgcn.vgpr
   }
-  amdgcn.wait deps %res#0 : !amdgcn.write_token<shared>
+  %wf16 = amdgcn.wait deps %res#0 : !amdgcn.write_token<shared> -> !amdgcn.fence_token
   return
 }
 
@@ -252,7 +250,7 @@ func.func @no_move_barrier_with_wait_after(%data_in: !amdgcn.vgpr, %lds_addr: !a
 // HOIST:       scf.for {{.*}} iter_args(%[[TOK:.*]] = %{{.*}}, %[[DATA:.*]] = %{{.*}})
 // HOIST:         amdgcn.global_load_dword
 // HOIST:         scf.if
-// HOIST:           amdgcn.wait deps %[[TOK]]
+// HOIST:           %{{.*}} = amdgcn.wait deps %[[TOK]] : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // HOIST:         scf.yield
 
 func.func @no_hoist_wait_inside_scf_if(%addr: !amdgcn.vgpr<[? + 2]>, %cond: i1) {
@@ -270,13 +268,13 @@ func.func @no_hoist_wait_inside_scf_if(%addr: !amdgcn.vgpr<[? + 2]>, %cond: i1) 
     %new_data, %new_tok = amdgcn.global_load_dword dest %dest addr %addr offset c(%c0_i32_mig10) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
     // Wait is inside scf.if -- not a direct child of the for body
     scf.if %cond {
-      amdgcn.wait deps %iter_tok : !amdgcn.read_token<flat>
+      %wf17 = amdgcn.wait deps %iter_tok : !amdgcn.read_token<flat> -> !amdgcn.fence_token
       %result = amdgcn.test_inst outs %s_compute ins %iter_data
         : (!amdgcn.vgpr, !amdgcn.vgpr) -> !amdgcn.vgpr
     }
     scf.yield %new_tok, %new_data : !amdgcn.read_token<flat>, !amdgcn.vgpr
   }
-  amdgcn.wait deps %res#0 : !amdgcn.read_token<flat>
+  %wf18 = amdgcn.wait deps %res#0 : !amdgcn.read_token<flat> -> !amdgcn.fence_token
   return
 }
 
@@ -284,7 +282,7 @@ func.func @no_hoist_wait_inside_scf_if(%addr: !amdgcn.vgpr<[? + 2]>, %cond: i1) 
 // HOIST-LABEL: func.func @no_hoist_count_only_wait
 // HOIST:       scf.for {{.*}} iter_args(%[[TOK:.*]] = %{{.*}}, %[[DATA:.*]] = %{{.*}})
 // HOIST:         amdgcn.global_load_dword
-// HOIST:         amdgcn.wait vm_cnt 0
+// HOIST:         %{{.*}} = amdgcn.wait vm_cnt 0 -> !amdgcn.fence_token
 // HOIST:         scf.yield
 
 func.func @no_hoist_count_only_wait(%addr: !amdgcn.vgpr<[? + 2]>) {
@@ -301,11 +299,11 @@ func.func @no_hoist_count_only_wait(%addr: !amdgcn.vgpr<[? + 2]>) {
     %c0_i32_mig12 = arith.constant 0 : i32
     %new_data, %new_tok = amdgcn.global_load_dword dest %dest addr %addr offset c(%c0_i32_mig12) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
     // Count-only wait has no token deps -- must not be hoisted
-    amdgcn.wait vm_cnt 0
+    %wf19 = amdgcn.wait vm_cnt 0 -> !amdgcn.fence_token
     %result = amdgcn.test_inst outs %s_compute ins %iter_data
       : (!amdgcn.vgpr, !amdgcn.vgpr) -> !amdgcn.vgpr
     scf.yield %new_tok, %new_data : !amdgcn.read_token<flat>, !amdgcn.vgpr
   }
-  amdgcn.wait deps %res#0 : !amdgcn.read_token<flat>
+  %wf20 = amdgcn.wait deps %res#0 : !amdgcn.read_token<flat> -> !amdgcn.fence_token
   return
 }

--- a/test/Dialect/AMDGCN/Transforms/late-waits.mlir
+++ b/test/Dialect/AMDGCN/Transforms/late-waits.mlir
@@ -8,7 +8,7 @@ amdgcn.module @late_waits_0 target = #amdgcn.target<gfx942> {
 // CHECK:         %[[ADDR:.*]] = amdgcn.make_register_range %[[A]], %[[B]]
 // CHECK:         amdgcn.global_load_dword dest %[[DEST]] addr %[[ADDR]]
 // CHECK:         amdgcn.s_waitcnt vmcnt = 0
-// CHECK-NOT:     amdgcn.wait
+// CHECK-NOT:     amdgcn.wait -> !amdgcn.fence_token
 // CHECK:         amdgcn.global_store_dword data %[[DEST]] addr %[[ADDR]]
 // CHECK:         return
 func.func @vmem_load_store() {
@@ -31,7 +31,7 @@ amdgcn.module @late_waits_1 target = #amdgcn.target<gfx942> {
 // CHECK:         %[[ADDR:.*]] = amdgcn.alloca : !amdgcn.vgpr<?>
 // CHECK:         amdgcn.ds_read_b32 dest %[[DEST]] addr %[[ADDR]]
 // CHECK:         amdgcn.s_waitcnt lgkmcnt = 0
-// CHECK-NOT:     amdgcn.wait
+// CHECK-NOT:     amdgcn.wait -> !amdgcn.fence_token
 // CHECK:         amdgcn.ds_write_b32 data %[[DEST]] addr %[[ADDR]]
 // CHECK:         return
 func.func @shared_load_store() {
@@ -57,7 +57,7 @@ amdgcn.module @late_waits_2 target = #amdgcn.target<gfx942> {
 // CHECK:       ^bb2:
 // CHECK:         amdgcn.s_waitcnt vmcnt = 0
 // CHECK:         amdgcn.global_store_dword data %[[DEST]]
-// CHECK-NOT:     amdgcn.wait
+// CHECK-NOT:     amdgcn.wait -> !amdgcn.fence_token
 func.func @vmem_load_branch(%cond: i1) {
   %0 = amdgcn.alloca : !amdgcn.vgpr<?>
   %1 = amdgcn.alloca : !amdgcn.vgpr<?>

--- a/test/Dialect/AMDGCN/Transforms/ll-sched-barrier-drain.mlir
+++ b/test/Dialect/AMDGCN/Transforms/ll-sched-barrier-drain.mlir
@@ -70,4 +70,21 @@ amdgcn.module @test target = #amdgcn.target<gfx942> {
     amdgcn.s_barrier
     amdgcn.end_kernel
   }
+
+  // CHECK-LABEL: kernel @cross_wave_token_barrier_order
+  // CHECK:         ds_write_b32
+  // CHECK:         cross_wave_token_barrier
+  // CHECK:         ds_read_b32
+  // CHECK:         end_kernel
+  amdgcn.kernel @cross_wave_token_barrier_order {
+    %addr = amdgcn.alloca : !v
+    %data = amdgcn.alloca : !v
+    %rd = amdgcn.alloca : !v
+    %c0 = arith.constant 0 : i32
+    %wtok = amdgcn.ds_write_b32 data %data addr %addr offset c(%c0) : ins(!v, !v) mods(i32) -> !amdgcn.write_token<shared>
+    // Tokenized barrier with fence token keeps write-before-read ordering.
+    %bar = amdgcn.cross_wave_token_barrier deps %wtok : !amdgcn.write_token<shared>
+    %r, %t = amdgcn.ds_read_b32 dest %rd addr %addr offset c(%c0) : outs(!v) ins(!v) mods(i32) -> !amdgcn.read_token<shared> fence_token %bar : !amdgcn.fence_token
+    amdgcn.end_kernel
+  }
 }

--- a/test/Dialect/AMDGCN/Transforms/ll-sched-barrier-token-edges.mlir
+++ b/test/Dialect/AMDGCN/Transforms/ll-sched-barrier-token-edges.mlir
@@ -1,0 +1,124 @@
+// RUN: aster-opt %s --pass-pipeline="builtin.module(test-amdgcn-sched-graph)" 2>&1 | FileCheck %s
+
+!v = !amdgcn.vgpr
+!s = !amdgcn.sgpr
+
+amdgcn.module @cross_wave_token_barrier_deps target = #amdgcn.target<gfx942> {
+  // CHECK-LABEL: Kernel: @cross_wave_token_barrier_deps
+  // CHECK:       digraph SchedGraph
+  // CHECK-DAG:     label = "ds_write_b32 -> cross_wave_token_barrier"
+  // CHECK-NOT:     label = "cross_wave_token_barrier -> ds_read_b32"
+  // CHECK-NOT:     label = "cross_wave_token_barrier -> s_mov_b32"
+  // CHECK-NOT:     label = "s_mov_b32 -> cross_wave_token_barrier"
+  // CHECK:       }
+  amdgcn.kernel @cross_wave_token_barrier_deps {
+    %addr = amdgcn.alloca : !v
+    %data = amdgcn.alloca : !v
+    %rd = amdgcn.alloca : !v
+    %s0 = amdgcn.alloca : !s
+    %c0 = arith.constant 0 : i32
+    %c7 = arith.constant 7 : i32
+    %tok = amdgcn.ds_write_b32 data %data addr %addr offset c(%c0) : ins(!v, !v) mods(i32) -> !amdgcn.write_token<shared>
+    %bar = amdgcn.cross_wave_token_barrier deps %tok : !amdgcn.write_token<shared>
+    %r, %t = amdgcn.ds_read_b32 dest %rd addr %addr offset c(%c0) : outs(!v) ins(!v) mods(i32) -> !amdgcn.read_token<shared>
+    %m = amdgcn.s_mov_b32 outs(%s0) ins(%c7) : outs(!s) ins(i32)
+    amdgcn.end_kernel
+  }
+}
+
+// -----
+
+amdgcn.module @cross_wave_token_barrier_after target = #amdgcn.target<gfx942> {
+  // CHECK-LABEL: Kernel: @cross_wave_token_barrier_after
+  // CHECK:       digraph SchedGraph
+  // CHECK-DAG:     label = "ds_write_b32 -> cross_wave_token_barrier"
+  // CHECK-DAG:     label = "cross_wave_token_barrier -> ds_read_b32"
+  // CHECK-NOT:     label = "cross_wave_token_barrier -> s_mov_b32"
+  // CHECK:       }
+  amdgcn.kernel @cross_wave_token_barrier_after {
+    %addr = amdgcn.alloca : !v
+    %data = amdgcn.alloca : !v
+    %rd = amdgcn.alloca : !v
+    %s0 = amdgcn.alloca : !s
+    %c0 = arith.constant 0 : i32
+    %c7 = arith.constant 7 : i32
+    %tok = amdgcn.ds_write_b32 data %data addr %addr offset c(%c0) : ins(!v, !v) mods(i32) -> !amdgcn.write_token<shared>
+    %bar = amdgcn.cross_wave_token_barrier deps %tok : !amdgcn.write_token<shared>
+    %r, %t = amdgcn.ds_read_b32 dest %rd addr %addr offset c(%c0) : outs(!v) ins(!v) mods(i32) -> !amdgcn.read_token<shared> fence_token %bar : !amdgcn.fence_token
+    %m = amdgcn.s_mov_b32 outs(%s0) ins(%c7) : outs(!s) ins(i32)
+    amdgcn.end_kernel
+  }
+}
+
+// -----
+
+// Plain s_barrier conservatively pins memory and SALU ops.
+amdgcn.module @plain_barrier target = #amdgcn.target<gfx942> {
+  // CHECK-LABEL: Kernel: @plain_barrier
+  // CHECK:       digraph SchedGraph
+  // CHECK-DAG:     label = "ds_write_b32 -> s_barrier"
+  // CHECK-DAG:     label = "s_barrier -> ds_read_b32"
+  // CHECK-DAG:     label = "s_barrier -> s_mov_b32"
+  // CHECK:       }
+  amdgcn.kernel @plain_barrier {
+    %addr = amdgcn.alloca : !v
+    %data = amdgcn.alloca : !v
+    %rd = amdgcn.alloca : !v
+    %s0 = amdgcn.alloca : !s
+    %c0 = arith.constant 0 : i32
+    %c7 = arith.constant 7 : i32
+    %tok = amdgcn.ds_write_b32 data %data addr %addr offset c(%c0) : ins(!v, !v) mods(i32) -> !amdgcn.write_token<shared>
+    amdgcn.s_barrier
+    %r, %t = amdgcn.ds_read_b32 dest %rd addr %addr offset c(%c0) : outs(!v) ins(!v) mods(i32) -> !amdgcn.read_token<shared>
+    %m = amdgcn.s_mov_b32 outs(%s0) ins(%c7) : outs(!s) ins(i32)
+    amdgcn.end_kernel
+  }
+}
+
+// -----
+
+// BarrierOpInterface ops are serialized in program order.
+amdgcn.module @barrier_serialization target = #amdgcn.target<gfx942> {
+  // CHECK-LABEL: Kernel: @barrier_serialization
+  // CHECK:       digraph SchedGraph
+  // CHECK-DAG:     label = "s_barrier -> s_barrier"
+  // CHECK-DAG:     label = "s_barrier -> cross_wave_token_barrier"
+  // CHECK:       }
+  amdgcn.kernel @barrier_serialization {
+    %addr = amdgcn.alloca : !v
+    %data = amdgcn.alloca : !v
+    %c0 = arith.constant 0 : i32
+    %tok = amdgcn.ds_write_b32 data %data addr %addr offset c(%c0) : ins(!v, !v) mods(i32) -> !amdgcn.write_token<shared>
+    amdgcn.s_barrier
+    amdgcn.s_barrier
+    %bar = amdgcn.cross_wave_token_barrier deps %tok : !amdgcn.write_token<shared>
+    amdgcn.end_kernel
+  }
+}
+
+// -----
+
+// SSA-managed successors: only the ds_read that takes the fence token via
+// `fence_token` is pinned after the barrier.
+amdgcn.module @cross_wave_token_barrier_acquire_precise target = #amdgcn.target<gfx942> {
+  // CHECK-LABEL: Kernel: @cross_wave_token_barrier_acquire_precise
+  // CHECK:       digraph SchedGraph
+  // CHECK-DAG:     label = "cross_wave_token_barrier -> ds_read_b32"
+  // CHECK-NOT:     label = "cross_wave_token_barrier -> ds_read_b64"
+  // CHECK:       }
+  amdgcn.kernel @cross_wave_token_barrier_acquire_precise {
+    %addr = amdgcn.alloca : !v
+    %addr2 = amdgcn.alloca : !v
+    %data = amdgcn.alloca : !v
+    %rd32 = amdgcn.alloca : !v
+    %rd0 = amdgcn.alloca : !v
+    %rd1 = amdgcn.alloca : !v
+    %rd64 = amdgcn.make_register_range %rd0, %rd1 : !v, !v
+    %c0 = arith.constant 0 : i32
+    %wtok = amdgcn.ds_write_b32 data %data addr %addr offset c(%c0) : ins(!v, !v) mods(i32) -> !amdgcn.write_token<shared>
+    %bar = amdgcn.cross_wave_token_barrier deps %wtok : !amdgcn.write_token<shared>
+    %r32, %t32 = amdgcn.ds_read_b32 dest %rd32 addr %addr offset c(%c0) : outs(!v) ins(!v) mods(i32) -> !amdgcn.read_token<shared> fence_token %bar : !amdgcn.fence_token
+    %r64, %t64 = amdgcn.ds_read_b64 dest %rd64 addr %addr2 offset c(%c0) : outs(!amdgcn.vgpr<[? + 2]>) ins(!v) mods(i32) -> !amdgcn.read_token<shared>
+    amdgcn.end_kernel
+  }
+}

--- a/test/Dialect/AMDGCN/Transforms/ll-sched.mlir
+++ b/test/Dialect/AMDGCN/Transforms/ll-sched.mlir
@@ -224,6 +224,39 @@ amdgcn.module @test target = #amdgcn.target<gfx942> {
     amdgcn.end_kernel
   }
 
+  // CHECK-LABEL: kernel @cross_wave_barrier_separates_lds
+  // CHECK:         ds_write_b64
+  // CHECK:         ds_write_b64
+  // CHECK:         cross_wave_token_barrier
+  // CHECK:         ds_read_b64
+  // CHECK:         ds_read_b64
+  // CHECK:         end_kernel
+  amdgcn.kernel @cross_wave_barrier_separates_lds {
+    %addr0 = amdgcn.alloca : !v
+    %addr1 = amdgcn.alloca : !v
+    %wd0 = amdgcn.alloca : !v
+    %wd1 = amdgcn.alloca : !v
+    %data0 = amdgcn.make_register_range %wd0, %wd1 : !v, !v
+    %wd2 = amdgcn.alloca : !v
+    %wd3 = amdgcn.alloca : !v
+    %data1 = amdgcn.make_register_range %wd2, %wd3 : !v, !v
+    %rd0 = amdgcn.alloca : !v
+    %rd1 = amdgcn.alloca : !v
+    %dst0 = amdgcn.make_register_range %rd0, %rd1 : !v, !v
+    %rd2 = amdgcn.alloca : !v
+    %rd3 = amdgcn.alloca : !v
+    %dst1 = amdgcn.make_register_range %rd2, %rd3 : !v, !v
+    %c0 = arith.constant 0 : i32
+    %c8 = arith.constant 8 : i32
+    // Cross-wave token barrier with fence tokens orders LDS write-then-read.
+    %wt0 = amdgcn.ds_write_b64 data %data0 addr %addr0 offset c(%c0) : ins(!vx2, !v) mods(i32) -> !amdgcn.write_token<shared>
+    %wt1 = amdgcn.ds_write_b64 data %data1 addr %addr1 offset c(%c0) : ins(!vx2, !v) mods(i32) -> !amdgcn.write_token<shared>
+    %bar = amdgcn.cross_wave_token_barrier deps %wt0, %wt1 : !amdgcn.write_token<shared>, !amdgcn.write_token<shared>
+    %rr0, %rt0 = amdgcn.ds_read_b64 dest %dst0 addr %addr0 offset c(%c8) : outs(!vx2) ins(!v) mods(i32) -> !amdgcn.read_token<shared> fence_token %bar : !amdgcn.fence_token
+    %rr1, %rt1 = amdgcn.ds_read_b64 dest %dst1 addr %addr1 offset c(%c8) : outs(!vx2) ins(!v) mods(i32) -> !amdgcn.read_token<shared> fence_token %bar : !amdgcn.fence_token
+    amdgcn.end_kernel
+  }
+
   // LDS ops: with LGKM_R/LGKM_W merged into one bucket all three DS ops
   // share priority; smallest-id (block order) tie-break preserves IR order.
   // CHECK-LABEL: kernel @lds_ops_ordered
@@ -275,7 +308,7 @@ amdgcn.module @test target = #amdgcn.target<gfx942> {
     %dst = amdgcn.make_register_range %rd0, %rd1 : !v, !v
     %data = amdgcn.make_register_range %wd0, %wd1 : !v, !v
     %wt = amdgcn.ds_write_b64 data %data addr %waddr offset c(%c0) : ins(!vx2, !v) mods(i32) -> !amdgcn.write_token<shared>
-    amdgcn.wait deps %wt : !amdgcn.write_token<shared>
+    %wf0 = amdgcn.wait deps %wt : !amdgcn.write_token<shared> -> !amdgcn.fence_token
     %rr, %rt = amdgcn.ds_read_b64 dest %dst addr %raddr offset c(%c0) : outs(!vx2) ins(!v) mods(i32) -> !amdgcn.read_token<shared>
     amdgcn.end_kernel
   }

--- a/test/Dialect/AMDGCN/Transforms/sched-value.mlir
+++ b/test/Dialect/AMDGCN/Transforms/sched-value.mlir
@@ -5,28 +5,28 @@
 // CHECK-LABEL:   func.func @amdgcn_load_wait_store(
 // CHECK-SAME:      %[[ARG0:.*]]: !amdgcn.vgpr<[? + 2]>, %[[ARG1:.*]]: !amdgcn.vgpr) {
 // CHECK:           %[[VAL_0:.*]], %[[LOAD_0:.*]] = amdgcn.global_load_dword dest %[[ARG1]] addr %[[ARG0]] offset c(%{{.*}}) {sched.stage = 2 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
-// CHECK:           amdgcn.wait deps %[[LOAD_0]] {sched.stage = 3 : i32} : !amdgcn.read_token<flat>
+// CHECK:           amdgcn.wait deps %[[LOAD_0]] {sched.stage = 3 : i32} : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // CHECK:           %[[STORE_0:.*]] = amdgcn.global_store_dword data %[[VAL_0]] addr %[[ARG0]] offset c(%{{.*}}) {sched.stage = 4 : i32} : ins(!amdgcn.vgpr, !amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.write_token<flat>
-// CHECK:           amdgcn.wait deps %[[STORE_0]], %[[LOAD_0]] {sched.stage = 5 : i32} : !amdgcn.write_token<flat>, !amdgcn.read_token<flat>
+// CHECK:           amdgcn.wait deps %[[STORE_0]], %[[LOAD_0]] {sched.stage = 5 : i32} : !amdgcn.write_token<flat>, !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // CHECK:           return
 // CHECK:         }
 amdgcn.module @default_sched_name target = <gfx942> {
 func.func @amdgcn_load_wait_store(%arg0: !amdgcn.vgpr<[? + 2]>, %arg1: !amdgcn.vgpr) attributes {sched = #sched} {
   %c0_i32_mig1 = arith.constant 0 : i32
   %dest_res, %token = amdgcn.global_load_dword dest %arg1 addr %arg0 offset c(%c0_i32_mig1) {sched.stage = 2 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
-  amdgcn.wait deps %token {sched.stage = 3 : i32} : !amdgcn.read_token<flat>
+  %wf0 = amdgcn.wait deps %token {sched.stage = 3 : i32} : !amdgcn.read_token<flat> -> !amdgcn.fence_token
   %0 = amdgcn.global_store_dword data %dest_res addr %arg0 offset c(%c0_i32_mig1) {sched.stage = 4 : i32} : ins(!amdgcn.vgpr, !amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.write_token<flat>
-  amdgcn.wait deps %0, %token {sched.stage = 5 : i32} : !amdgcn.write_token<flat>, !amdgcn.read_token<flat>
+  %wf1 = amdgcn.wait deps %0, %token {sched.stage = 5 : i32} : !amdgcn.write_token<flat>, !amdgcn.read_token<flat> -> !amdgcn.fence_token
   return
 }
 
 // CHECK-LABEL:   func.func @amdgcn_multiple_loads(
 // CHECK-SAME:      %[[ARG0:.*]]: !amdgcn.vgpr<[? + 2]>, %[[ARG1:.*]]: !amdgcn.vgpr) {
 // CHECK:           %[[VAL_0:.*]], %[[LOAD_0:.*]] = amdgcn.global_load_dword dest %[[ARG1]] addr %[[ARG0]] offset c(%{{.*}}) {sched.stage = 0 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
-// CHECK:           amdgcn.wait deps %[[LOAD_0]] {sched.stage = 0 : i32} : !amdgcn.read_token<flat>
+// CHECK:           amdgcn.wait deps %[[LOAD_0]] {sched.stage = 0 : i32} : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // CHECK:           %[[VAL_1:.*]], %[[LOAD_1:.*]] = amdgcn.global_load_dword dest %[[ARG1]] addr %[[ARG0]] offset c(%{{.*}}) {sched.stage = 2 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
 // CHECK:           %[[VAL_2:.*]], %[[LOAD_2:.*]] = amdgcn.global_load_dword dest %[[ARG1]] addr %[[ARG0]] offset c(%{{.*}}) {sched.stage = 1 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
-// CHECK:           amdgcn.wait deps %[[LOAD_2]] {sched.stage = 1 : i32} : !amdgcn.read_token<flat>
+// CHECK:           amdgcn.wait deps %[[LOAD_2]] {sched.stage = 1 : i32} : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // CHECK:           return
 // CHECK:         }
 func.func @amdgcn_multiple_loads(%arg0: !amdgcn.vgpr<[? + 2]>, %arg1: !amdgcn.vgpr) attributes {sched = #sched} {
@@ -36,8 +36,8 @@ func.func @amdgcn_multiple_loads(%arg0: !amdgcn.vgpr<[? + 2]>, %arg1: !amdgcn.vg
   %dest_res_0, %token_1 = amdgcn.global_load_dword dest %arg1 addr %arg0 offset c(%c0_i32_mig3) {sched.stage = 2 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
   %c0_i32_mig4 = arith.constant 0 : i32
   %dest_res_2, %token_3 = amdgcn.global_load_dword dest %arg1 addr %arg0 offset c(%c0_i32_mig4) {sched.stage = 1 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
-  amdgcn.wait deps %token {sched.stage = 0 : i32} : !amdgcn.read_token<flat>
-  amdgcn.wait deps %token_3 {sched.stage = 1 : i32} : !amdgcn.read_token<flat>
+  %wf2 = amdgcn.wait deps %token {sched.stage = 0 : i32} : !amdgcn.read_token<flat> -> !amdgcn.fence_token
+  %wf3 = amdgcn.wait deps %token_3 {sched.stage = 1 : i32} : !amdgcn.read_token<flat> -> !amdgcn.fence_token
   return
 }
 
@@ -45,7 +45,7 @@ func.func @amdgcn_multiple_loads(%arg0: !amdgcn.vgpr<[? + 2]>, %arg1: !amdgcn.vg
 // CHECK-SAME:      %[[ARG0:.*]]: !amdgcn.sgpr<[? + 2]>, %[[ARG1:.*]]: !amdgcn.vgpr, %[[ARG2:.*]]: !amdgcn.vgpr<[? + 2]>, %[[ARG3:.*]]: !amdgcn.sgpr, %[[ARG4:.*]]: !amdgcn.vgpr) {
 // CHECK:           %[[VAL_0:.*]], %[[LOAD_0:.*]] = amdgcn.s_load_dword dest %[[ARG3]] addr %[[ARG0]] offset c(%{{.*}}) {sched.stage = 1 : i32} : outs(!amdgcn.sgpr) ins(!amdgcn.sgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<constant>
 // CHECK:           %[[VAL_1:.*]], %[[LOAD_1:.*]] = amdgcn.ds_read_b32 dest %[[ARG4]] addr %[[ARG1]] offset c(%{{.*}}) {sched.stage = 4 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
-// CHECK:           amdgcn.wait deps %[[LOAD_0]] {sched.stage = 2 : i32} : !amdgcn.read_token<constant>
+// CHECK:           amdgcn.wait deps %[[LOAD_0]] {sched.stage = 2 : i32} : !amdgcn.read_token<constant> -> !amdgcn.fence_token
 // CHECK:           %[[VAL_2:.*]], %[[LOAD_2:.*]] = amdgcn.global_load_dword dest %[[ARG4]] addr %[[ARG2]] offset c(%{{.*}}) {sched.stage = 5 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
 // CHECK:           return
 // CHECK:         }
@@ -55,7 +55,7 @@ func.func @amdgcn_mixed_memory_spaces(%arg0: !amdgcn.sgpr<[? + 2]>, %arg1: !amdg
   %dest_res_0, %token_1 = amdgcn.ds_read_b32 dest %arg4 addr %arg1 offset c(%c0_i32_mig1) {sched.stage = 4 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
   %c0_i32_mig5 = arith.constant 0 : i32
   %dest_res_2, %token_3 = amdgcn.global_load_dword dest %arg4 addr %arg2 offset c(%c0_i32_mig5) {sched.stage = 5 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
-  amdgcn.wait deps %token {sched.stage = 2 : i32} : !amdgcn.read_token<constant>
+  %wf4 = amdgcn.wait deps %token {sched.stage = 2 : i32} : !amdgcn.read_token<constant> -> !amdgcn.fence_token
   return
 }
 
@@ -98,7 +98,7 @@ func.func @amdgcn_vop2_salu_barrier(%arg0: !amdgcn.vgpr, %arg1: !amdgcn.vgpr, %a
 // CHECK:           %[[VAL_0:.*]], %[[LOAD_0:.*]] = amdgcn.global_load_dword dest %[[ALLOCA_2]] addr %[[ALLOCA_0]] offset c(%{{.*}}) {sched.stage = 0 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
 // CHECK:           %[[VAL_2:.*]], %[[LOAD_2:.*]] = amdgcn.global_load_dword dest %[[ALLOCA_2]] addr %[[ALLOCA_0]] offset c(%{{.*}}) {sched.stage = 1 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
 // CHECK:           %[[STORE_0:.*]] = amdgcn.ds_write_b32 data %[[VAL_0]] addr %[[ALLOCA_1]] offset c(%{{.*}}) {sched.stage = 0 : i32} : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
-// CHECK:           amdgcn.wait lgkm_cnt 0 {sched.stage = 0 : i32}
+// CHECK:           amdgcn.wait lgkm_cnt 0 {sched.stage = 0 : i32} -> !amdgcn.fence_token
 // CHECK:           amdgcn.s_barrier {sched.stage = 0 : i32}
 // CHECK:           %[[VAL_1:.*]], %[[LOAD_1:.*]] = amdgcn.ds_read_b32 dest %[[ALLOCA_2]] addr %[[ALLOCA_1]] offset c(%{{.*}}) {sched.stage = 0 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
 // CHECK:           return
@@ -113,7 +113,7 @@ func.func @promote_vmem_forward() attributes {sched = #sched} {
   %dest_res_0, %token_1 = amdgcn.global_load_dword dest %2 addr %0 offset c(%c0_i32_mig7) {sched.stage = 1 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
   %c0_i32_mig1 = arith.constant 0 : i32
   %3 = amdgcn.ds_write_b32 data %dest_res addr %1 offset c(%c0_i32_mig1) {sched.stage = 0 : i32} : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
-  amdgcn.wait lgkm_cnt 0 {sched.stage = 0 : i32}
+  %wf5 = amdgcn.wait lgkm_cnt 0 {sched.stage = 0 : i32} -> !amdgcn.fence_token
   amdgcn.s_barrier {sched.stage = 0 : i32}
   %c0_i32_mig2 = arith.constant 0 : i32
   %dest_res_2, %token_3 = amdgcn.ds_read_b32 dest %2 addr %1 offset c(%c0_i32_mig2) {sched.stage = 0 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
@@ -126,7 +126,7 @@ func.func @promote_vmem_forward() attributes {sched = #sched} {
 // CHECK:           %[[ALLOCA_2:.*]] = lsir.alloca : !amdgcn.vgpr
 // CHECK:           %[[VAL_0:.*]], %[[LOAD_0:.*]] = amdgcn.global_load_dword dest %[[ALLOCA_2]] addr %[[ALLOCA_0]] offset c(%{{.*}}) {sched.stage = 0 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
 // CHECK:           %[[STORE_0:.*]] = amdgcn.ds_write_b32 data %[[VAL_0]] addr %[[ALLOCA_1]] offset c(%{{.*}}) {sched.stage = 0 : i32} : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
-// CHECK:           amdgcn.wait lgkm_cnt 0 {sched.stage = 1 : i32}
+// CHECK:           amdgcn.wait lgkm_cnt 0 {sched.stage = 1 : i32} -> !amdgcn.fence_token
 // CHECK:           amdgcn.s_barrier {sched.stage = 1 : i32}
 // CHECK:           %[[VAL_2:.*]], %[[LOAD_2:.*]] = amdgcn.ds_read_b32 dest %[[ALLOCA_2]] addr %[[ALLOCA_1]] offset c(%{{.*}}) {sched.stage = 2 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
 // CHECK:           %[[VAL_1:.*]], %[[LOAD_1:.*]] = amdgcn.global_load_dword dest %[[ALLOCA_2]] addr %[[ALLOCA_0]] offset c(%{{.*}}) {sched.stage = 0 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
@@ -140,7 +140,7 @@ func.func @promote_vmem_backward() attributes {sched = #sched} {
   %dest_res, %token = amdgcn.global_load_dword dest %2 addr %0 offset c(%c0_i32_mig8) {sched.stage = 0 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
   %c0_i32_mig2 = arith.constant 0 : i32
   %3 = amdgcn.ds_write_b32 data %dest_res addr %1 offset c(%c0_i32_mig2) {sched.stage = 0 : i32} : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
-  amdgcn.wait lgkm_cnt 0 {sched.stage = 1 : i32}
+  %wf6 = amdgcn.wait lgkm_cnt 0 {sched.stage = 1 : i32} -> !amdgcn.fence_token
   amdgcn.s_barrier {sched.stage = 1 : i32}
   %c0_i32_mig3 = arith.constant 0 : i32
   %dest_res_0, %token_1 = amdgcn.ds_read_b32 dest %2 addr %1 offset c(%c0_i32_mig3) {sched.stage = 2 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
@@ -156,7 +156,7 @@ func.func @promote_vmem_backward() attributes {sched = #sched} {
 // CHECK:           %[[VAL_0:.*]], %[[LOAD_0:.*]] = amdgcn.global_load_dword dest %[[ALLOCA_2]] addr %[[ALLOCA_0]] offset c(%{{.*}}) {sched.stage = 0 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
 // CHECK:           %[[VAL_1:.*]], %[[LOAD_1:.*]] = amdgcn.global_load_dword dest %[[ALLOCA_2]] addr %[[ALLOCA_0]] offset c(%{{.*}}) {sched.stage = 1 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
 // CHECK:           %[[STORE_0:.*]] = amdgcn.ds_write_b32 data %[[VAL_0]] addr %[[ALLOCA_1]] offset c(%{{.*}}) {sched.stage = 0 : i32} : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
-// CHECK:           amdgcn.wait vm_cnt 0 lgkm_cnt 0 {sched.stage = 0 : i32}
+// CHECK:           amdgcn.wait vm_cnt 0 lgkm_cnt 0 {sched.stage = 0 : i32} -> !amdgcn.fence_token
 // CHECK:           amdgcn.s_barrier {sched.stage = 0 : i32}
 // CHECK:           %[[VAL_2:.*]], %[[LOAD_2:.*]] = amdgcn.ds_read_b32 dest %[[ALLOCA_2]] addr %[[ALLOCA_1]] offset c(%{{.*}}) {sched.stage = 0 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
 // CHECK:           return
@@ -171,7 +171,7 @@ func.func @cant_promote_vmem_forward() attributes {sched = #sched} {
   %dest_res_0, %token_1 = amdgcn.global_load_dword dest %2 addr %0 offset c(%c0_i32_mig11) {sched.stage = 1 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
   %c0_i32_mig3 = arith.constant 0 : i32
   %3 = amdgcn.ds_write_b32 data %dest_res addr %1 offset c(%c0_i32_mig3) {sched.stage = 0 : i32} : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
-  amdgcn.wait vm_cnt 0 lgkm_cnt 0 {sched.stage = 0 : i32}
+  %wf7 = amdgcn.wait vm_cnt 0 lgkm_cnt 0 {sched.stage = 0 : i32} -> !amdgcn.fence_token
   amdgcn.s_barrier {sched.stage = 0 : i32}
   %c0_i32_mig4 = arith.constant 0 : i32
   %dest_res_2, %token_3 = amdgcn.ds_read_b32 dest %2 addr %1 offset c(%c0_i32_mig4) {sched.stage = 0 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
@@ -184,7 +184,7 @@ func.func @cant_promote_vmem_forward() attributes {sched = #sched} {
 // CHECK:           %[[ALLOCA_2:.*]] = lsir.alloca : !amdgcn.vgpr
 // CHECK:           %[[VAL_0:.*]], %[[LOAD_0:.*]] = amdgcn.global_load_dword dest %[[ALLOCA_2]] addr %[[ALLOCA_0]] offset c(%{{.*}}) {sched.stage = 0 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
 // CHECK:           %[[STORE_0:.*]] = amdgcn.ds_write_b32 data %[[VAL_0]] addr %[[ALLOCA_1]] offset c(%{{.*}}) {sched.stage = 0 : i32} : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
-// CHECK:           amdgcn.wait vm_cnt 0 lgkm_cnt 0 {sched.stage = 1 : i32}
+// CHECK:           amdgcn.wait vm_cnt 0 lgkm_cnt 0 {sched.stage = 1 : i32} -> !amdgcn.fence_token
 // CHECK:           amdgcn.s_barrier {sched.stage = 1 : i32}
 // CHECK:           %[[VAL_2:.*]], %[[LOAD_2:.*]] = amdgcn.ds_read_b32 dest %[[ALLOCA_2]] addr %[[ALLOCA_1]] offset c(%{{.*}}) {sched.stage = 2 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
 // CHECK:           %[[VAL_1:.*]], %[[LOAD_1:.*]] = amdgcn.global_load_dword dest %[[ALLOCA_2]] addr %[[ALLOCA_0]] offset c(%{{.*}}) {sched.stage = 0 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
@@ -198,7 +198,7 @@ func.func @cant_promote_vmem_backward() attributes {sched = #sched} {
   %dest_res, %token = amdgcn.global_load_dword dest %2 addr %0 offset c(%c0_i32_mig12) {sched.stage = 0 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
   %c0_i32_mig4 = arith.constant 0 : i32
   %3 = amdgcn.ds_write_b32 data %dest_res addr %1 offset c(%c0_i32_mig4) {sched.stage = 0 : i32} : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
-  amdgcn.wait vm_cnt 0 lgkm_cnt 0 {sched.stage = 1 : i32}
+  %wf8 = amdgcn.wait vm_cnt 0 lgkm_cnt 0 {sched.stage = 1 : i32} -> !amdgcn.fence_token
   amdgcn.s_barrier {sched.stage = 1 : i32}
   %c0_i32_mig5 = arith.constant 0 : i32
   %dest_res_0, %token_1 = amdgcn.ds_read_b32 dest %2 addr %1 offset c(%c0_i32_mig5) {sched.stage = 2 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
@@ -242,7 +242,7 @@ func.func @cant_promote_across_unknown_op() attributes {sched = #sched} {
 // CHECK:           %[[VAL_0:.*]], %[[LOAD_0:.*]] = amdgcn.global_load_dword dest %[[ALLOCA_2]] addr %[[ALLOCA_0]] offset c(%{{.*}}) {sched.stage = 0 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
 // CHECK:           %[[VAL_2:.*]], %[[LOAD_2:.*]] = amdgcn.global_load_dword dest %[[ALLOCA_2]] addr %[[ALLOCA_0]] offset c(%{{.*}}) {sched.stage = 1 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
 // CHECK:           %[[STORE_0:.*]] = amdgcn.ds_write_b32 data %[[VAL_0]] addr %[[ALLOCA_1]] offset c(%{{.*}}) {sched.stage = 0 : i32} : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
-// CHECK:           amdgcn.wait lgkm_cnt 0 {sched.stage = 0 : i32}
+// CHECK:           amdgcn.wait lgkm_cnt 0 {sched.stage = 0 : i32} -> !amdgcn.fence_token
 // CHECK:           amdgcn.s_barrier {sched.stage = 0 : i32}
 // CHECK:           %[[VAL_1:.*]], %[[LOAD_1:.*]] = amdgcn.ds_read_b32 dest %[[ALLOCA_2]] addr %[[ALLOCA_1]] offset c(%{{.*}}) {sched.stage = 0 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
 // CHECK:           return
@@ -258,7 +258,7 @@ func.func @promote_pure_op_forward() attributes {sched = #sched} {
   %dest_res_0, %token_1 = amdgcn.global_load_dword dest %2 addr %0 offset c(%c0_i32_mig17) {sched.stage = 1 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
   %c0_i32_mig6 = arith.constant 0 : i32
   %3 = amdgcn.ds_write_b32 data %dest_res addr %1 offset c(%c0_i32_mig6) {sched.stage = 0 : i32} : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
-  amdgcn.wait lgkm_cnt 0 {sched.stage = 0 : i32}
+  %wf9 = amdgcn.wait lgkm_cnt 0 {sched.stage = 0 : i32} -> !amdgcn.fence_token
   amdgcn.s_barrier {sched.stage = 0 : i32}
   %c0_i32_mig7 = arith.constant 0 : i32
   %dest_res_2, %token_3 = amdgcn.ds_read_b32 dest %2 addr %1 offset c(%c0_i32_mig7) {sched.stage = 0 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
@@ -273,7 +273,7 @@ func.func @promote_pure_op_forward() attributes {sched = #sched} {
 // CHECK:           %[[VAL_1:.*]] = amdgcn.v_add_u32 outs(%[[ALLOCA_1]]) ins(%[[VAL_0]], %[[VAL_0]]) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr, !amdgcn.vgpr)
 // CHECK:           %[[VAL_4:.*]] = amdgcn.v_add_i32 outs(%[[ALLOCA_1]]) ins(%[[VAL_0]], %[[VAL_0]]) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr, !amdgcn.vgpr)
 // CHECK:           %[[STORE_0:.*]] = amdgcn.ds_write_b32 data %[[VAL_0]] addr %[[ALLOCA_1]] offset c(%{{.*}}) : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
-// CHECK:           amdgcn.wait lgkm_cnt 0
+// CHECK:           amdgcn.wait lgkm_cnt 0 -> !amdgcn.fence_token
 // CHECK:           amdgcn.s_barrier
 // CHECK:           %[[VAL_3:.*]], %[[LOAD_2:.*]] = amdgcn.ds_read_b32 dest %[[ALLOCA_2]] addr %[[VAL_1]] offset c(%{{.*}}) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
 // CHECK:           %[[VAL_5:.*]], %[[LOAD_3:.*]] = amdgcn.ds_read_b32 dest %[[ALLOCA_2]] addr %[[VAL_4]] offset c(%{{.*}}) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
@@ -300,7 +300,7 @@ func.func @advanced_sched() attributes {
   %vdst0_res = amdgcn.v_add_i32 outs(%1) ins(%dest_res, %dest_res) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr, !amdgcn.vgpr)
   %c0_i32_mig7 = arith.constant 0 : i32
   %3 = amdgcn.ds_write_b32 data %dest_res addr %1 offset c(%c0_i32_mig7) : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
-  amdgcn.wait lgkm_cnt 0
+  %wf10 = amdgcn.wait lgkm_cnt 0 -> !amdgcn.fence_token
   amdgcn.s_barrier
   %vdst0_res_0 = amdgcn.v_add_u32 outs(%1) ins(%dest_res, %dest_res) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr, !amdgcn.vgpr)
   %c0_i32_mig8 = arith.constant 0 : i32

--- a/test/Dialect/AMDGCN/Transforms/strip-waits.mlir
+++ b/test/Dialect/AMDGCN/Transforms/strip-waits.mlir
@@ -23,7 +23,7 @@ amdgcn.module @gfx1250_strip_mod target = #amdgcn.target<gfx1250> {
     %ltok = amdgcn.tensor_load_to_lds desc0 %d0 desc1 %d1 desc2 %d2 desc3 %d3
         : ins(!amdgcn.sgpr<[0 : 4]>, !amdgcn.sgpr<[8 : 16]>, !amdgcn.sgpr<[16 : 20]>,
               !amdgcn.sgpr<[20 : 24]>) -> !amdgcn.read_token<tensor>
-    amdgcn.wait_gfx1250 deps %ltok : !amdgcn.read_token<tensor>
+    %wf0 = amdgcn.wait_gfx1250 deps %ltok : !amdgcn.read_token<tensor> -> !amdgcn.fence_token
 
     %v32 = lsir.alloca : !amdgcn.vgpr<32>
     %b_lo = lsir.alloca : !amdgcn.vgpr<[16 : 20]>
@@ -34,7 +34,7 @@ amdgcn.module @gfx1250_strip_mod target = #amdgcn.target<gfx1250> {
     %off16 = arith.constant 16 : i32
     %dtok1 = amdgcn.ds_load_b128 dest %b_hi addr %v32 offset c(%off16)
         : outs(!amdgcn.vgpr<[20 : 24]>) ins(!amdgcn.vgpr<32>) mods(i32) -> !amdgcn.read_token<shared>
-    amdgcn.wait_gfx1250 deps %dtok0, %dtok1 : !amdgcn.read_token<shared>, !amdgcn.read_token<shared>
+    %wf1 = amdgcn.wait_gfx1250 deps %dtok0, %dtok1 : !amdgcn.read_token<shared>, !amdgcn.read_token<shared> -> !amdgcn.fence_token
 
     %acc = lsir.alloca : !amdgcn.vgpr<[0 : 8]>
     %a_frag = lsir.alloca : !amdgcn.vgpr<[8 : 16]>

--- a/test/Dialect/AMDGCN/Transforms/wait-insertion.mlir
+++ b/test/Dialect/AMDGCN/Transforms/wait-insertion.mlir
@@ -11,7 +11,7 @@ amdgcn.module @test_wait_insertion target = #amdgcn.target<gfx942> {
 // CHECK:           %[[LOAD_0:.*]] = amdgcn.global_load_dword dest %[[ALLOCA_3]] addr %[[MAKE_REGISTER_RANGE_0]] offset c(%{{.*}}) : outs(!amdgcn.vgpr<?>) ins(!amdgcn.vgpr<[? : ? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
 // CHECK:           memref.store %[[LOAD_0]], %[[ALLOCA_0]][] : memref<!amdgcn.read_token<flat>>
 // CHECK:           %[[LOAD_1:.*]] = memref.load %[[ALLOCA_0]][] : memref<!amdgcn.read_token<flat>>
-// CHECK:           amdgcn.wait deps %[[LOAD_1]] : !amdgcn.read_token<flat>
+// CHECK:           amdgcn.wait deps %[[LOAD_1]] : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // CHECK:           %[[STORE_0:.*]] = amdgcn.global_store_dword data %[[ALLOCA_3]] addr %[[MAKE_REGISTER_RANGE_0]] offset c(%{{.*}}) : ins(!amdgcn.vgpr<?>, !amdgcn.vgpr<[? : ? + 2]>) mods(i32) -> !amdgcn.write_token<flat>
 // CHECK:           return
 // CHECK:         }
@@ -36,7 +36,7 @@ func.func @simple_load_store() {
 // CHECK:           %[[LOAD_0:.*]] = amdgcn.global_load_dword dest %[[ALLOCA_1]] addr %[[MAKE_REGISTER_RANGE_0]] offset c(%{{.*}}) : outs(!amdgcn.vgpr<?>) ins(!amdgcn.vgpr<[? : ? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
 // CHECK:           memref.store %[[LOAD_0]], %[[ALLOCA_0]][] : memref<!amdgcn.read_token<flat>>
 // CHECK:           %[[LOAD_1:.*]] = memref.load %[[ALLOCA_0]][] : memref<!amdgcn.read_token<flat>>
-// CHECK:           amdgcn.wait deps %[[LOAD_1]] : !amdgcn.read_token<flat>
+// CHECK:           amdgcn.wait deps %[[LOAD_1]] : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // CHECK:           amdgcn.v_mov_b32 outs(%[[ALLOCA_2]]) ins(%[[ALLOCA_1]]) : outs(!amdgcn.vgpr<?>) ins(!amdgcn.vgpr<?>)
 // CHECK:           amdgcn.test_inst ins %[[ALLOCA_2]] : (!amdgcn.vgpr<?>) -> ()
 // CHECK:           return
@@ -70,10 +70,10 @@ func.func @load_then_vop() {
 // CHECK:           %[[LOAD_1:.*]] = amdgcn.global_load_dword dest %[[ALLOCA_3]] addr %[[MAKE_REGISTER_RANGE_0]] offset c(%[[CONSTANT_1]]) : outs(!amdgcn.vgpr<?>) ins(!amdgcn.vgpr<[? : ? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
 // CHECK:           memref.store %[[LOAD_1]], %[[ALLOCA_0]][] : memref<!amdgcn.read_token<flat>>
 // CHECK:           %[[LOAD_2:.*]] = memref.load %[[ALLOCA_1]][] : memref<!amdgcn.read_token<flat>>
-// CHECK:           amdgcn.wait deps %[[LOAD_2]] : !amdgcn.read_token<flat>
+// CHECK:           amdgcn.wait deps %[[LOAD_2]] : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // CHECK:           %[[STORE_0:.*]] = amdgcn.global_store_dword data %[[ALLOCA_2]] addr %[[MAKE_REGISTER_RANGE_0]] offset c(%[[CONSTANT_2]]) : ins(!amdgcn.vgpr<?>, !amdgcn.vgpr<[? : ? + 2]>) mods(i32) -> !amdgcn.write_token<flat>
 // CHECK:           %[[LOAD_3:.*]] = memref.load %[[ALLOCA_0]][] : memref<!amdgcn.read_token<flat>>
-// CHECK:           amdgcn.wait deps %[[LOAD_3]] : !amdgcn.read_token<flat>
+// CHECK:           amdgcn.wait deps %[[LOAD_3]] : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // CHECK:           %[[STORE_1:.*]] = amdgcn.global_store_dword data %[[ALLOCA_3]] addr %[[MAKE_REGISTER_RANGE_0]] offset c(%[[CONSTANT_0]]) : ins(!amdgcn.vgpr<?>, !amdgcn.vgpr<[? : ? + 2]>) mods(i32) -> !amdgcn.write_token<flat>
 // CHECK:           return
 // CHECK:         }
@@ -101,9 +101,9 @@ func.func @multiple_loads_multiple_consumers() {
 // CHECK:           %[[ALLOCA_3:.*]] = amdgcn.alloca : !amdgcn.vgpr<?>
 // CHECK:           %[[LOAD_0:.*]] = amdgcn.global_load_dword dest %[[ALLOCA_3]] addr %[[MAKE_REGISTER_RANGE_0]] offset c(%{{.*}}) : outs(!amdgcn.vgpr<?>) ins(!amdgcn.vgpr<[? : ? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
 // CHECK:           memref.store %[[LOAD_0]], %[[ALLOCA_0]][] : memref<!amdgcn.read_token<flat>>
-// CHECK:           amdgcn.wait deps %[[LOAD_0]] : !amdgcn.read_token<flat>
+// CHECK:           amdgcn.wait deps %[[LOAD_0]] : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // CHECK:           %[[LOAD_1:.*]] = memref.load %[[ALLOCA_0]][] : memref<!amdgcn.read_token<flat>>
-// CHECK:           amdgcn.wait deps %[[LOAD_1]] : !amdgcn.read_token<flat>
+// CHECK:           amdgcn.wait deps %[[LOAD_1]] : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // CHECK:           %[[STORE_0:.*]] = amdgcn.global_store_dword data %[[ALLOCA_3]] addr %[[MAKE_REGISTER_RANGE_0]] offset c(%{{.*}}) : ins(!amdgcn.vgpr<?>, !amdgcn.vgpr<[? : ? + 2]>) mods(i32) -> !amdgcn.write_token<flat>
 // CHECK:           return
 // CHECK:         }
@@ -114,7 +114,7 @@ func.func @load_with_existing_wait() {
   %3 = amdgcn.alloca : !amdgcn.vgpr<?>
   %c0_i32_mig3 = arith.constant 0 : i32
   %token = amdgcn.global_load_dword dest %3 addr %2 offset c(%c0_i32_mig3) : outs(!amdgcn.vgpr<?>) ins(!amdgcn.vgpr<[? : ? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
-  amdgcn.wait deps %token : !amdgcn.read_token<flat>
+  %wf0 = amdgcn.wait deps %token : !amdgcn.read_token<flat> -> !amdgcn.fence_token
   %c0_i32_mig2 = arith.constant 0 : i32
   %4 = amdgcn.global_store_dword data %3 addr %2 offset c(%c0_i32_mig2) : ins(!amdgcn.vgpr<?>, !amdgcn.vgpr<[? : ? + 2]>) mods(i32) -> !amdgcn.write_token<flat>
   return
@@ -136,14 +136,14 @@ func.func @load_with_existing_wait() {
 // CHECK:           %[[LOAD_0:.*]] = amdgcn.global_load_dword dest %[[ALLOCA_4]] addr %[[MAKE_REGISTER_RANGE_0]] offset c(%{{.*}}) : outs(!amdgcn.vgpr<?>) ins(!amdgcn.vgpr<[? : ? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
 // CHECK:           memref.store %[[LOAD_0]], %[[ALLOCA_1]][] : memref<!amdgcn.read_token<flat>>
 // CHECK:           %[[LOAD_1:.*]] = memref.load %[[ALLOCA_1]][] : memref<!amdgcn.read_token<flat>>
-// CHECK:           amdgcn.wait deps %[[LOAD_1]] : !amdgcn.read_token<flat>
+// CHECK:           amdgcn.wait deps %[[LOAD_1]] : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // CHECK:           lsir.copy %[[ALLOCA_2]], %[[ALLOCA_4]] : !amdgcn.vgpr<?>, !amdgcn.vgpr<?>
 // CHECK:           cf.br ^bb3
 // CHECK:         ^bb2:
 // CHECK:           %[[LOAD_2:.*]] = amdgcn.global_load_dword dest %[[ALLOCA_5]] addr %[[MAKE_REGISTER_RANGE_0]] offset c(%{{.*}}) : outs(!amdgcn.vgpr<?>) ins(!amdgcn.vgpr<[? : ? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
 // CHECK:           memref.store %[[LOAD_2]], %[[ALLOCA_0]][] : memref<!amdgcn.read_token<flat>>
 // CHECK:           %[[LOAD_3:.*]] = memref.load %[[ALLOCA_0]][] : memref<!amdgcn.read_token<flat>>
-// CHECK:           amdgcn.wait deps %[[LOAD_3]] : !amdgcn.read_token<flat>
+// CHECK:           amdgcn.wait deps %[[LOAD_3]] : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // CHECK:           lsir.copy %[[ALLOCA_2]], %[[ALLOCA_5]] : !amdgcn.vgpr<?>, !amdgcn.vgpr<?>
 // CHECK:           cf.br ^bb3
 // CHECK:         ^bb3:
@@ -209,7 +209,7 @@ func.func @no_load_consumption() {
 // CHECK:           %[[LOAD_1:.*]] = amdgcn.global_load_dword dest %[[ALLOCA_1]] addr %[[MAKE_REGISTER_RANGE_0]] offset c(%{{.*}}) : outs(!amdgcn.vgpr<?>) ins(!amdgcn.vgpr<[? : ? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
 // CHECK:           memref.store %[[LOAD_1]], %[[ALLOCA_0]][] : memref<!amdgcn.read_token<flat>>
 // CHECK:           %[[LOAD_2:.*]] = memref.load %[[ALLOCA_0]][] : memref<!amdgcn.read_token<flat>>
-// CHECK:           amdgcn.wait deps %[[LOAD_2]] : !amdgcn.read_token<flat>
+// CHECK:           amdgcn.wait deps %[[LOAD_2]] : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // CHECK:           %[[STORE_0:.*]] = amdgcn.global_store_dword data %[[ALLOCA_1]] addr %[[MAKE_REGISTER_RANGE_0]] offset c(%{{.*}}) : ins(!amdgcn.vgpr<?>, !amdgcn.vgpr<[? : ? + 2]>) mods(i32) -> !amdgcn.write_token<flat>
 // CHECK:           %[[ADDI_0:.*]] = arith.addi %[[VAL_0]], %[[CONSTANT_1]] : index
 // CHECK:           %[[CMPI_0:.*]] = arith.cmpi ult, %[[ADDI_0]], %[[CONSTANT_0]] : index
@@ -245,7 +245,7 @@ func.func @load_in_loop() {
 // CHECK:           %[[LOAD_0:.*]] = amdgcn.ds_read_b32 dest %[[ALLOCA_1]] addr %[[ALLOCA_2]] offset c(%{{.*}}) : outs(!amdgcn.vgpr<?>) ins(<?>) mods(i32) -> !amdgcn.read_token<shared>
 // CHECK:           memref.store %[[LOAD_0]], %[[ALLOCA_0]][] : memref<!amdgcn.read_token<shared>>
 // CHECK:           %[[LOAD_1:.*]] = memref.load %[[ALLOCA_0]][] : memref<!amdgcn.read_token<shared>>
-// CHECK:           amdgcn.wait deps %[[LOAD_1]] : !amdgcn.read_token<shared>
+// CHECK:           amdgcn.wait deps %[[LOAD_1]] : !amdgcn.read_token<shared> -> !amdgcn.fence_token
 // CHECK:           %[[STORE_0:.*]] = amdgcn.ds_write_b32 data %[[ALLOCA_1]] addr %[[ALLOCA_2]] offset c(%{{.*}}) : ins(!amdgcn.vgpr<?>, <?>) mods(i32) -> !amdgcn.write_token<shared>
 // CHECK:           return
 // CHECK:         }
@@ -297,9 +297,9 @@ func.func @one_load_two_consumers() {
 // CHECK:           %[[LOAD_0:.*]] = amdgcn.global_load_dword dest %[[ALLOCA_1]] addr %[[MRR]] offset c(%{{.*}}) : outs(!amdgcn.vgpr<?>) ins(!amdgcn.vgpr<[? : ? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
 // CHECK:           memref.store %[[LOAD_0]], %[[ALLOCA_0]][] : memref<!amdgcn.read_token<flat>>
 // CHECK:           %[[TOK_0:.*]] = memref.load %[[ALLOCA_0]][] : memref<!amdgcn.read_token<flat>>
-// CHECK:           amdgcn.wait deps %[[TOK_0]] : !amdgcn.read_token<flat>
+// CHECK:           amdgcn.wait deps %[[TOK_0]] : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // CHECK:           amdgcn.v_mov_b32 outs(%[[ALLOCA_1]]) ins(%[[ALLOCA_2]]) : outs(!amdgcn.vgpr<?>) ins(!amdgcn.vgpr<?>)
-// CHECK-NOT:       amdgcn.wait
+// CHECK-NOT:       amdgcn.wait -> !amdgcn.fence_token
 // CHECK:           %{{.*}} = amdgcn.global_store_dword data %[[ALLOCA_1]] addr %[[MRR]] offset c(%{{.*}}) : ins(!amdgcn.vgpr<?>, !amdgcn.vgpr<[? : ? + 2]>) mods(i32) -> !amdgcn.write_token<flat>
 // CHECK:           return
 // CHECK:         }
@@ -330,12 +330,12 @@ func.func @load_killed_before_consumer() {
 // CHECK:           cf.cond_br %[[ARG0]], ^bb1, ^bb2
 // CHECK:         ^bb1:
 // CHECK:           %[[TOK_0:.*]] = memref.load %[[ALLOCA_0]][] : memref<!amdgcn.read_token<flat>>
-// CHECK:           amdgcn.wait deps %[[TOK_0]] : !amdgcn.read_token<flat>
+// CHECK:           amdgcn.wait deps %[[TOK_0]] : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // CHECK:           %{{.*}} = amdgcn.global_store_dword data %[[ALLOCA_1]] addr %[[MRR]] offset c(%{{.*}}) : ins(!amdgcn.vgpr<?>, !amdgcn.vgpr<[? : ? + 2]>) mods(i32) -> !amdgcn.write_token<flat>
 // CHECK:           cf.br ^bb3
 // CHECK:         ^bb2:
 // CHECK:           %[[TOK_1:.*]] = memref.load %[[ALLOCA_0]][] : memref<!amdgcn.read_token<flat>>
-// CHECK:           amdgcn.wait deps %[[TOK_1]] : !amdgcn.read_token<flat>
+// CHECK:           amdgcn.wait deps %[[TOK_1]] : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // CHECK:           %{{.*}} = amdgcn.global_store_dword data %[[ALLOCA_1]] addr %[[MRR]] offset c(%{{.*}}) : ins(!amdgcn.vgpr<?>, !amdgcn.vgpr<[? : ? + 2]>) mods(i32) -> !amdgcn.write_token<flat>
 // CHECK:           cf.br ^bb3
 // CHECK:         ^bb3:
@@ -372,14 +372,14 @@ func.func @load_before_branch_consumed_in_both(%cond: i1) {
 // CHECK:           cf.cond_br %[[ARG0]], ^bb1, ^bb2
 // CHECK:         ^bb1:
 // CHECK:           %[[LOAD_1:.*]] = memref.load %[[ALLOCA_0]][] : memref<!amdgcn.read_token<flat>>
-// CHECK:           amdgcn.wait deps %[[LOAD_1]] : !amdgcn.read_token<flat>
+// CHECK:           amdgcn.wait deps %[[LOAD_1]] : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // CHECK:           %[[STORE_0:.*]] = amdgcn.global_store_dword data %[[ALLOCA_1]] addr %[[MAKE_REGISTER_RANGE_0]] offset c(%{{.*}}) : ins(!amdgcn.vgpr<?>, !amdgcn.vgpr<[? : ? + 2]>) mods(i32) -> !amdgcn.write_token<flat>
 // CHECK:           cf.br ^bb3
 // CHECK:         ^bb2:
 // CHECK:           cf.br ^bb3
 // CHECK:         ^bb3:
 // CHECK:           %[[LOAD_2:.*]] = memref.load %[[ALLOCA_0]][] : memref<!amdgcn.read_token<flat>>
-// CHECK:           amdgcn.wait deps %[[LOAD_2]] : !amdgcn.read_token<flat>
+// CHECK:           amdgcn.wait deps %[[LOAD_2]] : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // CHECK:           %[[STORE_1:.*]] = amdgcn.global_store_dword data %[[ALLOCA_1]] addr %[[MAKE_REGISTER_RANGE_0]] offset c(%{{.*}}) : ins(!amdgcn.vgpr<?>, !amdgcn.vgpr<[? : ? + 2]>) mods(i32) -> !amdgcn.write_token<flat>
 // CHECK:           return
 // CHECK:         }
@@ -415,18 +415,18 @@ func.func @load_before_branch_consumed_in_single(%cond: i1) {
 // CHECK:           cf.cond_br %[[ARG0]], ^bb1, ^bb2
 // CHECK:         ^bb1:
 // CHECK:           %[[LOAD_1:.*]] = memref.load %[[ALLOCA_1]][] : memref<!amdgcn.read_token<flat>>
-// CHECK:           amdgcn.wait deps %[[LOAD_1]] : !amdgcn.read_token<flat>
+// CHECK:           amdgcn.wait deps %[[LOAD_1]] : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // CHECK:           %[[STORE_0:.*]] = amdgcn.global_store_dword data %[[ALLOCA_2]] addr %[[MAKE_REGISTER_RANGE_0]] offset c(%{{.*}}) : ins(!amdgcn.vgpr<?>, !amdgcn.vgpr<[? : ? + 2]>) mods(i32) -> !amdgcn.write_token<flat>
 // CHECK:           cf.br ^bb3
 // CHECK:         ^bb2:
 // CHECK:           %[[LOAD_2:.*]] = memref.load %[[ALLOCA_1]][] : memref<!amdgcn.read_token<flat>>
-// CHECK:           amdgcn.wait deps %[[LOAD_2]] : !amdgcn.read_token<flat>
+// CHECK:           amdgcn.wait deps %[[LOAD_2]] : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // CHECK:           %[[LOAD_3:.*]] = amdgcn.global_load_dword dest %[[ALLOCA_2]] addr %[[MAKE_REGISTER_RANGE_0]] offset c(%{{.*}}) : outs(!amdgcn.vgpr<?>) ins(!amdgcn.vgpr<[? : ? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
 // CHECK:           memref.store %[[LOAD_3]], %[[ALLOCA_0]][] : memref<!amdgcn.read_token<flat>>
 // CHECK:           cf.br ^bb3
 // CHECK:         ^bb3:
 // CHECK:           %[[LOAD_4:.*]] = memref.load %[[ALLOCA_0]][] : memref<!amdgcn.read_token<flat>>
-// CHECK:           amdgcn.wait deps %[[LOAD_4]] : !amdgcn.read_token<flat>
+// CHECK:           amdgcn.wait deps %[[LOAD_4]] : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // CHECK:           %[[STORE_1:.*]] = amdgcn.global_store_dword data %[[ALLOCA_2]] addr %[[MAKE_REGISTER_RANGE_0]] offset c(%{{.*}}) : ins(!amdgcn.vgpr<?>, !amdgcn.vgpr<[? : ? + 2]>) mods(i32) -> !amdgcn.write_token<flat>
 // CHECK:           return
 // CHECK:         }

--- a/test/Dialect/AMDGCN/canonicalize.mlir
+++ b/test/Dialect/AMDGCN/canonicalize.mlir
@@ -2,28 +2,28 @@
 
 // CHECK-LABEL:   func.func @merge_waits(
 // CHECK-SAME:      %[[ARG0:.*]]: !amdgcn.read_token<flat>, %[[ARG1:.*]]: !amdgcn.read_token<shared>, %[[ARG2:.*]]: !amdgcn.write_token<flat>) {
-// CHECK:           amdgcn.wait vm_cnt 0 lgkm_cnt 1 deps %[[ARG0]], %[[ARG1]], %[[ARG2]] : !amdgcn.read_token<flat>, !amdgcn.read_token<shared>, !amdgcn.write_token<flat>
+// CHECK:           amdgcn.wait vm_cnt 0 lgkm_cnt 1 deps %[[ARG0]], %[[ARG1]], %[[ARG2]] : !amdgcn.read_token<flat>, !amdgcn.read_token<shared>, !amdgcn.write_token<flat> -> !amdgcn.fence_token
 // CHECK:           return
 // CHECK:         }
 func.func @merge_waits(
     %rt1: !amdgcn.read_token<flat>,
     %rt2: !amdgcn.read_token<shared>,
     %wt1: !amdgcn.write_token<flat>) {
-  amdgcn.wait deps %rt1 : !amdgcn.read_token<flat>
-  amdgcn.wait deps %rt1, %rt2 : !amdgcn.read_token<flat>, !amdgcn.read_token<shared>
-  amdgcn.wait deps %rt1, %wt1 : !amdgcn.read_token<flat>, !amdgcn.write_token<flat>
-  amdgcn.wait vm_cnt 0 lgkm_cnt 1 deps %rt1, %wt1 : !amdgcn.read_token<flat>, !amdgcn.write_token<flat>
-  amdgcn.wait vm_cnt 2
+  %wf0 = amdgcn.wait deps %rt1 : !amdgcn.read_token<flat> -> !amdgcn.fence_token
+  %wf1 = amdgcn.wait deps %rt1, %rt2 : !amdgcn.read_token<flat>, !amdgcn.read_token<shared> -> !amdgcn.fence_token
+  %wf2 = amdgcn.wait deps %rt1, %wt1 : !amdgcn.read_token<flat>, !amdgcn.write_token<flat> -> !amdgcn.fence_token
+  %wf3 = amdgcn.wait vm_cnt 0 lgkm_cnt 1 deps %rt1, %wt1 : !amdgcn.read_token<flat>, !amdgcn.write_token<flat> -> !amdgcn.fence_token
+  %wf4 = amdgcn.wait vm_cnt 2 -> !amdgcn.fence_token
   return
 }
 
 // CHECK-LABEL:   func.func @remove_duplicate_waits(
 // CHECK-SAME:      %[[ARG0:.*]]: !amdgcn.read_token<flat>) {
-// CHECK:           amdgcn.wait deps %[[ARG0]] : !amdgcn.read_token<flat>
+// CHECK:           amdgcn.wait deps %[[ARG0]] : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // CHECK:           return
 // CHECK:         }
 func.func @remove_duplicate_waits(%rt1: !amdgcn.read_token<flat>) {
-  amdgcn.wait deps %rt1, %rt1, %rt1 : !amdgcn.read_token<flat>, !amdgcn.read_token<flat>, !amdgcn.read_token<flat>
+  %wf5 = amdgcn.wait deps %rt1, %rt1, %rt1 : !amdgcn.read_token<flat>, !amdgcn.read_token<flat>, !amdgcn.read_token<flat> -> !amdgcn.fence_token
   return
 }
 
@@ -31,7 +31,7 @@ func.func @remove_duplicate_waits(%rt1: !amdgcn.read_token<flat>) {
 // CHECK:           return
 // CHECK:         }
 func.func @erase_noop_wait() {
-  amdgcn.wait
+  %wf6 = amdgcn.wait -> !amdgcn.fence_token
   return
 }
 

--- a/test/Dialect/AMDGCN/gfx1250-ops.mlir
+++ b/test/Dialect/AMDGCN/gfx1250-ops.mlir
@@ -108,7 +108,7 @@ func.func @test_s_barrier_gfx1250() {
 }
 
 func.func @test_wait_gfx1250_explicit() {
-  amdgcn.wait_gfx1250 load_cnt 1 store_cnt 2 ds_cnt 3 km_cnt 4 tensor_cnt 5
+  %wf0 = amdgcn.wait_gfx1250 load_cnt 1 store_cnt 2 ds_cnt 3 km_cnt 4 tensor_cnt 5 -> !amdgcn.fence_token
   return
 }
 
@@ -117,7 +117,7 @@ func.func @test_wait_gfx1250_token(%d0: !amdgcn.sgpr<[? + 4]>,
     %d3: !amdgcn.sgpr<[? + 4]>) {
   %tok = amdgcn.tensor_load_to_lds desc0 %d0 desc1 %d1 desc2 %d2 desc3 %d3
       : ins(!amdgcn.sgpr<[? + 4]>, !amdgcn.sgpr<[? + 8]>, !amdgcn.sgpr<[? + 4]>, !amdgcn.sgpr<[? + 4]>) -> !amdgcn.read_token<tensor>
-  amdgcn.wait_gfx1250 deps %tok : !amdgcn.read_token<tensor>
+  %wf1 = amdgcn.wait_gfx1250 deps %tok : !amdgcn.read_token<tensor> -> !amdgcn.fence_token
   return
 }
 

--- a/test/Dialect/AMDGCN/ops.mlir
+++ b/test/Dialect/AMDGCN/ops.mlir
@@ -221,13 +221,34 @@ func.func @test_waits(
     %rt2: !amdgcn.read_token<shared>,
     %wt1: !amdgcn.write_token<flat>) {
   // Wait for tokens.
-  amdgcn.wait deps %rt1 : !amdgcn.read_token<flat>
-  amdgcn.wait deps %rt1, %rt2 : !amdgcn.read_token<flat>, !amdgcn.read_token<shared>
-  amdgcn.wait deps %rt1, %wt1 : !amdgcn.read_token<flat>, !amdgcn.write_token<flat>
+  %wf0 = amdgcn.wait deps %rt1 : !amdgcn.read_token<flat> -> !amdgcn.fence_token
+  %wf1 = amdgcn.wait deps %rt1, %rt2 : !amdgcn.read_token<flat>, !amdgcn.read_token<shared> -> !amdgcn.fence_token
+  %wf2 = amdgcn.wait deps %rt1, %wt1 : !amdgcn.read_token<flat>, !amdgcn.write_token<flat> -> !amdgcn.fence_token
   // Mixed wait with counts and tokens.
-  amdgcn.wait vm_cnt 0 lgkm_cnt 1 deps %rt1, %wt1 : !amdgcn.read_token<flat>, !amdgcn.write_token<flat>
+  %wf3 = amdgcn.wait vm_cnt 0 lgkm_cnt 1 deps %rt1, %wt1 : !amdgcn.read_token<flat>, !amdgcn.write_token<flat> -> !amdgcn.fence_token
   // Wait with only counts.
-  amdgcn.wait vm_cnt 2
+  %wf4 = amdgcn.wait vm_cnt 2 -> !amdgcn.fence_token
+  // Wait that produces a fence token for a following barrier.
+  %wf = amdgcn.wait deps %rt1 : !amdgcn.read_token<flat> -> !amdgcn.fence_token
+  return
+}
+
+func.func @test_cross_wave_token_barrier(
+    %rt1: !amdgcn.read_token<flat>,
+    %wt1: !amdgcn.write_token<shared>) {
+  %r0 = amdgcn.cross_wave_token_barrier deps %wt1 : !amdgcn.write_token<shared>
+  %r1 = amdgcn.cross_wave_token_barrier deps %wt1, %rt1 : !amdgcn.write_token<shared>, !amdgcn.read_token<flat>
+  %r2 = amdgcn.cross_wave_token_barrier
+  return
+}
+
+func.func @test_cross_wave_token_barrier_after(
+    %dst: !amdgcn.vgpr,
+    %addr: !amdgcn.vgpr,
+    %wt1: !amdgcn.write_token<shared>) {
+  %c0 = arith.constant 0 : i32
+  %fence = amdgcn.cross_wave_token_barrier deps %wt1 : !amdgcn.write_token<shared>
+  %r, %t = amdgcn.ds_read_b32 dest %dst addr %addr offset c(%c0) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared> fence_token %fence : !amdgcn.fence_token
   return
 }
 

--- a/test/Target/ASM/gfx1250-cross-wave-barrier.mlir
+++ b/test/Target/ASM/gfx1250-cross-wave-barrier.mlir
@@ -1,0 +1,15 @@
+// RUN: aster-opt %s --pass-pipeline='builtin.module(canonicalize,amdgcn.module(amdgcn-convert-waits))' | aster-translate --mlir-to-asm | FileCheck %s --check-prefix=ASM
+// RUN: aster-opt %s --pass-pipeline='builtin.module(canonicalize,amdgcn.module(amdgcn-convert-waits))' \
+// RUN:   | aster-translate --mlir-to-asm \
+// RUN:   | llvm-mc -triple=amdgcn-amd-amdhsa -mcpu=gfx1250 -mattr=+wavefrontsize32 -filetype=obj -o %t.o
+
+// cross_wave_token_barrier lowers to the gfx1250 split barrier in emitted asm.
+
+//      ASM: s_barrier_signal -1
+// ASM-NEXT: s_barrier_wait -1
+amdgcn.module @cross_wave_barrier_gfx1250_mod target = #amdgcn.target<gfx1250> {
+  amdgcn.kernel @cross_wave_barrier_gfx1250 attributes {normal_forms = [#amdgcn.all_registers_allocated]} {
+    %fence = amdgcn.cross_wave_token_barrier
+    amdgcn.end_kernel
+  }
+}

--- a/test/Target/ASM/gfx1250-loads-asm.mlir
+++ b/test/Target/ASM/gfx1250-loads-asm.mlir
@@ -65,7 +65,7 @@ amdgcn.module @gfx1250_loads_mod target = #amdgcn.target<gfx1250> {
     %d3 = lsir.alloca : !amdgcn.sgpr<[20 : 24]>
     %tok = amdgcn.tensor_load_to_lds desc0 %d0 desc1 %d1 desc2 %d2 desc3 %d3
         : ins(!amdgcn.sgpr<[0 : 4]>, !amdgcn.sgpr<[8 : 16]>, !amdgcn.sgpr<[16 : 20]>, !amdgcn.sgpr<[20 : 24]>) -> !amdgcn.read_token<tensor>
-    amdgcn.wait_gfx1250 deps %tok : !amdgcn.read_token<tensor>
+    %wf0 = amdgcn.wait_gfx1250 deps %tok : !amdgcn.read_token<tensor> -> !amdgcn.fence_token
     amdgcn.end_kernel
   }
 
@@ -75,12 +75,12 @@ amdgcn.module @gfx1250_loads_mod target = #amdgcn.target<gfx1250> {
     %offset = arith.constant 0 : i32
     %tok = amdgcn.ds_load_b128 dest %dst4 addr %addr offset c(%offset)
         : outs(!amdgcn.vgpr<[0 : 4]>) ins(!amdgcn.vgpr<4>) mods(i32) -> !amdgcn.read_token<shared>
-    amdgcn.wait_gfx1250 deps %tok : !amdgcn.read_token<shared>
+    %wf1 = amdgcn.wait_gfx1250 deps %tok : !amdgcn.read_token<shared> -> !amdgcn.fence_token
     amdgcn.end_kernel
   }
 
   amdgcn.kernel @fused_wait attributes {normal_forms = [#amdgcn.all_registers_allocated]} {
-    amdgcn.wait_gfx1250 load_cnt 0 ds_cnt 0
+    %wf2 = amdgcn.wait_gfx1250 load_cnt 0 ds_cnt 0 -> !amdgcn.fence_token
     amdgcn.end_kernel
   }
 }

--- a/test/Target/ASM/translate-no-tokens.mlir
+++ b/test/Target/ASM/translate-no-tokens.mlir
@@ -1,0 +1,31 @@
+// RUN: not aster-translate --split-input-file %s --mlir-to-asm 2>&1 | FileCheck %s
+
+// CHECK: normal form violation: dependency-token operands are disallowed but found one on: amdgcn.cross_wave_token_barrier
+
+amdgcn.module @mod target = #amdgcn.target<gfx942> {
+  amdgcn.kernel @k {
+  ^entry:
+    %c0 = arith.constant 0 : i32
+    %addr = amdgcn.alloca : !amdgcn.vgpr<0>
+    %data = amdgcn.alloca : !amdgcn.vgpr<1>
+    %tok = amdgcn.ds_write_b32 data %data addr %addr offset c(%c0) : ins(!amdgcn.vgpr<1>, !amdgcn.vgpr<0>) mods(i32) -> !amdgcn.write_token<shared>
+    %fence = amdgcn.cross_wave_token_barrier deps %tok : !amdgcn.write_token<shared>
+    amdgcn.end_kernel
+  }
+}
+
+// -----
+
+// CHECK: normal form violation: dependency-token operands are disallowed but found one on: amdgcn.wait
+
+amdgcn.module @mod target = #amdgcn.target<gfx942> {
+  amdgcn.kernel @k {
+  ^entry:
+    %c0 = arith.constant 0 : i32
+    %addr = amdgcn.alloca : !amdgcn.vgpr<0>
+    %data = amdgcn.alloca : !amdgcn.vgpr<1>
+    %tok = amdgcn.ds_write_b32 data %data addr %addr offset c(%c0) : ins(!amdgcn.vgpr<1>, !amdgcn.vgpr<0>) mods(i32) -> !amdgcn.write_token<shared>
+    %wf0 = amdgcn.wait deps %tok : !amdgcn.write_token<shared> -> !amdgcn.fence_token
+    amdgcn.end_kernel
+  }
+}

--- a/test/Transforms/lds-multibuffer-prep.mlir
+++ b/test/Transforms/lds-multibuffer-prep.mlir
@@ -42,11 +42,11 @@ func.func @two_stage_lds(%data_in: !amdgcn.vgpr, %addr: !amdgcn.vgpr) {
     %wtok = amdgcn.ds_write_b32 data %data_in addr %lds_addr offset c(%c0_i32) {sched.stage = 0 : i32} : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
 
     // Stage 1: wait, read, compute, dealloc
-    amdgcn.wait deps %wtok {sched.stage = 1 : i32} : !amdgcn.write_token<shared>
+    %wf0 = amdgcn.wait deps %wtok {sched.stage = 1 : i32} : !amdgcn.write_token<shared> -> !amdgcn.fence_token
     %dest = amdgcn.alloca {sched.stage = 1 : i32} : !amdgcn.vgpr
     %c0_i32_mig1 = arith.constant 0 : i32
     %read_data, %rtok = amdgcn.ds_read_b32 dest %dest addr %lds_addr offset c(%c0_i32_mig1) {sched.stage = 1 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
-    amdgcn.wait deps %rtok {sched.stage = 1 : i32} : !amdgcn.read_token<shared>
+    %wf1 = amdgcn.wait deps %rtok {sched.stage = 1 : i32} : !amdgcn.read_token<shared> -> !amdgcn.fence_token
     %result = amdgcn.test_inst outs %s_out ins %read_data {sched.stage = 1 : i32} : (!amdgcn.vgpr, !amdgcn.vgpr) -> !amdgcn.vgpr
     amdgcn.dealloc_lds %lds {sched.stage = 1 : i32}
   }
@@ -109,11 +109,11 @@ func.func @two_groups_three_stage(%data_in: !amdgcn.vgpr) {
     %wtok_a = amdgcn.ds_write_b32 data %data_in addr %addr_a offset c(%c0_i32) {sched.stage = 0 : i32} : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
 
     // Stage 1: read from A, dealloc A, alloc B, write to B
-    amdgcn.wait deps %wtok_a {sched.stage = 1 : i32} : !amdgcn.write_token<shared>
+    %wf2 = amdgcn.wait deps %wtok_a {sched.stage = 1 : i32} : !amdgcn.write_token<shared> -> !amdgcn.fence_token
     %dest_a = amdgcn.alloca {sched.stage = 1 : i32} : !amdgcn.vgpr
     %c0_i32_mig2 = arith.constant 0 : i32
     %from_a, %rtok_a = amdgcn.ds_read_b32 dest %dest_a addr %addr_a offset c(%c0_i32_mig2) {sched.stage = 1 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
-    amdgcn.wait deps %rtok_a {sched.stage = 1 : i32} : !amdgcn.read_token<shared>
+    %wf3 = amdgcn.wait deps %rtok_a {sched.stage = 1 : i32} : !amdgcn.read_token<shared> -> !amdgcn.fence_token
     amdgcn.dealloc_lds %lds_a {sched.stage = 1 : i32}
 
     // Group B: stage 1 -> stage 2
@@ -123,11 +123,11 @@ func.func @two_groups_three_stage(%data_in: !amdgcn.vgpr) {
     %wtok_b = amdgcn.ds_write_b32 data %from_a addr %addr_b offset c(%c0_i32) {sched.stage = 1 : i32} : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
 
     // Stage 2: read from B, compute, dealloc B
-    amdgcn.wait deps %wtok_b {sched.stage = 2 : i32} : !amdgcn.write_token<shared>
+    %wf4 = amdgcn.wait deps %wtok_b {sched.stage = 2 : i32} : !amdgcn.write_token<shared> -> !amdgcn.fence_token
     %dest_b = amdgcn.alloca {sched.stage = 2 : i32} : !amdgcn.vgpr
     %c0_i32_mig3 = arith.constant 0 : i32
     %from_b, %rtok_b = amdgcn.ds_read_b32 dest %dest_b addr %addr_b offset c(%c0_i32_mig3) {sched.stage = 2 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
-    amdgcn.wait deps %rtok_b {sched.stage = 2 : i32} : !amdgcn.read_token<shared>
+    %wf5 = amdgcn.wait deps %rtok_b {sched.stage = 2 : i32} : !amdgcn.read_token<shared> -> !amdgcn.fence_token
     %result = amdgcn.test_inst outs %s_out ins %from_b {sched.stage = 2 : i32} : (!amdgcn.vgpr, !amdgcn.vgpr) -> !amdgcn.vgpr
     amdgcn.dealloc_lds %lds_b {sched.stage = 2 : i32}
   }
@@ -174,11 +174,11 @@ func.func @existing_iter_args(%data_in: !amdgcn.vgpr, %init_acc: !amdgcn.vgpr) -
     %wtok = amdgcn.ds_write_b32 data %data_in addr %lds_addr offset c(%c0_i32) {sched.stage = 0 : i32} : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
 
     // Stage 1: wait, read, accumulate, dealloc
-    amdgcn.wait deps %wtok {sched.stage = 1 : i32} : !amdgcn.write_token<shared>
+    %wf6 = amdgcn.wait deps %wtok {sched.stage = 1 : i32} : !amdgcn.write_token<shared> -> !amdgcn.fence_token
     %dest = amdgcn.alloca {sched.stage = 1 : i32} : !amdgcn.vgpr
     %c0_i32_mig4 = arith.constant 0 : i32
     %read_data, %rtok = amdgcn.ds_read_b32 dest %dest addr %lds_addr offset c(%c0_i32_mig4) {sched.stage = 1 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
-    amdgcn.wait deps %rtok {sched.stage = 1 : i32} : !amdgcn.read_token<shared>
+    %wf7 = amdgcn.wait deps %rtok {sched.stage = 1 : i32} : !amdgcn.read_token<shared> -> !amdgcn.fence_token
     %new_acc = amdgcn.test_inst outs %s_out ins %acc {sched.stage = 1 : i32} : (!amdgcn.vgpr, !amdgcn.vgpr) -> !amdgcn.vgpr
     amdgcn.dealloc_lds %lds {sched.stage = 1 : i32}
     scf.yield %new_acc : !amdgcn.vgpr
@@ -215,11 +215,11 @@ func.func @index_offset_type(%data_in: !amdgcn.vgpr) {
     %lds_addr = lsir.to_reg %lds_off {sched.stage = 0 : i32} : index -> !amdgcn.vgpr
     %wtok = amdgcn.ds_write_b32 data %data_in addr %lds_addr offset c(%c0_i32) {sched.stage = 0 : i32} : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
 
-    amdgcn.wait deps %wtok {sched.stage = 1 : i32} : !amdgcn.write_token<shared>
+    %wf8 = amdgcn.wait deps %wtok {sched.stage = 1 : i32} : !amdgcn.write_token<shared> -> !amdgcn.fence_token
     %dest = amdgcn.alloca {sched.stage = 1 : i32} : !amdgcn.vgpr
     %c0_i32_mig5 = arith.constant 0 : i32
     %read_data, %rtok = amdgcn.ds_read_b32 dest %dest addr %lds_addr offset c(%c0_i32_mig5) {sched.stage = 1 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
-    amdgcn.wait deps %rtok {sched.stage = 1 : i32} : !amdgcn.read_token<shared>
+    %wf9 = amdgcn.wait deps %rtok {sched.stage = 1 : i32} : !amdgcn.read_token<shared> -> !amdgcn.fence_token
     %result = amdgcn.test_inst outs %s_out ins %read_data {sched.stage = 1 : i32} : (!amdgcn.vgpr, !amdgcn.vgpr) -> !amdgcn.vgpr
     amdgcn.dealloc_lds %lds {sched.stage = 1 : i32}
   }

--- a/test/Transforms/scf-pipeline-barrier.mlir
+++ b/test/Transforms/scf-pipeline-barrier.mlir
@@ -10,13 +10,13 @@
 // CHECK:       %[[KER:.*]]:5 = scf.for {{.*}} iter_args(%[[A_WTOK:.*]] = %[[P_WTOK]]
 // CHECK:         amdgcn.ds_write_b32
 // CHECK:         amdgcn.s_barrier
-// CHECK:         amdgcn.wait deps %[[A_WTOK]]
+// CHECK:         amdgcn.wait deps %[[A_WTOK]] : !amdgcn.write_token<shared> -> !amdgcn.fence_token
 // CHECK:         amdgcn.ds_read_b32
 // CHECK:         scf.yield
 
 // Epilogue: barrier present, before the wait+read drain
 // CHECK:       amdgcn.s_barrier
-// CHECK:       amdgcn.wait deps %[[KER]]#0
+// CHECK:       amdgcn.wait deps %[[KER]]#0 : !amdgcn.write_token<shared> -> !amdgcn.fence_token
 // CHECK:       amdgcn.ds_read_b32
 // CHECK:       return
 
@@ -34,11 +34,11 @@ func.func @barrier_at_stage1(%data_in: !amdgcn.vgpr) {
 
     amdgcn.s_barrier {sched.stage = 1 : i32}
 
-    amdgcn.wait deps %wtok {sched.stage = 1 : i32} : !amdgcn.write_token<shared>
+    %wf0 = amdgcn.wait deps %wtok {sched.stage = 1 : i32} : !amdgcn.write_token<shared> -> !amdgcn.fence_token
     %dest = amdgcn.alloca {sched.stage = 1 : i32} : !amdgcn.vgpr
     %c0_i32_mig1 = arith.constant 0 : i32
     %read_data, %rtok = amdgcn.ds_read_b32 dest %dest addr %lds_addr offset c(%c0_i32_mig1) {sched.stage = 1 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
-    amdgcn.wait deps %rtok {sched.stage = 1 : i32} : !amdgcn.read_token<shared>
+    %wf1 = amdgcn.wait deps %rtok {sched.stage = 1 : i32} : !amdgcn.read_token<shared> -> !amdgcn.fence_token
     %result = amdgcn.test_inst outs %s_out ins %read_data {sched.stage = 1 : i32} : (!amdgcn.vgpr, !amdgcn.vgpr) -> !amdgcn.vgpr
     amdgcn.dealloc_lds %lds {sched.stage = 1 : i32}
   }
@@ -62,11 +62,11 @@ func.func @barrier_missing_stage(%data_in: !amdgcn.vgpr) {
     // expected-error @below {{amdgcn.s_barrier in a pipelined loop body requires an explicit sched.stage attribute}}
     amdgcn.s_barrier
 
-    amdgcn.wait deps %wtok {sched.stage = 1 : i32} : !amdgcn.write_token<shared>
+    %wf2 = amdgcn.wait deps %wtok {sched.stage = 1 : i32} : !amdgcn.write_token<shared> -> !amdgcn.fence_token
     %dest = amdgcn.alloca {sched.stage = 1 : i32} : !amdgcn.vgpr
     %c0_i32_mig2 = arith.constant 0 : i32
     %read_data, %rtok = amdgcn.ds_read_b32 dest %dest addr %lds_addr offset c(%c0_i32_mig2) {sched.stage = 1 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
-    amdgcn.wait deps %rtok {sched.stage = 1 : i32} : !amdgcn.read_token<shared>
+    %wf3 = amdgcn.wait deps %rtok {sched.stage = 1 : i32} : !amdgcn.read_token<shared> -> !amdgcn.fence_token
     %result = amdgcn.test_inst outs %s_out ins %read_data {sched.stage = 1 : i32} : (!amdgcn.vgpr, !amdgcn.vgpr) -> !amdgcn.vgpr
     amdgcn.dealloc_lds %lds {sched.stage = 1 : i32}
   }

--- a/test/Transforms/scf-pipeline-drain-fail.mlir
+++ b/test/Transforms/scf-pipeline-drain-fail.mlir
@@ -212,9 +212,9 @@ module {
         %67 = amdgcn.buffer_load_lds_dwordx4 addr %8 m0 %11 offset u(%10) + off_idx(%66) + c(%c0_i32) {offen, sched.stage = 1 : i32} : ins(!amdgcn.sgpr<[? + 4]>, !amdgcn.m0<0>, !amdgcn.sgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<flat>
         memref.store %67, %alloca_1[%c0] {sched.stage = 1 : i32} : memref<1x!amdgcn.read_token<flat>>
         %68 = memref.load %alloca_0[%c0] {sched.stage = 2 : i32} : memref<1x!amdgcn.read_token<flat>>
-        amdgcn.wait deps %68 {sched.stage = 2 : i32} : !amdgcn.read_token<flat>
+        %wf0 = amdgcn.wait deps %68 {sched.stage = 2 : i32} : !amdgcn.read_token<flat> -> !amdgcn.fence_token
         %69 = memref.load %alloca_1[%c0] {sched.stage = 2 : i32} : memref<1x!amdgcn.read_token<flat>>
-        amdgcn.wait deps %69 {sched.stage = 2 : i32} : !amdgcn.read_token<flat>
+        %wf1 = amdgcn.wait deps %69 {sched.stage = 2 : i32} : !amdgcn.read_token<flat> -> !amdgcn.fence_token
         amdgcn.s_barrier {sched.stage = 2 : i32}
         %alloca_2 = memref.alloca() : memref<2x!aster_utils.any>
         %alloca_3 = memref.alloca() : memref<2x!amdgcn.read_token<shared>>
@@ -236,7 +236,7 @@ module {
         %73 = memref.load %alloca_3[%c1] {sched.stage = 3 : i32} : memref<2x!amdgcn.read_token<shared>>
         %74 = memref.load %alloca_5[%c0] {sched.stage = 3 : i32} : memref<2x!amdgcn.read_token<shared>>
         %75 = memref.load %alloca_5[%c1] {sched.stage = 3 : i32} : memref<2x!amdgcn.read_token<shared>>
-        amdgcn.wait deps %72, %73, %74, %75 {sched.stage = 3 : i32} : !amdgcn.read_token<shared>, !amdgcn.read_token<shared>, !amdgcn.read_token<shared>, !amdgcn.read_token<shared>
+        %wf2 = amdgcn.wait deps %72, %73, %74, %75 {sched.stage = 3 : i32} : !amdgcn.read_token<shared>, !amdgcn.read_token<shared>, !amdgcn.read_token<shared>, !amdgcn.read_token<shared> -> !amdgcn.fence_token
         %76 = memref.load %alloca[%c0] {sched.stage = 3 : i32} : memref<1x!amdgcn.agpr<[? + 4]>>
         %77 = memref.load %alloca_2[%c0] {sched.stage = 3 : i32} : memref<2x!aster_utils.any>
         %78 = aster_utils.from_any %77 {sched.stage = 3 : i32} : !amdgcn.vgpr<[? + 2]>

--- a/test/Transforms/scf-pipeline-epilogue-parallel.mlir
+++ b/test/Transforms/scf-pipeline-epilogue-parallel.mlir
@@ -10,21 +10,21 @@
 // Per-iteration mappings: iter 1's load results are separate from iter 0's.
 // wait+compute uses iter 0's token/data (P0_T, P0_D), not iter 1's.
 // CHECK:       %[[P1_D:.*]], %[[P1_T:.*]] = amdgcn.global_load_dword
-// CHECK:       amdgcn.wait deps %[[P0_T]]
+// CHECK:       amdgcn.wait deps %[[P0_T]] : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // CHECK:       %[[P1_C:.*]] = amdgcn.test_inst outs %{{.*}} ins %[[P0_D]]
 
 // Kernel: 5 iter_args (3 cross-stage + 2 i32 offsets)
 // Token and data from iter 1's load, computed from iter 0's compute.
 // CHECK:       %[[KER:.*]]:5 = scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} iter_args(%[[A_T:.*]] = %[[P1_T]], %[[A_D:.*]] = %[[P1_D]], %[[A_C:.*]] = %[[P1_C]], {{.*}}) -> (!amdgcn.read_token<flat>, !amdgcn.vgpr, !amdgcn.vgpr, i32, i32)
 // CHECK:         %[[K_D:.*]], %[[K_T:.*]] = amdgcn.global_load_dword
-// CHECK:         amdgcn.wait deps %[[A_T]]
+// CHECK:         amdgcn.wait deps %[[A_T]] : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // CHECK:         %[[K_C:.*]] = amdgcn.test_inst outs %{{.*}} ins %[[A_D]]
 // CHECK:         amdgcn.global_store_dword data %[[A_C]]
 // CHECK:         scf.yield %[[K_T]], %[[K_D]], %[[K_C]]
 
 // -- Epilogue section 1 --
 // Stage 1 ops for iter 5:
-// CHECK:       amdgcn.wait deps %[[KER]]#0
+// CHECK:       amdgcn.wait deps %[[KER]]#0 : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // CHECK:       %[[E1_C:.*]] = amdgcn.test_inst outs %{{.*}} ins %[[KER]]#1
 
 // Stage 2 ops for iter 4: MUST use %[[KER]]#2, NOT %[[E1_C]]
@@ -44,7 +44,7 @@ func.func @epilogue_parallel_lanes(%addr: !amdgcn.vgpr<[? + 2]>) {
   scf.for %i = %c0 to %c6 step %c1 {
     %c0_i32_mig1 = arith.constant 0 : i32
     %data, %rtok = amdgcn.global_load_dword dest %dest addr %addr offset c(%c0_i32_mig1) {sched.stage = 0 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
-    amdgcn.wait deps %rtok {sched.stage = 1 : i32} : !amdgcn.read_token<flat>
+    %wf0 = amdgcn.wait deps %rtok {sched.stage = 1 : i32} : !amdgcn.read_token<flat> -> !amdgcn.fence_token
     %computed = amdgcn.test_inst outs %s_compute ins %data {sched.stage = 1 : i32} : (!amdgcn.vgpr, !amdgcn.vgpr) -> !amdgcn.vgpr
     %wtok = amdgcn.global_store_dword data %computed addr %addr offset c(%c0_i32_mig1) {sched.stage = 2 : i32} : ins(!amdgcn.vgpr, !amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.write_token<flat>
   }

--- a/test/Transforms/scf-pipeline-lds.mlir
+++ b/test/Transforms/scf-pipeline-lds.mlir
@@ -24,7 +24,7 @@
 // CHECK:         %[[K_WTOK:.*]] = amdgcn.ds_write_b32
 
 // Stage 1: read from previous iteration's buffer
-// CHECK:         amdgcn.wait deps %[[A_WTOK]]
+// CHECK:         amdgcn.wait deps %[[A_WTOK]] : !amdgcn.write_token<shared> -> !amdgcn.fence_token
 // CHECK:         amdgcn.ds_read_b32 dest %{{.*}} addr %[[A_ADDR]]
 // CHECK:         amdgcn.test_inst
 
@@ -32,7 +32,7 @@
 // CHECK:         scf.yield %[[K_WTOK]], %[[K_ADDR]], %[[PREV]], %[[CUR]]
 
 // Epilogue: stage 1 drains the last iteration's LDS
-// CHECK:       amdgcn.wait
+// CHECK:       amdgcn.wait deps %{{.*}} : !amdgcn.{{.*}} -> !amdgcn.fence_token
 // CHECK:       amdgcn.ds_read_b32
 // CHECK:       amdgcn.test_inst
 
@@ -55,11 +55,11 @@ func.func @lds_write_read_two_stage(%data_in: !amdgcn.vgpr, %addr: !amdgcn.vgpr)
     %wtok = amdgcn.ds_write_b32 data %data_in addr %lds_addr offset c(%c0_i32) {sched.stage = 0 : i32} : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
 
     // Stage 1: wait, read from LDS, compute, dealloc
-    amdgcn.wait deps %wtok {sched.stage = 1 : i32} : !amdgcn.write_token<shared>
+    %wf0 = amdgcn.wait deps %wtok {sched.stage = 1 : i32} : !amdgcn.write_token<shared> -> !amdgcn.fence_token
     %dest = amdgcn.alloca {sched.stage = 1 : i32} : !amdgcn.vgpr
     %c0_i32_mig1 = arith.constant 0 : i32
     %read_data, %rtok = amdgcn.ds_read_b32 dest %dest addr %lds_addr offset c(%c0_i32_mig1) {sched.stage = 1 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
-    amdgcn.wait deps %rtok {sched.stage = 1 : i32} : !amdgcn.read_token<shared>
+    %wf1 = amdgcn.wait deps %rtok {sched.stage = 1 : i32} : !amdgcn.read_token<shared> -> !amdgcn.fence_token
     %result = amdgcn.test_inst outs %s_out ins %read_data {sched.stage = 1 : i32} : (!amdgcn.vgpr, !amdgcn.vgpr) -> !amdgcn.vgpr
     amdgcn.dealloc_lds %lds {sched.stage = 1 : i32}
   }
@@ -89,7 +89,7 @@ func.func @lds_write_read_two_stage(%data_in: !amdgcn.vgpr, %addr: !amdgcn.vgpr)
 // Prologue section 1: stage 0 + stage 1
 // CHECK:       lsir.to_reg
 // CHECK:       amdgcn.ds_write_b32
-// CHECK:       amdgcn.wait
+// CHECK:       amdgcn.wait deps %{{.*}} : !amdgcn.{{.*}} -> !amdgcn.fence_token
 // CHECK:       amdgcn.ds_read_b32
 // CHECK:       lsir.to_reg
 // CHECK:       amdgcn.ds_write_b32
@@ -102,12 +102,12 @@ func.func @lds_write_read_two_stage(%data_in: !amdgcn.vgpr, %addr: !amdgcn.vgpr)
 // CHECK:         lsir.to_reg
 // CHECK:         amdgcn.ds_write_b32
 // Stage 1: read prev group A, write group B
-// CHECK:         amdgcn.wait
+// CHECK:         amdgcn.wait deps %{{.*}} : !amdgcn.{{.*}} -> !amdgcn.fence_token
 // CHECK:         amdgcn.ds_read_b32
 // CHECK:         lsir.to_reg
 // CHECK:         amdgcn.ds_write_b32
 // Stage 2: read prev group B, compute
-// CHECK:         amdgcn.wait
+// CHECK:         amdgcn.wait deps %{{.*}} : !amdgcn.{{.*}} -> !amdgcn.fence_token
 // CHECK:         amdgcn.ds_read_b32
 // CHECK:         amdgcn.test_inst
 // No alloc_lds inside loop body
@@ -115,14 +115,14 @@ func.func @lds_write_read_two_stage(%data_in: !amdgcn.vgpr, %addr: !amdgcn.vgpr)
 // CHECK:         scf.yield
 
 // Epilogue drains remaining stages
-// CHECK:       amdgcn.wait
+// CHECK:       amdgcn.wait deps %{{.*}} : !amdgcn.{{.*}} -> !amdgcn.fence_token
 // CHECK:       amdgcn.ds_read_b32
 // CHECK:       lsir.to_reg
 // CHECK:       amdgcn.ds_write_b32
-// CHECK:       amdgcn.wait
+// CHECK:       amdgcn.wait deps %{{.*}} : !amdgcn.{{.*}} -> !amdgcn.fence_token
 // CHECK:       amdgcn.ds_read_b32
 // CHECK:       amdgcn.test_inst
-// CHECK:       amdgcn.wait
+// CHECK:       amdgcn.wait deps %{{.*}} : !amdgcn.{{.*}} -> !amdgcn.fence_token
 // CHECK:       amdgcn.ds_read_b32
 // CHECK:       amdgcn.test_inst
 
@@ -147,11 +147,11 @@ func.func @double_lds_three_stage(%gaddr: !amdgcn.vgpr<[? + 2]>, %data_in: !amdg
     %wtok_a = amdgcn.ds_write_b32 data %data_in addr %addr_a offset c(%c0_i32) {sched.stage = 0 : i32} : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
 
     // Stage 1: read from LDS_A, alloc LDS_B, write to LDS_B
-    amdgcn.wait deps %wtok_a {sched.stage = 1 : i32} : !amdgcn.write_token<shared>
+    %wf2 = amdgcn.wait deps %wtok_a {sched.stage = 1 : i32} : !amdgcn.write_token<shared> -> !amdgcn.fence_token
     %dest_a = amdgcn.alloca {sched.stage = 1 : i32} : !amdgcn.vgpr
     %c0_i32_mig2 = arith.constant 0 : i32
     %from_a, %rtok_a = amdgcn.ds_read_b32 dest %dest_a addr %addr_a offset c(%c0_i32_mig2) {sched.stage = 1 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
-    amdgcn.wait deps %rtok_a {sched.stage = 1 : i32} : !amdgcn.read_token<shared>
+    %wf3 = amdgcn.wait deps %rtok_a {sched.stage = 1 : i32} : !amdgcn.read_token<shared> -> !amdgcn.fence_token
     amdgcn.dealloc_lds %lds_a {sched.stage = 1 : i32}
     %lds_b = amdgcn.alloc_lds 128 {sched.stage = 1 : i32}
     %off_b = amdgcn.get_lds_offset %lds_b {sched.stage = 1 : i32} : i32
@@ -159,11 +159,11 @@ func.func @double_lds_three_stage(%gaddr: !amdgcn.vgpr<[? + 2]>, %data_in: !amdg
     %wtok_b = amdgcn.ds_write_b32 data %from_a addr %addr_b offset c(%c0_i32) {sched.stage = 1 : i32} : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
 
     // Stage 2: read from LDS_B, compute, dealloc
-    amdgcn.wait deps %wtok_b {sched.stage = 2 : i32} : !amdgcn.write_token<shared>
+    %wf4 = amdgcn.wait deps %wtok_b {sched.stage = 2 : i32} : !amdgcn.write_token<shared> -> !amdgcn.fence_token
     %dest_b = amdgcn.alloca {sched.stage = 2 : i32} : !amdgcn.vgpr
     %c0_i32_mig3 = arith.constant 0 : i32
     %from_b, %rtok_b = amdgcn.ds_read_b32 dest %dest_b addr %addr_b offset c(%c0_i32_mig3) {sched.stage = 2 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
-    amdgcn.wait deps %rtok_b {sched.stage = 2 : i32} : !amdgcn.read_token<shared>
+    %wf5 = amdgcn.wait deps %rtok_b {sched.stage = 2 : i32} : !amdgcn.read_token<shared> -> !amdgcn.fence_token
     %result = amdgcn.test_inst outs %s_out ins %from_b {sched.stage = 2 : i32} : (!amdgcn.vgpr, !amdgcn.vgpr) -> !amdgcn.vgpr
     amdgcn.dealloc_lds %lds_b {sched.stage = 2 : i32}
   }
@@ -186,7 +186,7 @@ func.func @double_lds_three_stage(%gaddr: !amdgcn.vgpr<[? + 2]>, %data_in: !amdg
 // CHECK:       amdgcn.global_load_dword
 
 // Prologue section 1
-// CHECK:       amdgcn.wait
+// CHECK:       amdgcn.wait deps %{{.*}} : !amdgcn.{{.*}} -> !amdgcn.fence_token
 // CHECK:       lsir.to_reg
 // CHECK:       amdgcn.ds_write_b32
 
@@ -197,24 +197,24 @@ func.func @double_lds_three_stage(%gaddr: !amdgcn.vgpr<[? + 2]>, %data_in: !amdg
 // CHECK:         amdgcn.global_load_dword
 
 // Stage 1: wait on prev global load, write to LDS
-// CHECK:         amdgcn.wait
+// CHECK:         amdgcn.wait deps %{{.*}} : !amdgcn.{{.*}} -> !amdgcn.fence_token
 // CHECK:         lsir.to_reg
 // CHECK:         amdgcn.ds_write_b32
 
 // Stage 2: read from prev LDS, compute
-// CHECK:         amdgcn.wait
+// CHECK:         amdgcn.wait deps %{{.*}} : !amdgcn.{{.*}} -> !amdgcn.fence_token
 // CHECK:         amdgcn.ds_read_b32
 // CHECK:         amdgcn.test_inst
 // CHECK:         scf.yield
 
 // Epilogue
-// CHECK:       amdgcn.wait
+// CHECK:       amdgcn.wait deps %{{.*}} : !amdgcn.{{.*}} -> !amdgcn.fence_token
 // CHECK:       lsir.to_reg
 // CHECK:       amdgcn.ds_write_b32
-// CHECK:       amdgcn.wait
+// CHECK:       amdgcn.wait deps %{{.*}} : !amdgcn.{{.*}} -> !amdgcn.fence_token
 // CHECK:       amdgcn.ds_read_b32
 // CHECK:       amdgcn.test_inst
-// CHECK:       amdgcn.wait
+// CHECK:       amdgcn.wait deps %{{.*}} : !amdgcn.{{.*}} -> !amdgcn.fence_token
 // CHECK:       amdgcn.ds_read_b32
 // CHECK:       amdgcn.test_inst
 
@@ -236,18 +236,18 @@ func.func @global_to_lds_to_compute(%gaddr: !amdgcn.vgpr<[? + 2]>) {
     %gdata, %gtok = amdgcn.global_load_dword dest %g_dest addr %gaddr offset c(%c0_i32_mig1) {sched.stage = 0 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
 
     // Stage 1: wait for global load, write to LDS
-    amdgcn.wait deps %gtok {sched.stage = 1 : i32} : !amdgcn.read_token<flat>
+    %wf6 = amdgcn.wait deps %gtok {sched.stage = 1 : i32} : !amdgcn.read_token<flat> -> !amdgcn.fence_token
     %lds = amdgcn.alloc_lds 256 {sched.stage = 1 : i32}
     %lds_off = amdgcn.get_lds_offset %lds {sched.stage = 1 : i32} : i32
     %lds_addr = lsir.to_reg %lds_off {sched.stage = 1 : i32} : i32 -> !amdgcn.vgpr
     %wtok = amdgcn.ds_write_b32 data %gdata addr %lds_addr offset c(%c0_i32) {sched.stage = 1 : i32} : ins(!amdgcn.vgpr, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<shared>
 
     // Stage 2: read from LDS, compute, dealloc
-    amdgcn.wait deps %wtok {sched.stage = 2 : i32} : !amdgcn.write_token<shared>
+    %wf7 = amdgcn.wait deps %wtok {sched.stage = 2 : i32} : !amdgcn.write_token<shared> -> !amdgcn.fence_token
     %r_dest = amdgcn.alloca {sched.stage = 2 : i32} : !amdgcn.vgpr
     %c0_i32_mig4 = arith.constant 0 : i32
     %from_lds, %rtok = amdgcn.ds_read_b32 dest %r_dest addr %lds_addr offset c(%c0_i32_mig4) {sched.stage = 2 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
-    amdgcn.wait deps %rtok {sched.stage = 2 : i32} : !amdgcn.read_token<shared>
+    %wf8 = amdgcn.wait deps %rtok {sched.stage = 2 : i32} : !amdgcn.read_token<shared> -> !amdgcn.fence_token
     %result = amdgcn.test_inst outs %s_out ins %from_lds {sched.stage = 2 : i32} : (!amdgcn.vgpr, !amdgcn.vgpr) -> !amdgcn.vgpr
     amdgcn.dealloc_lds %lds {sched.stage = 2 : i32}
   }

--- a/test/Transforms/scf-pipeline-multi-value.mlir
+++ b/test/Transforms/scf-pipeline-multi-value.mlir
@@ -55,12 +55,12 @@ func.func @two_producers_one_consumer() {
 // CHECK:       %[[C1:.*]] = arith.constant 1 : index
 // CHECK:       %[[KER:.*]]:2 = scf.for %{{.*}} = %[[C1]] to %{{.*}} step %{{.*}} iter_args(%[[A_T:.*]] = %[[PRO_T]], %[[A_D:.*]] = %[[PRO_D]]) -> (!amdgcn.read_token<flat>, !amdgcn.vgpr)
 // CHECK:         %[[K_D:.*]], %[[K_T:.*]] = amdgcn.global_load_dword
-// CHECK:         amdgcn.wait deps %[[A_T]] : !amdgcn.read_token<flat>
+// CHECK:         amdgcn.wait deps %[[A_T]] : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // CHECK:         amdgcn.test_inst outs %{{.*}} ins %[[A_D]]
 // CHECK:         scf.yield %[[K_T]], %[[K_D]] : !amdgcn.read_token<flat>, !amdgcn.vgpr
 
 // Epilogue
-// CHECK:       amdgcn.wait deps %[[KER]]#0
+// CHECK:       amdgcn.wait deps %[[KER]]#0 : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // CHECK:       amdgcn.test_inst outs %{{.*}} ins %[[KER]]#1
 // CHECK:       return
 
@@ -73,7 +73,7 @@ func.func @load_data_and_token_cross_stage(%addr: !amdgcn.vgpr<[? + 2]>) {
   scf.for %i = %c0 to %c4 step %c1 {
     %c0_i32_mig1 = arith.constant 0 : i32
     %data, %tok = amdgcn.global_load_dword dest %dest addr %addr offset c(%c0_i32_mig1) {sched.stage = 0 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
-    amdgcn.wait deps %tok {sched.stage = 1 : i32} : !amdgcn.read_token<flat>
+    %wf0 = amdgcn.wait deps %tok {sched.stage = 1 : i32} : !amdgcn.read_token<flat> -> !amdgcn.fence_token
     %out = amdgcn.test_inst outs %s_out ins %data {sched.stage = 1 : i32} : (!amdgcn.vgpr, !amdgcn.vgpr) -> !amdgcn.vgpr
   }
   return

--- a/test/Transforms/scf-pipeline-three-stage.mlir
+++ b/test/Transforms/scf-pipeline-three-stage.mlir
@@ -27,7 +27,7 @@
 // Per-iteration mappings: iter 1's load results are separate from iter 0's.
 // wait+compute uses iter 0's token/data (P0_T, P0_D), not iter 1's.
 // CHECK:       %[[P1_D:.*]], %[[P1_T:.*]] = amdgcn.global_load_dword
-// CHECK:       amdgcn.wait deps %[[P0_T]]
+// CHECK:       amdgcn.wait deps %[[P0_T]] : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // CHECK:       %[[P1_C:.*]] = amdgcn.test_inst outs %{{.*}} ins %[[P0_D]]
 
 // Kernel: 5 iter_args (3 cross-stage + 2 i32 offsets)
@@ -35,7 +35,7 @@
 // Computed comes from iter 0's compute (P1_C).
 // CHECK:       %[[KER:.*]]:5 = scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} iter_args(%[[A_T:.*]] = %[[P1_T]], %[[A_D:.*]] = %[[P1_D]], %[[A_C:.*]] = %[[P1_C]], {{.*}}) -> (!amdgcn.read_token<flat>, !amdgcn.vgpr, !amdgcn.vgpr, i32, i32)
 // CHECK:         %[[K_D:.*]], %[[K_T:.*]] = amdgcn.global_load_dword
-// CHECK:         amdgcn.wait deps %[[A_T]]
+// CHECK:         amdgcn.wait deps %[[A_T]] : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // CHECK:         %[[K_C:.*]] = amdgcn.test_inst outs %{{.*}} ins %[[A_D]]
 // CHECK:         amdgcn.global_store_dword data %[[A_C]]
 // CHECK:         scf.yield %[[K_T]], %[[K_D]], %[[K_C]]
@@ -43,7 +43,7 @@
 // Epilogue section 1: wait+compute(iter 5) + store(iter 4)
 // wait+compute uses kernel results #0, #1 (iter 5's stage 0 values).
 // store uses kernel result #2 (iter 4's stage 1 value).
-// CHECK:       amdgcn.wait deps %[[KER]]#0
+// CHECK:       amdgcn.wait deps %[[KER]]#0 : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // CHECK:       %[[E1_C:.*]] = amdgcn.test_inst outs %{{.*}} ins %[[KER]]#1
 // CHECK:       amdgcn.global_store_dword data %[[KER]]#2
 
@@ -61,7 +61,7 @@ func.func @three_stage_load_compute_store(%addr: !amdgcn.vgpr<[? + 2]>) {
   scf.for %i = %c0 to %c6 step %c1 {
     %c0_i32_mig1 = arith.constant 0 : i32
     %data, %rtok = amdgcn.global_load_dword dest %dest addr %addr offset c(%c0_i32_mig1) {sched.stage = 0 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
-    amdgcn.wait deps %rtok {sched.stage = 1 : i32} : !amdgcn.read_token<flat>
+    %wf0 = amdgcn.wait deps %rtok {sched.stage = 1 : i32} : !amdgcn.read_token<flat> -> !amdgcn.fence_token
     %computed = amdgcn.test_inst outs %s_compute ins %data {sched.stage = 1 : i32} : (!amdgcn.vgpr, !amdgcn.vgpr) -> !amdgcn.vgpr
     %wtok = amdgcn.global_store_dword data %computed addr %addr offset c(%c0_i32_mig1) {sched.stage = 2 : i32} : ins(!amdgcn.vgpr, !amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.write_token<flat>
   }

--- a/test/Transforms/scf-pipeline-two-stage.mlir
+++ b/test/Transforms/scf-pipeline-two-stage.mlir
@@ -60,12 +60,12 @@ func.func @two_stage_dps() {
 // CHECK:       %[[C1:.*]] = arith.constant 1 : index
 // CHECK:       %[[KER:.*]]:2 = scf.for %[[KI:.*]] = %[[C1]] to %{{.*}} step %{{.*}} iter_args(%[[A_T:.*]] = %[[PRO_T]], %[[A_D:.*]] = %[[PRO_D]]) -> (!amdgcn.read_token<flat>, !amdgcn.vgpr)
 // CHECK:         %[[K_D:.*]], %[[K_T:.*]] = amdgcn.global_load_dword
-// CHECK:         amdgcn.wait deps %[[A_T]] : !amdgcn.read_token<flat>
+// CHECK:         amdgcn.wait deps %[[A_T]] : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // CHECK:         amdgcn.test_inst outs %{{.*}} ins %[[A_D]]
 // CHECK:         scf.yield %[[K_T]], %[[K_D]] : !amdgcn.read_token<flat>, !amdgcn.vgpr
 
 // Epilogue: wait + compute using kernel results
-// CHECK:       amdgcn.wait deps %[[KER]]#0 : !amdgcn.read_token<flat>
+// CHECK:       amdgcn.wait deps %[[KER]]#0 : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 // CHECK:       amdgcn.test_inst outs %{{.*}} ins %[[KER]]#1
 // CHECK:       return
 
@@ -78,7 +78,7 @@ func.func @two_stage_load_compute(%addr: !amdgcn.vgpr<[? + 2]>) {
   scf.for %i = %c0 to %c4 step %c1 {
     %c0_i32_mig1 = arith.constant 0 : i32
     %data, %tok = amdgcn.global_load_dword dest %dest addr %addr offset c(%c0_i32_mig1) {sched.stage = 0 : i32} : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr<[? + 2]>) mods(i32) -> !amdgcn.read_token<flat>
-    amdgcn.wait deps %tok {sched.stage = 1 : i32} : !amdgcn.read_token<flat>
+    %wf0 = amdgcn.wait deps %tok {sched.stage = 1 : i32} : !amdgcn.read_token<flat> -> !amdgcn.fence_token
     %result = amdgcn.test_inst outs %s_compute ins %data {sched.stage = 1 : i32} : (!amdgcn.vgpr, !amdgcn.vgpr) -> !amdgcn.vgpr
   }
   return

--- a/test/integration/g2s-load-lds-e2e.mlir
+++ b/test/integration/g2s-load-lds-e2e.mlir
@@ -110,7 +110,7 @@ amdgcn.module @g2s_e2e_mod target = #amdgcn.target<gfx950> {
 
     // Wait for G2S to complete (vmcnt tracks buffer loads).
     // Must use token-based wait so the late-waits pass preserves it.
-    amdgcn.wait deps %tok_g2s : !amdgcn.read_token<flat>
+    %wf0 = amdgcn.wait deps %tok_g2s : !amdgcn.read_token<flat> -> !amdgcn.fence_token
 
     // Read back from LDS: ds_read_b32 at offset 44 + tid*4
     // voffset is tid*4, add M0 offset via constant_offset = 44
@@ -118,13 +118,13 @@ amdgcn.module @g2s_e2e_mod target = #amdgcn.target<gfx950> {
     %lds_val, %tok_lds = amdgcn.ds_read_b32 dest %lds_dest addr %voffset offset c(%c44) : outs(!amdgcn.vgpr) ins(!amdgcn.vgpr) mods(i32) -> !amdgcn.read_token<shared>
 
     // Wait for LDS read to complete (lgkmcnt tracks DS ops)
-    amdgcn.wait deps %tok_lds : !amdgcn.read_token<shared>
+    %wf1 = amdgcn.wait deps %tok_lds : !amdgcn.read_token<shared> -> !amdgcn.fence_token
 
     // Store result to output: dst[tid] = lds_val
     // Thread offset for output = tid * 4
     %tok_st = amdgcn.global_store_dword data %lds_val addr %dst_ptr offset d(%voffset) + c(%c0) : ins(!amdgcn.vgpr, !amdgcn.sgpr<[? + 2]>, !amdgcn.vgpr) mods(i32) -> !amdgcn.write_token<flat>
 
-    amdgcn.wait deps %tok_st : !amdgcn.write_token<flat>
+    %wf2 = amdgcn.wait deps %tok_st : !amdgcn.write_token<flat> -> !amdgcn.fence_token
     amdgcn.end_kernel
   }
 }

--- a/test/integration/mfma-to-global-store-scheduled-allocated-1x1x1.mlir
+++ b/test/integration/mfma-to-global-store-scheduled-allocated-1x1x1.mlir
@@ -228,7 +228,7 @@ amdgcn.module @kernel_module target = #amdgcn.target<gfx942> {
       func.call @ds_write_body(%threadidx_x, %k, %n, %N, %b_memref, %c512_i32)
         : (index, index, index, index, memref<?x?x!amdgcn.vgpr<[? + 2]>>, i32) -> ()
 
-      amdgcn.wait lgkm_cnt 0
+      %wf0 = amdgcn.wait lgkm_cnt 0 -> !amdgcn.fence_token
       // Part 1c: DS read for A
       func.call @ds_read_body(%threadidx_x, %m, %k, %K, %a_memref, %c0_i32)
         : (index, index, index, index, memref<?x?x!amdgcn.vgpr<[? + 2]>>, i32) -> ()


### PR DESCRIPTION
This allows more precisely pinning which barriers fence which memory operations to allow better barrier bypass and more aggressive scheduling.

Note however that this is easier to misuse and if using cross_wave_token_barrier, the user is required to properly set all the fences to avoid incorrect reorderings.