### PR TITLE
Unify graphbuilder edges on both arch and preallocated registers.

### DIFF
--- a/include/aster/Dialect/AMDGCN/IR/Interfaces/AMDGCNRegisterTypeInterface.td
+++ b/include/aster/Dialect/AMDGCN/IR/Interfaces/AMDGCNRegisterTypeInterface.td
@@ -28,6 +28,18 @@ def AMDGCNRegisterTypeInterface : TypeInterface<"AMDGCNRegisterTypeInterface", [
       "::mlir::aster::amdgcn::RegisterKind", "getRegisterKind"
     >
   ];
+  let extraSharedClassDeclaration = [{
+    /// Returns true if two allocated AMDGCN register types alias (same kind
+    /// and overlapping index ranges).
+    bool overlaps(AMDGCNRegisterTypeInterface other) const {
+      if (!other || !$_type.hasAllocatedSemantics() ||
+          !other.hasAllocatedSemantics())
+        return false;
+      if ($_type.getRegisterKind() != other.getRegisterKind())
+        return false;
+      return $_type.allocatedRangesOverlap(other);
+    }
+  }];
 }
 
 #endif // ASTER_AMDGCN_AMDGCNREGISTERTYPEINTERFACE_TD

--- a/include/aster/Interfaces/RegisterType.h
+++ b/include/aster/Interfaces/RegisterType.h
@@ -154,6 +154,19 @@ public:
            indexAlignment == other.indexAlignment;
   }
 
+  /// Returns true if two allocated register ranges overlap (half-open
+  /// intervals).
+  bool overlaps(const RegisterRange &other) const {
+    if (getSemantics() != RegisterSemantics::Allocated ||
+        other.getSemantics() != RegisterSemantics::Allocated)
+      return false;
+    int16_t lhsBegin = begin().getRegister();
+    int16_t lhsEnd = lhsBegin + size();
+    int16_t rhsBegin = other.begin().getRegister();
+    int16_t rhsEnd = rhsBegin + other.size();
+    return lhsEnd > rhsBegin && rhsEnd > lhsBegin;
+  }
+
   /// Compare register ranges.
   bool operator<(const RegisterRange &other) const {
     return std::make_tuple(regBegin, rangeSize, indexAlignment) <

--- a/include/aster/Interfaces/RegisterType.td
+++ b/include/aster/Interfaces/RegisterType.td
@@ -122,6 +122,38 @@ def RegisterTypeInterface : TypeInterface<"RegisterTypeInterface", [
     ::mlir::aster::RegisterTypeInterface cloneRegisterType(::mlir::aster::Register reg) const {
       return $_type.cloneRegisterType(::mlir::aster::RegisterRange(reg, 1));
     }
+
+    /// Returns true if two allocated register types have overlapping index ranges.
+    bool allocatedRangesOverlap(::mlir::aster::RegisterTypeInterface other) const {
+      if (!other || !$_type.hasAllocatedSemantics() ||
+          !other.hasAllocatedSemantics())
+        return false;
+      return $_type.getAsRange().overlaps(other.getAsRange());
+    }
+
+    /// Expands composite types and register ranges into constituent single-register
+    /// types. Returns failure if a composite part cannot be split further.
+    ::mlir::LogicalResult getUnderlyingRegisterTypes(
+        ::llvm::SmallVectorImpl<::mlir::aster::RegisterTypeInterface> &regs)
+        const {
+      if ($_type.isRegisterRange()) {
+        ::mlir::aster::RegisterRange range = $_type.getAsRange();
+        regs.reserve(regs.size() + range.size());
+        for (int16_t i = 0; i < range.size(); ++i)
+          regs.push_back(
+              $_type.cloneRegisterType(range.begin().getWithOffset(i)));
+        return ::mlir::success();
+      }
+      ::llvm::SmallVector<::mlir::aster::RegisterTypeInterface, 4> parts;
+      if (::mlir::succeeded($_type.getSplitType(parts, nullptr))) {
+        for (::mlir::aster::RegisterTypeInterface part : parts)
+          if (::mlir::failed(part.getUnderlyingRegisterTypes(regs)))
+            return ::mlir::failure();
+        return ::mlir::success();
+      }
+      regs.push_back($_type);
+      return ::mlir::success();
+    }
   }];
 }
 

--- a/lib/Dialect/AMDGCN/IR/Hazards.cpp
+++ b/lib/Dialect/AMDGCN/IR/Hazards.cpp
@@ -40,26 +40,6 @@ static MutableArrayRef<OpOperand> getOpOperands(OperandRange operands) {
   return MutableArrayRef<OpOperand>(operands.getBase(), operands.size());
 }
 
-/// Check if two register types overlap.
-static bool checkOverlap(AMDGCNRegisterTypeInterface lhs,
-                         AMDGCNRegisterTypeInterface rhs) {
-  if (!lhs || !rhs || !lhs.hasAllocatedSemantics() ||
-      !rhs.hasAllocatedSemantics())
-    return false;
-
-  // If the register kinds are different, they cannot overlap.
-  if (lhs.getRegisterKind() != rhs.getRegisterKind())
-    return false;
-
-  int16_t lhsBegin = lhs.getAsRange().begin().getRegister();
-  int16_t lhsEnd = lhsBegin + lhs.getAsRange().size();
-  int16_t rhsBegin = rhs.getAsRange().begin().getRegister();
-  int16_t rhsEnd = rhsBegin + rhs.getAsRange().size();
-
-  // Check if the ranges overlap.
-  return lhsEnd > rhsBegin && rhsEnd > lhsBegin;
-}
-
 static int16_t getMfmaPassCase(OpCode op) {
   switch (op) {
   // 16 cycles -> 4 passes (case 1), per Table 37: 16x16x16, 16x16x32.
@@ -368,7 +348,8 @@ bool CDNA3StoreWriteDataHazardAttr::isHazardTriggered(
     return false;
 
   return llvm::any_of(TypeRange(instOp.getInstOuts()), [&](Type out) {
-    return checkOverlap(dyn_cast<AMDGCNRegisterTypeInterface>(out), writeRegTy);
+    auto outRegTy = dyn_cast<AMDGCNRegisterTypeInterface>(out);
+    return outRegTy && outRegTy.overlaps(writeRegTy);
   });
 }
 
@@ -441,7 +422,8 @@ bool CDNA3StoreHazardAttr::isHazardTriggered(
 
   // Check if the VALU instruction writes to the same register as the store.
   return llvm::any_of(TypeRange(instOp.getInstOuts()), [&](Type out) {
-    return checkOverlap(dyn_cast<AMDGCNRegisterTypeInterface>(out), writeRegTy);
+    auto outRegTy = dyn_cast<AMDGCNRegisterTypeInterface>(out);
+    return outRegTy && outRegTy.overlaps(writeRegTy);
   });
 }
 
@@ -487,7 +469,7 @@ bool CDNA3ValuSgprVmemHazardAttr::isHazardTriggered(
   for (Value input : instOp.getInstIns()) {
     auto inputRegTy = dyn_cast<AMDGCNRegisterTypeInterface>(input.getType());
     if (inputRegTy && inputRegTy.getRegisterKind() == RegisterKind::SGPR &&
-        checkOverlap(inputRegTy, sgprRegTy))
+        inputRegTy.overlaps(sgprRegTy))
       return true;
   }
   return false;
@@ -664,7 +646,7 @@ bool CDNA3ValuVgprReadlaneHazardAttr::isHazardTriggered(
   for (Value input : instOp.getInstIns()) {
     auto inputRegTy = dyn_cast<AMDGCNRegisterTypeInterface>(input.getType());
     if (inputRegTy && inputRegTy.getRegisterKind() == RegisterKind::VGPR &&
-        checkOverlap(inputRegTy, vgprRegTy))
+        inputRegTy.overlaps(vgprRegTy))
       return true;
   }
   return false;
@@ -753,7 +735,7 @@ bool CDNA3NonDLOpsValuMfmaHazardAttr::isHazardTriggered(
   // V_MFMA*/V_SMFMA* read VGPR as SrcC (or SrcA/B). Check inputs.
   return llvm::any_of(instOp.getInstIns(), [&](Value input) {
     auto inputRegTy = dyn_cast<AMDGCNRegisterTypeInterface>(input.getType());
-    return inputRegTy && checkOverlap(inputRegTy, vgprRegTy);
+    return inputRegTy && inputRegTy.overlaps(vgprRegTy);
   });
 }
 
@@ -928,8 +910,8 @@ bool CDNA3XdlWriteVgprMfmaReadSrcABHazardAttr::isHazardTriggered(
   // Check if SrcA or SrcB overlaps with the raiser's vdst.
   auto srcARegTy = dyn_cast<AMDGCNRegisterTypeInterface>(srcA.getType());
   auto srcBRegTy = dyn_cast<AMDGCNRegisterTypeInterface>(srcB.getType());
-  bool hasSrcABOverlap = (srcARegTy && checkOverlap(srcARegTy, raiserRegTy)) ||
-                         (srcBRegTy && checkOverlap(srcBRegTy, raiserRegTy));
+  bool hasSrcABOverlap = (srcARegTy && srcARegTy.overlaps(raiserRegTy)) ||
+                         (srcBRegTy && srcBRegTy.overlaps(raiserRegTy));
   if (!hasSrcABOverlap)
     return false;
 
@@ -1001,8 +983,8 @@ bool CDNA4XdlWriteVgprMfmaReadSrcABHazardAttr::isHazardTriggered(
 
   auto srcARegTy = dyn_cast<AMDGCNRegisterTypeInterface>(srcA.getType());
   auto srcBRegTy = dyn_cast<AMDGCNRegisterTypeInterface>(srcB.getType());
-  bool hasSrcABOverlap = (srcARegTy && checkOverlap(srcARegTy, raiserRegTy)) ||
-                         (srcBRegTy && checkOverlap(srcBRegTy, raiserRegTy));
+  bool hasSrcABOverlap = (srcARegTy && srcARegTy.overlaps(raiserRegTy)) ||
+                         (srcBRegTy && srcBRegTy.overlaps(raiserRegTy));
   if (!hasSrcABOverlap)
     return false;
 
@@ -1079,7 +1061,7 @@ bool CDNA3XdlWriteVgprVmemValuHazardAttr::isHazardTriggered(
   for (Value input : instOp.getInstIns()) {
     auto inputRegTy = dyn_cast<AMDGCNRegisterTypeInterface>(input.getType());
     if (inputRegTy && inputRegTy.getRegisterKind() == dstKind &&
-        checkOverlap(inputRegTy, raiserRegTy)) {
+        inputRegTy.overlaps(raiserRegTy)) {
       hasConflict = true;
       break;
     }
@@ -1089,7 +1071,7 @@ bool CDNA3XdlWriteVgprVmemValuHazardAttr::isHazardTriggered(
       auto outputRegTy =
           dyn_cast<AMDGCNRegisterTypeInterface>(output.getType());
       if (outputRegTy && outputRegTy.getRegisterKind() == dstKind &&
-          checkOverlap(outputRegTy, raiserRegTy)) {
+          outputRegTy.overlaps(raiserRegTy)) {
         hasConflict = true;
         break;
       }
@@ -1172,7 +1154,7 @@ bool CDNA4XdlWriteVgprVmemValuHazardAttr::isHazardTriggered(
   for (Value input : instOp.getInstIns()) {
     auto inputRegTy = dyn_cast<AMDGCNRegisterTypeInterface>(input.getType());
     if (inputRegTy && inputRegTy.getRegisterKind() == dstKind &&
-        checkOverlap(inputRegTy, raiserRegTy)) {
+        inputRegTy.overlaps(raiserRegTy)) {
       hasConflict = true;
       break;
     }
@@ -1182,7 +1164,7 @@ bool CDNA4XdlWriteVgprVmemValuHazardAttr::isHazardTriggered(
       auto outputRegTy =
           dyn_cast<AMDGCNRegisterTypeInterface>(output.getType());
       if (outputRegTy && outputRegTy.getRegisterKind() == dstKind &&
-          checkOverlap(outputRegTy, raiserRegTy)) {
+          outputRegTy.overlaps(raiserRegTy)) {
         hasConflict = true;
         break;
       }

--- a/lib/Dialect/AMDGCN/Scheduler/GraphBuilderAttrs.cpp
+++ b/lib/Dialect/AMDGCN/Scheduler/GraphBuilderAttrs.cpp
@@ -18,6 +18,7 @@
 #include "aster/Interfaces/SchedInterfaces.h"
 #include "mlir/Analysis/DataFlowFramework.h"
 #include "mlir/Analysis/SliceAnalysis.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/DebugLog.h"
@@ -81,15 +82,8 @@ LogicalResult GraphBuilder::run(SchedGraph &graph) {
   return success();
 }
 
+// Build the memory dependence edges for the graph.
 void GraphBuilder::buildMemDepEdges(SchedGraph &graph) {
-  // The scheduler enforces ordering only WITHIN this block. Build the
-  // cross-block analysis (which verifies the flat-CFG normal form), then add
-  // only the LDS dependences whose producer is earlier in THIS block.
-  // Cross-block producers are structural (CFG edges + waits) and a loop-carried
-  // back edge (producer not before the consumer in program order) would be a
-  // cycle in this block's graph. Scope to LDS: same-buffer DS RAW/WAR/WAW is a
-  // correctness constraint the scheduler must respect; distinct buffers carry
-  // no edge; global ordering stays with the token/wait machinery.
   auto mdaOr = MemoryDependenceAnalysis::create(
       block->getParentOp(),
       {GlobalMemoryResource::get(), LDSMemoryResource::get()});
@@ -122,15 +116,16 @@ void GraphBuilder::buildSSADeps(SchedGraph &graph) {
     //
     // Exclude SOP1 mov ops and SOP2 SALU arithmetic ops (s_add_*, ...) from
     // sync points. The implicit read/write effects on architectural registers
-    // SCC are captured by the RAW/WAR edges added in buildNonSSADeps. Treating
-    // as fences would serialize independent arithmetic chains.
+    // SCC are captured by the register effect edges added in buildNonSSADeps.
+    // Treating as fences would serialize independent arithmetic chains.
     bool isReorderableArith = false;
     if (auto instOp = dyn_cast<AMDGCNInstOpInterface>(op))
       isReorderableArith = instOp.hasAnyProps(
           {InstProp::Sop1, InstProp::Sop2, InstProp::IsValu});
     if ((!hasEffects || !mlir::isPure(op)) && !isReorderableArith &&
         !isa<LoadOpInterface, StoreOpInterface, AllocaOpInterface>(op)) {
-      LDBG() << "Adding sync point: " << i;
+      LDBG() << "Adding sync point: " << i
+             << " op: " << OpWithFlags(op, OpPrintingFlags().skipRegions());
       syncPoints.push_back(i);
     }
 
@@ -145,173 +140,102 @@ void GraphBuilder::buildSSADeps(SchedGraph &graph) {
   }
 }
 
-template <typename RegType>
-struct IsModeledArchReg : std::false_type {};
-template <>
-struct IsModeledArchReg<SCCType> : std::true_type {};
-template <>
-struct IsModeledArchReg<VCCType> : std::true_type {};
-template <>
-struct IsModeledArchReg<M0Type> : std::true_type {};
-
-/// Returns the read/write effects of `op` on the architectural register
-/// `RegType` (currently SCC, VCC, or M0). The register is referenced as a DPS
-/// alloca operand: an outs operand of `RegType` means the op writes the
-/// register; an ins operand of `RegType` means the op reads it. Ops without
-/// AMDGCNInstOpInterface have no architectural-register effects modeled here.
-template <typename RegType>
-static void getArchRegEffects(Operation *op, bool &reads, bool &writes) {
-  static_assert(IsModeledArchReg<RegType>::value,
-                "getArchRegEffects only supports modeled architectural "
-                "registers (SCC, VCC, M0)");
-  reads = false;
-  writes = false;
-  auto instOp = dyn_cast<AMDGCNInstOpInterface>(op);
-  if (!instOp)
-    return;
-  for (Value v : instOp.getInstOuts()) {
-    if (isa<RegType>(v.getType())) {
-      writes = true;
-      break;
-    }
-  }
-  for (Value v : instOp.getInstIns()) {
-    if (isa<RegType>(v.getType())) {
-      reads = true;
-      break;
-    }
-  }
+static bool archRegTypesOverlap(Type a, Type b) {
+  if (isa<SCCType>(a))
+    return isa<SCCType>(b);
+  if (isa<SCCType>(b))
+    return false;
+  if (isa<M0Type>(a))
+    return isa<M0Type>(b);
+  if (isa<M0Type>(b))
+    return false;
+  // 0, 1, 2, 3 -> none, lo, hi, full.
+  int ma = isa<VCCType>(a)     ? 3
+           : isa<VCCLoType>(a) ? 1
+           : isa<VCCHiType>(a) ? 2
+                               : 0;
+  int mb = isa<VCCType>(b)     ? 3
+           : isa<VCCLoType>(b) ? 1
+           : isa<VCCHiType>(b) ? 2
+                               : 0;
+  return ma && mb && (ma & mb);
 }
 
-/// Add scheduling edges for the read/write effects on a single architectural
-/// register (`RegType`). The register is shared by every op that touches it
-/// but flows through DPS alloca operands rather than SSA results, so no SSA
-/// def-use chain captures the dependence.
-template <typename RegType>
-static void addArchRegEffectEdges(SchedGraph &graph, Block *block) {
-  static_assert(IsModeledArchReg<RegType>::value,
-                "addArchRegEffectEdges only supports modeled architectural "
-                "registers (SCC, VCC, M0)");
-  SmallVector<Operation *> writers;
-  SmallVector<Operation *> readers;
-  for (Operation &op : *block) {
-    bool reads = false;
-    bool writes = false;
-    getArchRegEffects<RegType>(&op, reads, writes);
-    if (!reads && !writes)
-      continue;
-    if (reads) {
-      // RAW: pin every prior writer before this reader.
-      for (Operation *w : writers)
-        graph.addEdge(w, &op);
-    }
-    if (writes) {
-      // WAR: pin every prior reader before this writer.
-      for (Operation *r : readers)
-        graph.addEdge(r, &op);
-    }
-    if (reads)
-      readers.push_back(&op);
-    if (writes)
-      writers.push_back(&op);
-  }
+/// True when two register resource types alias (arch half intersection or
+/// allocated physical range overlap). Architectural and physical never overlap.
+static bool regTypesOverlap(Type a, Type b) {
+  if (archRegTypesOverlap(a, b))
+    return true;
+  auto regA = dyn_cast<AMDGCNRegisterTypeInterface>(a);
+  auto regB = dyn_cast<AMDGCNRegisterTypeInterface>(b);
+  if (!regA || !regB)
+    return false;
+  return regA.overlaps(regB);
 }
 
-/// Resolve a register operand to preallocated VGPR/SGPR/AGPR, recursively
-/// through make_register_range / split_register_range.
-static void
-collectAllocatedRegistersForValue(Value v,
-                                  SmallVectorImpl<RegisterTypeInterface> &out) {
+static void appendRegTypesFromOperand(Value v, llvm::DenseSet<Type> &types) {
   auto regTy = dyn_cast<RegisterTypeInterface>(v.getType());
   if (!regTy || !regTy.hasAllocatedSemantics())
     return;
-  if (auto bundle = v.getDefiningOp<OperandBundleOpInterface>()) {
-    for (Value c : bundle.unpackBundle())
-      collectAllocatedRegistersForValue(c, out);
-    return;
-  }
-  if (auto split = v.getDefiningOp<SplitRegisterRangeOp>()) {
-    collectAllocatedRegistersForValue(split.getInput(), out);
-    return;
-  }
-  std::optional<RegisterKind> kind = getRegKind(regTy);
-  if (kind != RegisterKind::VGPR && kind != RegisterKind::SGPR &&
-      kind != RegisterKind::AGPR)
-    return;
-  out.push_back(regTy);
-}
-
-/// Expand an allocated range into per-word keys (kind << 32 | index) so
-/// vgpr<32>:2 overlaps vgpr<33> but not sgpr<33>.
-static void appendRegWords(RegisterTypeInterface regTy,
-                           llvm::DenseSet<int64_t> &words) {
-  std::optional<RegisterKind> kind = getRegKind(regTy);
-  assert(kind && "expected an AMD register kind on an allocated register");
-  RegisterRange range = regTy.getAsRange();
-  int16_t base = range.begin().getRegister();
-  for (int16_t i = 0, e = range.size(); i < e; ++i)
-    words.insert((int64_t(*kind) << 32) | uint32_t(base + i));
-}
-
-static void addOperandRegWords(Value v, llvm::DenseSet<int64_t> &words) {
   SmallVector<RegisterTypeInterface> regs;
-  collectAllocatedRegistersForValue(v, regs);
+  if (failed(regTy.getUnderlyingRegisterTypes(regs)))
+    return;
   for (RegisterTypeInterface r : regs)
-    appendRegWords(r, words);
+    types.insert(r);
 }
 
-struct OpPhysRegUse {
-  Operation *op;
-  llvm::DenseSet<int64_t> readWords;
-  llvm::DenseSet<int64_t> writeWords;
+struct RegResourceState {
+  SmallVector<std::pair<Operation *, Type>> writers;
+  SmallVector<std::pair<Operation *, Type>> readers;
 };
 
-/// Add scheduling edges between ops whose preallocated register ranges overlap.
-/// One op must write the overlapping word (no RAR). Edges follow program order
-/// for now; last-writer / first-reader refinement is left for later.
-///
-///   %a = ... : !amdgcn.vgpr<33>              // W
-///   %b = ... : !amdgcn.vgpr<33>              // unrelated SSA, same phys reg
-///   ... = v_mov_b32 ... ins(%b)              // R
-///   => writer -> reader (program order).
-static bool allocatedRegWordsOverlap(const OpPhysRegUse &a,
-                                     const OpPhysRegUse &b) {
-  for (int64_t word : a.writeWords)
-    if (b.readWords.contains(word) || b.writeWords.contains(word))
-      return true;
-  for (int64_t word : a.readWords)
-    if (b.writeWords.contains(word))
-      return true;
-  return false;
-}
-
-/// Conservative modeling of edges for preallocated physical registers,
-/// with at least one op writing the overlapping word (no RAR).
-// TODO: firstRead / lastWrite refinement.
-static void addPhysicalRegisterEffectEdges(SchedGraph &graph, Block *block) {
-  SmallVector<OpPhysRegUse> uses;
+/// Add scheduling edges for read/write effects on register resources:
+///   - architectural registers (SCC, VCC and their lo/hi halves, M0)
+///   - preallocated physical registers (VGPR / SGPR / AGPR and ranges thereof)
+// TODO: limit to last/observable writes
+static void addRegisterEffectEdges(SchedGraph &graph, Block *block) {
+  RegResourceState state;
   for (Operation &op : *block) {
     auto instOp = dyn_cast<AMDGCNInstOpInterface>(&op);
     if (!instOp)
       continue;
-    OpPhysRegUse use{&op, {}, {}};
-    for (Value in : instOp.getInstIns())
-      addOperandRegWords(in, use.readWords);
-    for (Value out : instOp.getInstOuts())
-      addOperandRegWords(out, use.writeWords);
-    if (use.readWords.empty() && use.writeWords.empty())
-      continue;
-    uses.push_back(std::move(use));
-  }
 
-  for (size_t i = 0; i < uses.size(); ++i)
-    for (size_t j = i + 1; j < uses.size(); ++j)
-      if (allocatedRegWordsOverlap(uses[i], uses[j]) &&
-          !graph.hasEdge(uses[i].op, uses[j].op))
-        graph.addEdge(uses[i].op, uses[j].op);
+    llvm::DenseSet<Type> readTypes, writeTypes;
+    for (Value v : instOp.getInstOuts())
+      appendRegTypesFromOperand(v, writeTypes);
+    for (Value v : instOp.getInstIns())
+      appendRegTypesFromOperand(v, readTypes);
+    if (readTypes.empty() && writeTypes.empty())
+      continue;
+
+    llvm::DenseSet<Type> allTypes = readTypes;
+    allTypes.insert(writeTypes.begin(), writeTypes.end());
+    for (Type ty : allTypes) {
+      bool reads = readTypes.contains(ty);
+      bool writes = writeTypes.contains(ty);
+      if (reads) {
+        for (auto [w, wt] : state.writers)
+          if (w != &op && regTypesOverlap(ty, wt))
+            graph.addEdge(w, &op);
+      }
+      if (writes) {
+        for (auto [r, rt] : state.readers)
+          if (r != &op && regTypesOverlap(ty, rt))
+            graph.addEdge(r, &op);
+        for (auto [w, wt] : state.writers)
+          if (w != &op && regTypesOverlap(ty, wt))
+            graph.addEdge(w, &op);
+      }
+      if (reads)
+        state.readers.emplace_back(&op, ty);
+      if (writes)
+        state.writers.emplace_back(&op, ty);
+    }
+  }
 }
 
 void GraphBuilder::buildNonSSADeps(SchedGraph &graph) {
+  // Preprocess and erase synchronization points.
   ArrayRef<Operation *> ops = graph.getOps();
   for (int64_t &i : syncPoints) {
     Operation *op = ops[i];
@@ -355,18 +279,8 @@ void GraphBuilder::buildNonSSADeps(SchedGraph &graph) {
   }
 
   // RAW / WAR / WAW edges for read/write effects on architectural registers
-  // SCC, VCC, and M0.
-  addArchRegEffectEdges<SCCType>(graph, block);
-  addArchRegEffectEdges<VCCType>(graph, block);
-  // Note: M0 flows through DPS alloca operands (an ins on !amdgcn.m0 ins for
-  // buffer_load_lds / ds ops, an outs on s_mov_b32), so no SSA chain captures
-  // the ordering between an M0 writer and its readers.
-  // Modeling M0 here lets the s_mov M0 setup drop out of the conservative
-  // sync-point fence set (see buildSSADeps) without losing M0 ordering.
-  addArchRegEffectEdges<M0Type>(graph, block);
-  // Edges for preallocated physical registers, with at least one op writing the
-  // overlapping word (no RAR).
-  addPhysicalRegisterEffectEdges(graph, block);
+  // (SCC, VCC, M0) and preallocated physical registers (VGPR/SGPR/AGPR).
+  addRegisterEffectEdges(graph, block);
 }
 
 static bool isTokenOfKind(Type type, MemoryInstructionKind kind) {

--- a/test/Dialect/AMDGCN/Transforms/ll-sched-archreg-edges.mlir
+++ b/test/Dialect/AMDGCN/Transforms/ll-sched-archreg-edges.mlir
@@ -45,13 +45,13 @@ amdgcn.module @vcc_raw target = #amdgcn.target<gfx942> {
 
 // -----
 
-amdgcn.module @scc_waw_relaxed target = #amdgcn.target<gfx942> {
-  // CHECK-LABEL: Kernel: @scc_waw_relaxed
+amdgcn.module @scc_waw target = #amdgcn.target<gfx942> {
+  // CHECK-LABEL: Kernel: @scc_waw
   // CHECK:       digraph SchedGraph
-  // CHECK-NOT:     label = "s_add_u32 -> s_and_b32"
+  // CHECK-DAG:     label = "s_add_u32 -> s_and_b32"
   // CHECK-NOT:     label = "s_and_b32 -> s_add_u32"
   // CHECK:       }
-  amdgcn.kernel @scc_waw_relaxed {
+  amdgcn.kernel @scc_waw {
     %s_a   = amdgcn.alloca : !s
     %s_b   = amdgcn.alloca : !s
     %s_d1  = amdgcn.alloca : !s


### PR DESCRIPTION
Arch registers gain tighter WAW edges for now.
Relaxations on the unified implementation will follow.