### PR TITLE
Add support for gfx1250 global_prefetch_b8 op + roundtrip/asm/e2e tests

### DIFF
--- a/include/aster/Dialect/AMDGCN/IR/AMDGCNInstBase.td
+++ b/include/aster/Dialect/AMDGCN/IR/AMDGCNInstBase.td
@@ -202,6 +202,29 @@ def IDXEN : UnitModifier<"idxen", "If set, send VADDR as an index. If unset, tre
 def LDS : UnitModifier<"lds", "If set, data is written to LDS memory. If unset, data is read from/written to a VGPR.">;
 def NT : UnitModifier<"nt", "Non-Temporal: data is streamed or uncached.">;
 def OFFEN : UnitModifier<"offen", "If set, send VADDR as an offset. If unset, send the instruction offset stored in OFFSET. Only one of these offsets may be sent.">;
+// CDNA3 manual: 9.1.10.2. Vector Memory. Cache-policy semantics for SC0/SC1/NT.
+// Reads
+// =====
+// The 2-bit scope = (SC1 << 1) | SC0 is an ordinal (deeper = larger).
+// NT is the orthogonal non-temporal hint.
+// Per-level cache behavior:
+//   Scope  SC1 SC0 NT | CU cache   | L2 cache                                | last-level
+//   Wave   0   0   0  | Hit LRU    | Hit LRU                                 | Hit LRU
+//                  1  | Miss Evict | Hit Stream                              | Hit Evict
+//   Group  0   1   0  | Hit LRU    | Hit LRU                                 | Hit Evict
+//                  1  | Miss Evict | Hit Stream                              | Hit Evict
+//   Device 1   0   0  | Miss Evict | 1 L2: Hit LRU; >1 L2: Coherent Bypass   | Hit LRU
+//                  1  | Miss Evict | 1 L2: Hit Stream; >1 L2: Coherent Bypass| Hit Evict
+//   System 1   1   0  | Miss Evict | Coherent Cache Bypass                   | Hit LRU
+//                  1  | Miss Evict | Coherent Cache Bypass                   | Hit Evict
+//
+// scope -> SCOPE_{CU=0, SE=1(Group), DEV=2(Device), SYS=3(System)}.
+// "Device" (SC1, scope 2) is the L2 / GL2 prefetch target.
+//
+// Writes
+// ======
+// See manual for details.
+//
 def SC0 : UnitModifier<"sc0", "For regular load and store operations, SC0 and SC1 indicate memory scope such as wave, group, device and system. For atomics, SC0 means Atomic with return. 1 = Atomic with return, 0 = Atomic with no return.">;
 def SC1 : UnitModifier<"sc1", "For regular load and store operations, SC0 and SC1 indicate memory scope such as wave, group, device and system.">;
 def MATRIX_A_REUSE : UnitModifier<"matrix_a_reuse", "WMMA operand-reuse hint: reuse the matrix A tiles from the previous WMMA.">;

--- a/include/aster/Dialect/AMDGCN/IR/Instructions/VMem.td
+++ b/include/aster/Dialect/AMDGCN/IR/Instructions/VMem.td
@@ -20,6 +20,7 @@ include "aster/Dialect/AMDGCN/IR/Interfaces/InstOpInterfaces.td"
 class BufferLoadInst<string mnemonic, list<Type> dataType> : AMDISAInstruction<mnemonic, [BufferLoadInstOpInterface]> {
   let props = [IsVMem, IsBuffer];
   let archs = [CDNA3Isa, CDNA4Isa];
+  // TODO: consider other effects once we know how we want this scheduled.
   let effects = [GlobalRead];
   let outputs = (ins
     AnyRegOf<dataType>:$dest
@@ -1075,6 +1076,73 @@ def GlobalLoadAsyncToLdsB128 : GlobalLoadAsyncToLdsInst<"global_load_async_to_ld
   let encodings = [InstEnc<[ENC_FLAT_GLBL_GFX12_50], 0x62>];
 }
 #endif // GLOBALLOADASYNCTOLDSB128_DEF
+
+//===----------------------------------------------------------------------===//
+// gfx1250 global prefetch (global_prefetch_b8).
+//===----------------------------------------------------------------------===//
+
+#ifndef GLOBALPREFETCHB_INST_DEF
+#define GLOBALPREFETCHB_INST_DEF
+// Prefetch from global memory into the cache hierarchy.
+// This is a fire-and-forget cache hint: no destination and no completion token.
+//   Scope  SC1 SC0
+//   Wave     0   0
+//   Group    0   1
+//   Device   1   0
+//   System   1   1
+class GlobalPrefetchBInst<string mnemonic>
+    : AMDISAInstruction<mnemonic, []> {
+  let props = [IsVMem, IsGlobal];
+  let archs = [GFX12_50Isa];
+  let effects = [GlobalRead];
+  let outputs = (ins);
+  let inputs = (ins
+    AnyRegOf<[VGPROf<2>, TwoSGPROrVCCType]>:$addr,
+    OptionalReg<VGPROf<1>>:$offset
+  );
+  let trailingArgs = (ins
+    OffsetType<13, /*signed=*/true>:$const_offset,
+    NT:$nt,
+    SC0:$sc0,
+    SC1:$sc1
+  );
+  let genInstAssemblyFormat = 0;
+  let assemblyFormat = [{
+    `addr` $addr
+    `offset` (`d` `(`$offset^ `)` `+`)? `c` `(`$const_offset`)` attr-dict `:`
+    `ins` `(` type($addr) (`,` type($offset)^)? `)` `mods` `(` type($const_offset) `)`
+  }];
+  let asm_syntax = [
+    ASMString<[ENC_FLAT_GLBL_GFX12_50],
+      "${mnemonic} $addr, off [const_offset] @printLoadTemporality([nt]) @printScope([sc0], [sc1])",
+      CPred<"isa<VGPRType>($_self.getAddr().getType())">>,
+    ASMString<[ENC_FLAT_GLBL_GFX12_50],
+      "${mnemonic} $offset, $addr [const_offset] @printLoadTemporality([nt]) @printScope([sc0], [sc1])",
+      CPred<"isa<SGPRType>($_self.getAddr().getType())">>,
+  ];
+  let hasVerifier = 1;
+  let extraClassDefinition = [{
+    LogicalResult $cppClass::verify() {
+      if (isa<VGPRType>(getAddr().getType()) && getOffset())
+        return emitError("expects no offset with VGPR address");
+      if (isa<SGPRType>(getAddr().getType()) && !getOffset())
+        return emitError("expects an offset with SGPR address");
+      return success();
+    }
+  }];
+}
+#endif // GLOBALPREFETCHB_INST_DEF
+
+#ifndef GLOBALPREFETCHB8_DEF
+#define GLOBALPREFETCHB8_DEF
+def GlobalPrefetchB8 : GlobalPrefetchBInst<"global_prefetch_b8"> {
+  let description = [{
+    Prefetch from global memory into the cache hierarchy.
+  }];
+  // LLVM: GLOBAL_PREFETCH_B8, VFLAT_Real_AllAddr_gfx1250<0x05d>.
+  let encodings = [InstEnc<[ENC_FLAT_GLBL_GFX12_50], 0x5d>];
+}
+#endif // GLOBALPREFETCHB8_DEF
 
 //===----------------------------------------------------------------------===//
 // gfx1250 global store instructions (global_store_b* family).

--- a/lib/Target/ASM/AMDGCNInstAsmPrinter.cpp
+++ b/lib/Target/ASM/AMDGCNInstAsmPrinter.cpp
@@ -55,4 +55,32 @@ static void printCondBr(amdgcn::AsmPrinter &printer, CBranchInstOpInterface op,
   printer.getStream() << "s_branch " << printer.getBranchLabel(falseDest);
 }
 
+/// Print the memory scope the LLVM assembler expects in text.
+static void printScope(amdgcn::AsmPrinter &printer, AMDGCNInstOpInterface op,
+                       bool sc0, bool sc1) {
+  switch ((sc1 ? 2 : 0) | (sc0 ? 1 : 0)) {
+  case 1:
+    printer.getStream() << " scope:SCOPE_SE";
+    break;
+  case 2:
+    printer.getStream() << " scope:SCOPE_DEV";
+    break;
+  case 3:
+    printer.getStream() << " scope:SCOPE_SYS";
+    break;
+  default:
+    break; // SCOPE_CU (0): elided.
+  }
+}
+
+/// Print the load temporal hint the LLVM assembler expects in text.
+// Note: ASTER's single NT bit only spans TH_RT (NT=0, the default, elided) and
+// TH_NT (NT=1).
+// TODO: add the richer hints (HT/LU/WB/compound) when needed
+static void printLoadTemporality(amdgcn::AsmPrinter &printer,
+                                 AMDGCNInstOpInterface op, bool nt) {
+  if (nt)
+    printer.getStream() << " th:TH_LOAD_NT";
+}
+
 #include "AMDGCNInstAsmPrinter.cpp.inc"

--- a/test/Dialect/AMDGCN/gfx1250-ops.mlir
+++ b/test/Dialect/AMDGCN/gfx1250-ops.mlir
@@ -89,6 +89,28 @@ func.func @test_global_load_async_to_lds_b32_saddr(%saddr: !amdgcn.sgpr<[? + 2]>
 }
 
 //===----------------------------------------------------------------------===//
+// global_prefetch_b8 (gfx1250 L2 data prefetch; no result, no token).
+//===----------------------------------------------------------------------===//
+
+func.func @test_global_prefetch_b8(%addr: !amdgcn.vgpr<[? + 2]>) {
+  %c0 = arith.constant 0 : i32
+  amdgcn.global_prefetch_b8 addr %addr offset c(%c0) : ins(!amdgcn.vgpr<[? + 2]>) mods(i32)
+  return
+}
+
+func.func @test_global_prefetch_b8_mods(%addr: !amdgcn.vgpr<[? + 2]>) {
+  %c16 = arith.constant 16 : i32
+  amdgcn.global_prefetch_b8 addr %addr offset c(%c16) {nt, sc1} : ins(!amdgcn.vgpr<[? + 2]>) mods(i32)
+  return
+}
+
+func.func @test_global_prefetch_b8_saddr(%saddr: !amdgcn.sgpr<[? + 2]>, %voff: !amdgcn.vgpr) {
+  %c0 = arith.constant 0 : i32
+  amdgcn.global_prefetch_b8 addr %saddr offset d(%voff) + c(%c0) : ins(!amdgcn.sgpr<[? + 2]>, !amdgcn.vgpr) mods(i32)
+  return
+}
+
+//===----------------------------------------------------------------------===//
 // SOPP control + wait ops (s_set_vgpr_msb, s_setprio_inc_wg, s_wait_*cnt)
 //===----------------------------------------------------------------------===//
 

--- a/test/Target/ASM/gfx1250-loads-asm.mlir
+++ b/test/Target/ASM/gfx1250-loads-asm.mlir
@@ -62,6 +62,27 @@
 //  CHECK-NEXT: s_wait_loadcnt_dscnt 16191
 //  CHECK-NEXT: s_endpgm
 
+// global_prefetch_b8 is a fire-and-forget L2 hint: no dest, no token, no wait.
+// CHECK-LABEL: prefetch_vaddr:
+//  CHECK-NEXT: global_prefetch_b8 v[0:1], off
+//  CHECK-NEXT: s_endpgm
+
+// The SADDR form takes an SGPR base + VGPR voffset and a const byte offset.
+// CHECK-LABEL: prefetch_saddr:
+//  CHECK-NEXT: global_prefetch_b8 v0, s[0:1] offset: 16
+//  CHECK-NEXT: s_endpgm
+
+// SC1 (scope 2 = Device) prefetches into L2; the printer renders it as the
+// gfx12 scope:SCOPE_DEV token (not the bare sc1) so the asm assembles.
+// CHECK-LABEL: prefetch_sc1:
+//  CHECK-NEXT: global_prefetch_b8 v[0:1], off scope:SCOPE_DEV
+//  CHECK-NEXT: s_endpgm
+
+// NT + SC1 render as th:TH_LOAD_NT scope:SCOPE_DEV (th before scope, offset first).
+// CHECK-LABEL: prefetch_nt_sc1:
+//  CHECK-NEXT: global_prefetch_b8 v[0:1], off offset: 32 th:TH_LOAD_NT scope:SCOPE_DEV
+//  CHECK-NEXT: s_endpgm
+
 amdgcn.module @gfx1250_loads_mod target = #amdgcn.target<gfx1250> {
 
   amdgcn.kernel @ds_load_b128 attributes {normal_forms = [#amdgcn.all_registers_allocated]} {
@@ -150,6 +171,35 @@ amdgcn.module @gfx1250_loads_mod target = #amdgcn.target<gfx1250> {
 
   amdgcn.kernel @wait_saturate_fused attributes {normal_forms = [#amdgcn.all_registers_allocated]} {
     %wf = amdgcn.wait_gfx1250 load_cnt 100 ds_cnt 100 -> !amdgcn.fence_token
+    amdgcn.end_kernel
+  }
+
+  amdgcn.kernel @prefetch_vaddr attributes {normal_forms = [#amdgcn.all_registers_allocated]} {
+    %addr = lsir.alloca : !amdgcn.vgpr<[0 : 2]>
+    %offset = arith.constant 0 : i32
+    amdgcn.global_prefetch_b8 addr %addr offset c(%offset) : ins(!amdgcn.vgpr<[0 : 2]>) mods(i32)
+    amdgcn.end_kernel
+  }
+
+  amdgcn.kernel @prefetch_saddr attributes {normal_forms = [#amdgcn.all_registers_allocated]} {
+    %saddr = lsir.alloca : !amdgcn.sgpr<[0 : 2]>
+    %voff = lsir.alloca : !amdgcn.vgpr<0>
+    %offset = arith.constant 16 : i32
+    amdgcn.global_prefetch_b8 addr %saddr offset d(%voff) + c(%offset) : ins(!amdgcn.sgpr<[0 : 2]>, !amdgcn.vgpr<0>) mods(i32)
+    amdgcn.end_kernel
+  }
+
+  amdgcn.kernel @prefetch_sc1 attributes {normal_forms = [#amdgcn.all_registers_allocated]} {
+    %addr = lsir.alloca : !amdgcn.vgpr<[0 : 2]>
+    %offset = arith.constant 0 : i32
+    amdgcn.global_prefetch_b8 addr %addr offset c(%offset) {sc1} : ins(!amdgcn.vgpr<[0 : 2]>) mods(i32)
+    amdgcn.end_kernel
+  }
+
+  amdgcn.kernel @prefetch_nt_sc1 attributes {normal_forms = [#amdgcn.all_registers_allocated]} {
+    %addr = lsir.alloca : !amdgcn.vgpr<[0 : 2]>
+    %offset = arith.constant 32 : i32
+    amdgcn.global_prefetch_b8 addr %addr offset c(%offset) {nt, sc1} : ins(!amdgcn.vgpr<[0 : 2]>) mods(i32)
     amdgcn.end_kernel
   }
 

--- a/test/integration/test_gfx1250_prefetch_e2e.py
+++ b/test/integration/test_gfx1250_prefetch_e2e.py
@@ -1,0 +1,32 @@
+import pytest
+
+from aster.execution.helpers import compile_and_run
+from aster.test_pass_pipelines import TEST_LOWER_WAITS_MINIMAL_PASS_PIPELINE
+
+
+@pytest.mark.parametrize("target", ["gfx1250", "gfx1251"])
+@pytest.mark.parametrize(
+    "kernel",
+    [
+        "prefetch_vaddr",
+        "prefetch_saddr",
+        "prefetch_sc1",
+        "prefetch_nt_sc1",
+    ],
+)
+def test_gfx1250_prefetch_e2e(kernel, target):
+    def preprocess(x):
+        return x.replace("<gfx1250>", f"<{target}>")
+
+    compile_and_run(
+        "../Target/ASM/gfx1250-loads-asm.mlir",
+        kernel,
+        pass_pipeline=TEST_LOWER_WAITS_MINIMAL_PASS_PIPELINE,
+        mcpu=target,
+        preprocess=preprocess,
+        library_paths=[],
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])


### PR DESCRIPTION
This also requires a custom asm printer form so that the memory scope is printed as the LLVM assembler wants to see it.